### PR TITLE
Naive fibrations vs covariant families

### DIFF
--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -867,5 +867,21 @@ types over a product type.
       (F' a'') (ihc' a'')
       (F (f' a'')) (ihc (f' a''))
 
+#def is-homotopy-cartesian-cancellation
+  : is-homotopy-cartesian A' C' A C f F
+  → is-homotopy-cartesian A'' C'' A C
+      (comp A'' A' A f f')
+      (\ a'' →
+        comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
+          (F (f' a'')) (F' a'')
+      )
+  → is-homotopy-cartesian A'' C'' A' C' f' F'
+  :=
+    \ ihc ihc'' a'' →
+    is-equiv-right-cancel (C'' a'') (C' (f' a'')) (C (f (f' a'')))
+      (F' a'') (F (f' a''))
+      (ihc (f' a''))
+      (ihc'' a'')
+
 #end homotopy-cartesian-pasting
 ```

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -235,7 +235,7 @@ and of the fiber at `(a', f)` of the map
   :=
     fib (coslice (total-type A C) (a, c))
         (coslice A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c))
         (a', f)
 ```
 
@@ -283,13 +283,13 @@ Constructing the backward map requires some rectification.
     \ (((a'', c''), ĝ), γ) →
     temp-Z7hl-backward' a''
       (first-path-Σ A (hom A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c) ((a'',c''), ĝ))
         (a', f)
         γ
       )
       c'' ĝ
       (second-path-Σ A (hom A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c) ((a'',c''), ĝ))
         (a', f)
         γ
       )
@@ -301,7 +301,7 @@ One composite is definitionally equal to the identity.
 #def temp-Z7hl-forward-retract
   : is-retract-of (dhom-from A a a' f C c) (temp-Z7hl-fib)
   :=
-  (temp-Z7hl-forward, (temp-Z7hl-backward, \ g → refl))
+  (temp-Z7hl-forward, (temp-Z7hl-backward, \ _ → refl))
 
 #end is-naive-left-fibration-is-covariant-key-proofs
 ```
@@ -314,7 +314,7 @@ then `C : A → U` is a covariant family.
 #def is-naive-left-fibration-is-covariant-thm
   ( A : U)
   ( C : A → U)
-  ( inlf-A-C : is-naive-left-fibration A (total-type A C) (\ (a, c) → a))
+  ( inlf-A-C : is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
   : is-covariant A C
   :=
     \ a a' f c →
@@ -325,7 +325,7 @@ then `C : A → U` is a covariant family.
       (is-contr-map-is-equiv
         (coslice (total-type A C) (a, c))
         (coslice A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c))
         (inlf-A-C (a, c))
         (a', f)
       )

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -173,6 +173,111 @@ logical equivalence
           ( C-is-covariant x y f u)))
 ```
 
+## Naive left fibrations
+
+For any functor `p : Ĉ → A`,
+we can make a naive definition of what it means to be a left fibration.
+
+```rzk
+#def is-naive-left-fibration
+  ( A Ĉ : U)
+  ( p : Ĉ → A)
+  : U
+  :=
+    is-homotopy-cartesian
+      Ĉ (coslice Ĉ)
+      A (coslice A)
+      p (coslice-fun Ĉ A p)
+```
+
+As a sanity check we unpack the definition of `is-naive-left-fibration`.
+
+```rzk
+#def is-naive-left-fibration-unpacked
+  ( A Ĉ : U)
+  ( p : Ĉ → A)
+  : is-naive-left-fibration A Ĉ p =
+      ((c : Ĉ) → is-equiv (coslice Ĉ c) (coslice A (p c)) (coslice-fun Ĉ A p c))
+  := refl
+```
+
+For every covariant type `#!rzk C : A → U`,
+the projection `#!rzk p : total-type A C → A` is a naive left fibration in this sense:
+
+```rzk title="The statement of RS17, Theorem 8.5"
+#def is-naive-left-fibration-is-covariant-thm
+  (A : U)
+  (C : A → U)
+  : U
+  := iff
+    (is-covariant A C)
+    (is-naive-left-fibration A (total-type A C) (\ (a, c) → a))
+```
+
+```rzk
+#section is-naive-left-fibration-is-covariant-proof
+#variable A : U
+#variable C : A → U
+#variable a : A
+#variable a' : A
+#variable f : hom A a a'
+#variable c : C a
+
+#def temp-forward
+  : dhom-from A a a' f C c
+  → fib (coslice (total-type A C) (a, c)) (coslice A a)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (a', f)
+  :=
+    \ (c', f̂) → (((a', c'), \ t → (f t, f̂ t)) , refl)
+
+#def temp-backward-1
+  : fib (coslice (total-type A C) (a, c)) (coslice A a)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (a', f)
+  → Σ (c' : C a'), hom (total-type A C) (a, c) (a', c')
+  :=
+    \ (((a'', c''), ĝ), γ) →
+    (transport A
+      (\ z → (Σ (d : C z), hom (total-type A C) (a, c) (z,d)))
+      a'' a'
+      (first-path-Σ A (\ x → hom A a x)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (a', f)
+        γ
+      )
+      (c'', ĝ)
+    )
+
+#def temp-backward-1
+  : fib (coslice (total-type A C) (a, c)) (coslice A a)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (a', f)
+  → Σ ((c', h) : product (C a') (hom A a a')), dhom A a a' h C c c'
+  :=
+    \ (((a'', c''), ĝ), γ) →      -- ĝ : hom (total-type A C) (a, c) (a'', c'')
+    (transport A
+      (\ z → (Σ ((d, h) : product (C z) (hom A a z)), dhom A a z h C c d))
+      a'' a'
+      (first-path-Σ A (\ x → hom A a x)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (a', f)
+        γ
+      )
+      ((c'',
+        transport A (\ z → hom A a z)
+        (first-path-Σ A (\ x → hom A a x)
+          (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+          (a', f)
+          γ
+        )
+        f
+      ), U)
+    )
+
+#end is-naive-left-fibration-is-covariant-proof
+```
+
 ## Representable covariant families
 
 If A is a Segal type and a : A is any term, then hom A a defines a covariant


### PR DESCRIPTION
1) For an arbitrary map `p : C -> A` define the notion of being a naive left fibration, capturing homotopy-unique lifting along `{0} -> \Delta^1`.

2) Make progress towards proving RS17, Theorem 8.5: a type family `C : A -> U`  is covariant if and only if the projection `\Sigma C --> A` is a naive left fibration
2.1) Define maps in both direction between the corresponding extension types (one is strict, one is weak)
2.2) One composite is definitionally the identity, yielding the easy direction of the theorem (<-)

Notes:
- Partially addresses #11.
- Relies on #46, which is not yet merged.
- As a work-around for the lack of local variables in rzk, I have prepended the name of certain helper-terms with "temp-Z7hl" to avoid clashes in the global name space
- Ideally, this section/theorem should be a very special case of a general situation, where the inclusion `{0} -> \Delta^1` is replaced by an arbitrary subshape `\Phi -> \Psi`. The proofs should be essentially the same, except that a  lot of the helpes notation (such as hom, dhom, coslice, etc) would have to be introduced first.