### PR TITLE
Formalise Propositions 3.6 and 3.7 from RS17 paper

### DIFF
--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -117,8 +117,9 @@ Maps out of $Δ²$ are a retract of maps out of $Δ¹×Δ¹$.
   : is-retract-of (Δ² → A) (Δ¹×Δ¹ → A)
   :=
     ( ( \ f → \ (t , s) →
-        recOR ( t <= s |-> f (t , t) ,
-                  s <= t |-> f (t , s))) ,
+        recOR
+          ( t <= s |-> f (t , t) ,
+            s <= t |-> f (t , s))) ,
       ( ( \ f → \ ts → f ts ) , \ _ → refl))
 ```
 
@@ -136,9 +137,12 @@ Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
   : (Δ³ → A) → (Δ²×Δ¹ → A)
   :=
     \ f → \ ((t1 , t2) , t3) →
-    recOR ( t3 <= t2 |-> f ((t1 , t2) , t2) ,
-            t2 <= t3 |-> recOR (t3 <= t1 |-> f ((t1 , t3) , t2) ,
-                                t1 <= t3 |-> f ((t1 , t1) , t2)))
+    recOR
+      ( t3 <= t2 |-> f ((t1 , t2) , t2) ,
+        t2 <= t3 |->
+          recOR
+            ( t3 <= t1 |-> f ((t1 , t3) , t2) ,
+              t1 <= t3 |-> f ((t1 , t1) , t2)))
 
 #def Δ³-is-retract-Δ²×Δ¹
   (A : U)

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -121,3 +121,29 @@ Maps out of $Δ²$ are a retract of maps out of $Δ¹×Δ¹$.
                   s <= t |-> f (t , s))) ,
       ( ( \ f → \ ts → f ts ) , \ _ → refl))
 ```
+
+Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
+
+```rzk title="RS17, Proposition 3.7"
+
+#def Δ³-is-retract-Δ²×Δ¹-retraction
+  (A : U)
+  : (Δ²×Δ¹ → A) → (Δ³ → A)
+  := \ f → \ ((t1 , t2) , t3) → f ((t1 , t3) , t2)
+
+#def Δ³-is-retract-Δ²×Δ¹-section
+  (A : U)
+  : (Δ³ → A) → (Δ²×Δ¹ → A)
+  :=
+    \ f → \ ((t1 , t2) , t3) →
+    recOR ( t3 <= t2 |-> f ((t1 , t2) , t2) ,
+            t2 <= t3 |-> recOR (t3 <= t1 |-> f ((t1 , t3) , t2) ,
+                                t1 <= t3 |-> f ((t1 , t1) , t2)))
+
+#def Δ³-is-retract-Δ²×Δ¹
+  (A : U)
+  : is-retract-of (Δ³ → A) (Δ²×Δ¹ → A)
+  :=
+    ( Δ³-is-retract-Δ²×Δ¹-section A ,
+      ( Δ³-is-retract-Δ²×Δ¹-retraction A , \ _ → refl))
+```

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -108,3 +108,16 @@ The union of shapes is defined by disjunction on topes.
   : I → TOPE
   := \ t → ψ t ∨ χ t
 ```
+
+Maps out of $Δ²$ are a retract of maps out of $Δ¹×Δ¹$.
+
+```rzk title="RS17, Proposition 3.6"
+#def Δ²-is-retract-Δ¹×Δ¹
+  (A : U)
+  : is-retract-of (Δ² → A) (Δ¹×Δ¹ → A)
+  :=
+    ( ( \ f → \ (t , s) →
+        recOR ( t <= s |-> f (t , t) ,
+                  s <= t |-> f (t , s))) ,
+      ( ( \ f → \ ts → f ts ) , \ _ → refl))
+```


### PR DESCRIPTION
Closes #3. 
Prop 3.6 works fine, but for prop 3.7 the check of _Δ³-is-retract-Δ²×Δ¹-section_ does not terminate in my laptop. I'm not sure what's happening, but proof seems ok.