### PR TITLE
`total-space`: pointfree notation for total space of dependent type

### DIFF
--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -10,7 +10,7 @@ It is convenient to have a shorthand for `Σ (x : A), C x`
 which avoids explicit naming the variable `x : A`.
 
 ```rzk
-#def total-space
+#def total-type
   ( A : U)
   ( C : A → U)
   : U

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -6,6 +6,18 @@ This is a literate `rzk` file:
 #lang rzk-1
 ```
 
+It is convenient to have a shorthand for `Σ (x : A), C x`
+which avoids explicit naming the variable `x : A`.
+
+```rzk
+#def total-space
+  ( A : U)
+  ( C : A → U)
+  : U
+  :=
+    Σ (x : A), C x
+```
+
 ## Paths involving products
 
 ```rzk

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -51,6 +51,27 @@ Extension types are used to define the type of arrows between fixed terms:
 
 ```
 
+For each `a : A`, the total types of the representables
+`\ z → hom A a z`
+and
+`\ z → hom A z a`
+are called the coslice and slice, respectively.
+
+
+```rzk
+#def coslice
+  ( A : U)
+  ( a : A)
+  : U
+  := Σ ( z : A) , (hom A a z)
+
+#def slice
+  ( A : U)
+  ( a : A)
+  : U
+  := Σ (z : A) , (hom A z a)
+```
+
 Extension types are also used to define the type of commutative triangles:
 
 <svg style="float: right" viewBox="0 0 200 200" width="150" height="200">

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -813,15 +813,8 @@ family defines an inverse equivalence to evaluation at the element.
 
 ## Initial objects in slice categories
 
-The type `#!rzk coslice A a` is the type of arrows in $A$ with domain $a$.
-
-```rzk
-#def coslice
-  ( A : U)
-  ( a : A)
-  : U
-  := Σ ( z : A) , (hom A a z)
-```
+Recall that the type `#!rzk coslice A a`
+is the type of arrows in $A$ with domain $a$.
 
 We now show that the coslice under $a$ in a Segal type $A$ has an initial object
 given by the identity arrow at $a$. This makes use of the following equivalence.
@@ -1042,15 +1035,8 @@ family defines an inverse equivalence to evaluation at the element.
 
 ## Final objects in slice categories
 
-The type `#!rzk slice A a` is the type of arrows in $A$ with codomain $a$.
-
-```rzk
-#def slice
-  ( A : U)
-  ( a : A)
-  : U
-  := Σ (z : A) , (hom A z a)
-```
+Recall that the type `#!rzk slice A a`
+is the type of arrows in $A$ with codomain $a$.
 
 We now show that the slice over $a$ in a Segal type $A$ has a final object given
 by the identity arrow at $a$. This makes use of the following equivalence.


### PR DESCRIPTION
1) add pointfree notation for total types of dependent families
2) move definitions of slice and coslice to earlier file