### PR TITLE
Naive left fibrations vs covariant families

### DIFF
--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -219,7 +219,7 @@ We fix the following variables.
 #variable c : C a
 
 -- We prepend all local variables in this section
--- with the randomly string "temp-Z7hl"
+-- with the random identifier "temp-Z7hl"
 -- to avoid clashes in the global name-space.
 -- Once the language supports local scoping,
 -- these variables should be renamed.
@@ -247,14 +247,14 @@ It is convenient to replace this fiber by an equivalent type,
 where we unpack the homs in the Sigma-type `Σ C`.
 
 ```rzk
-#def temp-Z7hl-fib-Σ
+#def temp-Z7hl-fib'
   : U
   :=
     Σ (G : coslice (total-type A C) (a, c)),
       Eq-Σ A (hom A a) (temp-Z7hl-coslice-fun G) (a', f)
 
 #def temp-Z7hl-fib-compare
-  : Equiv (temp-Z7hl-fib) (temp-Z7hl-fib-Σ)
+  : Equiv (temp-Z7hl-fib) (temp-Z7hl-fib')
   :=
     total-equiv-family-equiv
       (coslice (total-type A C) (a, c))
@@ -269,7 +269,8 @@ where we unpack the homs in the Sigma-type `Σ C`.
 
 ```
 
-We prove the theorem by showing that these two types are equivalent.
+We prove the theorem by showing that the two types
+`dhom-from A a a' f C c` and `temp-Z7hl-fib'` are equivalent.
 Since the left side is stricter than the right,
 the forward map is straightforward.
 
@@ -278,6 +279,11 @@ the forward map is straightforward.
   : dhom-from A a a' f C c → temp-Z7hl-fib
   :=
     \ (c', f̂) → (((a', c'), \ t → (f t, f̂ t)) , refl)
+
+#def temp-Z7hl-forward'
+  : dhom-from A a a' f C c → temp-Z7hl-fib'
+  :=
+    \ (c', f̂) → (((a', c'), \ t → (f t, f̂ t)) , (refl, refl))
 ```
 
 Constructing the backward map requires some rectification.
@@ -295,22 +301,6 @@ Constructing the backward map requires some rectification.
           = f
     ) →
     dhom-from A a a' f C c
-
-#def temp-Z7hl-family-with-comp
-  ( a'' : A)
-  ( p : a'' = a')
-  : U
-  :=
-    ( c'' : C a'') →
-    ( ĝ : hom (total-type A C) (a, c) (a'', c'')) →
-    ( γ : coslice-fun (total-type A C) A
-            (\ (a, _) → a)
-            (a, c)
-            ((a'', c''), ĝ)
-            =   (a', f)
-    ) →
-    Σ ( u : dhom-from A a a' f C c),
-      temp-Z7hl-forward u = (((a'', c''), ĝ), γ)
 
 #def temp-Z7hl-backward'
   : ( a'' : A) → ( p : a'' = a') → temp-Z7hl-family a'' p

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -245,12 +245,16 @@ by invoking the induction principle for fibers.
 #variable a : A
 #variable C : A → U
 #variable c : C a
-       --  temp-b9wX
 ```
 
 We make some abbreviations to make the proof more readable:
 
 ```rzk
+-- We prepend all local names in this section
+-- with the random identifyier temp-b9wX
+-- to avoid cluttering the global name space.
+-- Once rzk supports local variables, these should be renamed.
+
 #def temp-b9wX-coslice-fun
   : coslice (total-type A C) (a, c) → coslice A a
   := coslice-fun (total-type A C) A (\ (x, _) → x) (a, c)
@@ -319,7 +323,7 @@ yielding the desired equivalence.
       \ u → second (temp-b9wX-forward-section' (a', f) u)
     ))
 
-#def temp-b9wX-equiv
+#def temp-b9wX-the-equivalence
   ( a' : A)
   ( f : hom A a a')
   : Equiv
@@ -337,12 +341,51 @@ yielding the desired equivalence.
 #end is-naive-left-fibration-is-covariant-proof
 ```
 
+Finally, we deduce the theorem by some straightforward logical bookkeeping.
+
+```rzk title="RS17, Theorem 8.5"
+#def is-naive-left-fibration-iff-is-covariant
+  ( A : U)
+  ( C : A → U)
+  :
+    iff
+      (is-covariant A C)
+      (is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
+  :=
+    ( \ is-covariant-C (a, c) →
+        is-equiv-is-contr-map
+          ( coslice (total-type A C) (a, c))
+          ( coslice A a)
+          ( temp-b9wX-coslice-fun A a C c)
+          ( \ (a', f) →
+            is-contr-equiv-is-contr
+              (dhom-from A a a' f C c)
+              (temp-b9wX-fib A a C c a' f)
+              (temp-b9wX-the-equivalence A a C c a' f)
+              (is-covariant-C a a' f c)
+          )
+    , \ inlf-ΣC a a' f c →
+        is-contr-equiv-is-contr'
+          ( dhom-from A a a' f C c)
+          ( temp-b9wX-fib A a C c a' f)
+          ( temp-b9wX-the-equivalence A a C c a' f)
+          ( is-contr-map-is-equiv
+            ( coslice (total-type A C) (a, c))
+            ( coslice A a)
+            ( temp-b9wX-coslice-fun A a C c)
+            ( inlf-ΣC (a, c))
+            (a', f)
+          )
+    )
+```
+
 ## Representable covariant families
 
-If A is a Segal type and a : A is any term, then hom A a defines a covariant
-family over A, and conversely if this family is covariant for every a : A, then
-A must be a Segal type. The proof involves a rather lengthy composition of
-equivalences.
+If `A` is a Segal type and `a : A` is any term,
+then `hom A a` defines a covariant family over A,
+and conversely if this family is covariant for every `a : A`,
+then `A` must be a Segal type.
+The proof involves a rather lengthy composition of equivalences.
 
 ```rzk
 #def dhom-representable

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -226,164 +226,115 @@ We aim to prove that a type family  `#!rzk C : A → U`,
 is covariant if and only if
 the projection `#!rzk p : total-type A C → A` is a naive left fibration.
 
+The theorem asserts the logical equivalence of two contractibility statements,
+one for `dhom-from A a a' f C c`
+and one for the fiber of the canonical map
+`coslice (total-type A C) (a, c) → coslice A a`;
+Thus it suffices to show that for each
+`a a' : A`, `f : hom A a a'`, `c : C a`, `c' : C a'`.
+these two types are equivalent.
+
 We fix the following variables.
+Note that we do not fix `a' : A` and `f : hom A a a'`.
+Letting these vary lets us give an easy proof
+by invoking the induction principle for fibers.
 
 ```rzk
-#section is-naive-left-fibration-is-covariant-key-proofs
+#section is-naive-left-fibration-is-covariant-proof
 #variable A : U
 #variable a : A
-#variable a' : A
-#variable f : hom A a a'
 #variable C : A → U
 #variable c : C a
-
--- We prepend all local variables in this section
--- with the random identifier "temp-Z7hl"
--- to avoid clashes in the global name-space.
--- Once the language supports local scoping,
--- these variables should be renamed.
+       --  temp-b9wX
 ```
-The two sides of the equivalence assert, respectively, the contractibility
-of `dhom-from A a a' f C c`
-and of the fiber at `(a', f)` of the map
-`coslice (total-type C) (a, c) → coslice A a`.
+
+We make some abbreviations to make the proof more readable:
 
 ```rzk
-#def temp-Z7hl-coslice-fun
+#def temp-b9wX-coslice-fun
   : coslice (total-type A C) (a, c) → coslice A a
   := coslice-fun (total-type A C) A (\ (x, _) → x) (a, c)
 
-#def temp-Z7hl-fib
+#def temp-b9wX-fib
+  (a' : A)
+  (f : hom A a a')
   : U
   :=
     fib (coslice (total-type A C) (a, c))
         (coslice A a)
-        (temp-Z7hl-coslice-fun)
+        (temp-b9wX-coslice-fun)
         (a', f)
 ```
 
-It is convenient to replace this fiber by an equivalent type,
-where we unpack the homs in the Sigma-type `Σ C`.
+We construct the forward map;
+this one is straightforward since
+it goes from strict extension type to a weak one.
 
 ```rzk
-#def temp-Z7hl-fib'
-  : U
-  :=
-    Σ (G : coslice (total-type A C) (a, c)),
-      Eq-Σ A (hom A a) (temp-Z7hl-coslice-fun G) (a', f)
-
-#def temp-Z7hl-fib-compare
-  : Equiv (temp-Z7hl-fib) (temp-Z7hl-fib')
-  :=
-    total-equiv-family-equiv
-      (coslice (total-type A C) (a, c))
-      (\ G → temp-Z7hl-coslice-fun G = (a', f))
-      (\ G → Eq-Σ A (hom A a) (temp-Z7hl-coslice-fun G) (a', f))
-      (\ G →
-        extensionality-Σ
-          A (hom A a)
-          (temp-Z7hl-coslice-fun G)
-          (a', f)
-      )
-
-```
-
-We prove the theorem by showing that the two types
-`dhom-from A a a' f C c` and `temp-Z7hl-fib'` are equivalent.
-Since the left side is stricter than the right,
-the forward map is straightforward.
-
-```rzk
-#def temp-Z7hl-forward
-  : dhom-from A a a' f C c → temp-Z7hl-fib
+#def temp-b9wX-forward
+  ( a' : A)
+  ( f : hom A a a')
+  : dhom-from A a a' f C c → temp-b9wX-fib a' f
   :=
     \ (c', f̂) → (((a', c'), \ t → (f t, f̂ t)) , refl)
-
-#def temp-Z7hl-forward'
-  : dhom-from A a a' f C c → temp-Z7hl-fib'
-  :=
-    \ (c', f̂) → (((a', c'), \ t → (f t, f̂ t)) , (refl, refl))
 ```
 
-Constructing the backward map requires some rectification.
+The only non-trivial part is showing that this map has a section.
+We do this by the following fiber induction.
 
 ```rzk
-#def temp-Z7hl-family
-  ( a'' : A)
-  ( p : a'' = a')
+#def temp-b9wX-has-section'-forward
+  ( (a', f) : coslice A a)
+  ( u : temp-b9wX-fib a' f)
   : U
-  :=
-    ( c'' : C a'') →
-    ( ĝ : hom (total-type A C) (a, c) (a'', c'')) →
-    ( q : transport A (hom A a) a'' a'
-            p (\ t → first (ĝ t))
-          = f
-    ) →
-    dhom-from A a a' f C c
+  := Σ ( v : dhom-from A a a' f C c), ( temp-b9wX-forward a' f v = u)
 
-#def temp-Z7hl-backward'
-  : ( a'' : A) → ( p : a'' = a') → temp-Z7hl-family a'' p
+#def temp-b9wX-forward-section'
+  : ( (a', f) : coslice A a) →
+    ( u : temp-b9wX-fib a' f) →
+    temp-b9wX-has-section'-forward (a', f) u
   :=
-    ind-path-l A a' (temp-Z7hl-family)
-    (\ c'' ĝ q →
-      transport (hom A a a')
-        (\ g → dhom-from A a a' g C c) (\ t → first (ĝ t)) f
-        q
-        (c'', \ t → second (ĝ t))
+    ind-fib
+      ( coslice (total-type A C) (a, c))
+      ( coslice A a)
+      ( temp-b9wX-coslice-fun)
+      ( temp-b9wX-has-section'-forward)
+      (\ ((a', c'), ĝ) → ((c', \ t → second (ĝ t)) , refl))
+```
+
+We have constructed a section; but it is automatically also a retraction,
+yielding the desired equivalence.
+
+```rzk
+#def temp-b9wX-has-inverse-forward
+  ( a' : A)
+  ( f : hom A a a')
+  : has-inverse
+      (dhom-from A a a' f C c)
+      (temp-b9wX-fib a' f)
+      (temp-b9wX-forward a' f)
+  :=
+    ( \ u → first (temp-b9wX-forward-section' (a', f) u),
+    ( \ _ → refl,
+      \ u → second (temp-b9wX-forward-section' (a', f) u)
+    ))
+
+#def temp-b9wX-equiv
+  ( a' : A)
+  ( f : hom A a a')
+  : Equiv
+      (dhom-from A a a' f C c)
+      (temp-b9wX-fib a' f)
+  :=
+    ( (temp-b9wX-forward a' f),
+      is-equiv-has-inverse
+        (dhom-from A a a' f C c)
+        (temp-b9wX-fib a' f)
+        (temp-b9wX-forward a' f)
+        (temp-b9wX-has-inverse-forward a' f)
     )
 
-#def temp-Z7hl-backward
-  : temp-Z7hl-fib → dhom-from A a a' f C c
-  :=
-    \ (((a'', c''), ĝ), γ) →
-    temp-Z7hl-backward' a''
-      (first-path-Σ A (hom A a)
-        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c) ((a'',c''), ĝ))
-        (a', f)
-        γ
-      )
-      c'' ĝ
-      (second-path-Σ A (hom A a)
-        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c) ((a'',c''), ĝ))
-        (a', f)
-        γ
-      )
-```
-
-One composite is definitionally equal to the identity.
-
-```rzk
-#def temp-Z7hl-forward-retract
-  : is-retract-of (dhom-from A a a' f C c) (temp-Z7hl-fib)
-  :=
-  (temp-Z7hl-forward, (temp-Z7hl-backward, \ _ → refl))
-
-#end is-naive-left-fibration-is-covariant-key-proofs
-```
-
-We deduce that if the projection `total-type A C → A`
-is a naive left fibration,
-then `C : A → U` is a covariant family.
-
-```rzk title="Theorem 8.5 (←)"
-#def is-naive-left-fibration-is-covariant-thm
-  ( A : U)
-  ( C : A → U)
-  ( inlf-A-C : is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
-  : is-covariant A C
-  :=
-    \ a a' f c →
-    is-contr-is-retract-of-is-contr
-      (dhom-from A a a' f C c)
-      (temp-Z7hl-fib A a a' f C c)
-      (temp-Z7hl-forward-retract A a a' f C c)
-      (is-contr-map-is-equiv
-        (coslice (total-type A C) (a, c))
-        (coslice A a)
-        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c))
-        (inlf-A-C (a, c))
-        (a', f)
-      )
+#end is-naive-left-fibration-is-covariant-proof
 ```
 
 ## Representable covariant families

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -227,17 +227,14 @@ is covariant if and only if
 the projection `#!rzk p : total-type A C → A` is a naive left fibration.
 
 The theorem asserts the logical equivalence of two contractibility statements,
-one for `dhom-from A a a' f C c`
-and one for the fiber of the canonical map
+one for the types `dhom-from A a a' f C c`
+and one for the fibers of the canonical map
 `coslice (total-type A C) (a, c) → coslice A a`;
 Thus it suffices to show that for each
-`a a' : A`, `f : hom A a a'`, `c : C a`, `c' : C a'`.
+`a a' : A`, `f : hom A a a'`, `c : C a`.
 these two types are equivalent.
 
 We fix the following variables.
-Note that we do not fix `a' : A` and `f : hom A a a'`.
-Letting these vary lets us give an easy proof
-by invoking the induction principle for fibers.
 
 ```rzk
 #section is-naive-left-fibration-is-covariant-proof
@@ -246,6 +243,11 @@ by invoking the induction principle for fibers.
 #variable C : A → U
 #variable c : C a
 ```
+
+Note that we do not fix `a' : A` and `f : hom A a a'`.
+Letting these vary lets us give an easy proof
+by invoking the induction principle for fibers.
+
 
 We make some abbreviations to make the proof more readable:
 
@@ -306,8 +308,8 @@ We do this by the following fiber induction.
       (\ ((a', c'), ĝ) → ((c', \ t → second (ĝ t)) , refl))
 ```
 
-We have constructed a section; but it is automatically also a retraction,
-yielding the desired equivalence.
+We have constructed a section.
+It is also definitionally a retraction, yielding the desired equivalence.
 
 ```rzk
 #def temp-b9wX-has-inverse-forward

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -346,6 +346,44 @@ It is also definitionally a retraction, yielding the desired equivalence.
 Finally, we deduce the theorem by some straightforward logical bookkeeping.
 
 ```rzk title="RS17, Theorem 8.5"
+#def is-naive-left-fibration-is-covariant
+  ( A : U)
+  ( C : A → U)
+  ( is-covariant-C : is-covariant A C)
+  : is-naive-left-fibration A (total-type A C) (\ (a, _) → a)
+  :=
+    \ (a, c) →
+      is-equiv-is-contr-map
+        ( coslice (total-type A C) (a, c))
+        ( coslice A a)
+        ( temp-b9wX-coslice-fun A a C c)
+        ( \ (a', f) →
+          is-contr-equiv-is-contr
+            (dhom-from A a a' f C c)
+            (temp-b9wX-fib A a C c a' f)
+            (temp-b9wX-the-equivalence A a C c a' f)
+            (is-covariant-C a a' f c)
+        )
+
+#def is-covariant-is-naive-left-fibration
+  ( A : U)
+  ( C : A → U)
+  ( inlf-ΣC : is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
+  : is-covariant A C
+  :=
+    \ a a' f c →
+      is-contr-equiv-is-contr'
+        ( dhom-from A a a' f C c)
+        ( temp-b9wX-fib A a C c a' f)
+        ( temp-b9wX-the-equivalence A a C c a' f)
+        ( is-contr-map-is-equiv
+          ( coslice (total-type A C) (a, c))
+          ( coslice A a)
+          ( temp-b9wX-coslice-fun A a C c)
+          ( inlf-ΣC (a, c))
+          (a', f)
+        )
+
 #def is-naive-left-fibration-iff-is-covariant
   ( A : U)
   ( C : A → U)
@@ -354,31 +392,8 @@ Finally, we deduce the theorem by some straightforward logical bookkeeping.
       (is-covariant A C)
       (is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
   :=
-    ( \ is-covariant-C (a, c) →
-        is-equiv-is-contr-map
-          ( coslice (total-type A C) (a, c))
-          ( coslice A a)
-          ( temp-b9wX-coslice-fun A a C c)
-          ( \ (a', f) →
-            is-contr-equiv-is-contr
-              (dhom-from A a a' f C c)
-              (temp-b9wX-fib A a C c a' f)
-              (temp-b9wX-the-equivalence A a C c a' f)
-              (is-covariant-C a a' f c)
-          )
-    , \ inlf-ΣC a a' f c →
-        is-contr-equiv-is-contr'
-          ( dhom-from A a a' f C c)
-          ( temp-b9wX-fib A a C c a' f)
-          ( temp-b9wX-the-equivalence A a C c a' f)
-          ( is-contr-map-is-equiv
-            ( coslice (total-type A C) (a, c))
-            ( coslice A a)
-            ( temp-b9wX-coslice-fun A a C c)
-            ( inlf-ΣC (a, c))
-            (a', f)
-          )
-    )
+    ( is-naive-left-fibration-is-covariant A C,
+      is-covariant-is-naive-left-fibration A C)
 ```
 
 ## Representable covariant families

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -235,7 +235,7 @@ and of the fiber at `(a', f)` of the map
   :=
     fib (coslice (total-type A C) (a, c))
         (coslice A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c))
         (a', f)
 ```
 
@@ -283,13 +283,13 @@ Constructing the backward map requires some rectification.
     \ (((a'', c''), ĝ), γ) →
     temp-Z7hl-backward' a''
       (first-path-Σ A (hom A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c) ((a'',c''), ĝ))
         (a', f)
         γ
       )
       c'' ĝ
       (second-path-Σ A (hom A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c) ((a'',c''), ĝ))
         (a', f)
         γ
       )
@@ -301,7 +301,7 @@ One composite is definitionally equal to the identity.
 #def temp-Z7hl-forward-retract
   : is-retract-of (dhom-from A a a' f C c) (temp-Z7hl-fib)
   :=
-  (temp-Z7hl-forward, (temp-Z7hl-backward, \ g → refl))
+  (temp-Z7hl-forward, (temp-Z7hl-backward, \ _ → refl))
 
 #end is-naive-left-fibration-is-covariant-key-proofs
 ```
@@ -314,7 +314,7 @@ then `C : A → U` is a covariant family.
 #def is-naive-left-fibration-is-covariant-thm
   ( A : U)
   ( C : A → U)
-  ( inlf-A-C : is-naive-left-fibration A (total-type A C) (\ (a, c) → a))
+  ( inlf-A-C : is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
   : is-covariant A C
   :=
     \ a a' f c →
@@ -325,7 +325,7 @@ then `C : A → U` is a covariant family.
       (is-contr-map-is-equiv
         (coslice (total-type A C) (a, c))
         (coslice A a)
-        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c))
         (inlf-A-C (a, c))
         (a', f)
       )

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -217,6 +217,12 @@ We fix the following variables.
 #variable f : hom A a a'
 #variable C : A → U
 #variable c : C a
+
+-- We prepend all local variables in this section
+-- with the randomly string "temp-Z7hl"
+-- to avoid clashes in the global name-space.
+-- Once the language supports local scoping,
+-- these variables should be renamed.
 ```
 The two sides of the equivalence assert, respectively, the contractibility
 of `dhom-from A a a' f C c`
@@ -224,19 +230,43 @@ and of the fiber at `(a', f)` of the map
 `coslice (total-type C) (a, c) → coslice A a`.
 
 ```rzk
--- We prepend all local variables in this section
--- with the randomly string "temp-Z7hl"
--- to avoid clashes in the global name-space.
--- Once the language supports local scoping,
--- these variables should be renamed.
+#def temp-Z7hl-coslice-fun
+  : coslice (total-type A C) (a, c) → coslice A a
+  := coslice-fun (total-type A C) A (\ (x, _) → x) (a, c)
 
 #def temp-Z7hl-fib
   : U
   :=
     fib (coslice (total-type A C) (a, c))
         (coslice A a)
-        (coslice-fun (total-type A C) A (\ (a, _) → a) (a, c))
+        (temp-Z7hl-coslice-fun)
         (a', f)
+```
+
+It is convenient to replace this fiber by an equivalent type,
+where we unpack the homs in the Sigma-type `Σ C`.
+
+```rzk
+#def temp-Z7hl-fib-Σ
+  : U
+  :=
+    Σ (G : coslice (total-type A C) (a, c)),
+      Eq-Σ A (hom A a) (temp-Z7hl-coslice-fun G) (a', f)
+
+#def temp-Z7hl-fib-compare
+  : Equiv (temp-Z7hl-fib) (temp-Z7hl-fib-Σ)
+  :=
+    total-equiv-family-equiv
+      (coslice (total-type A C) (a, c))
+      (\ G → temp-Z7hl-coslice-fun G = (a', f))
+      (\ G → Eq-Σ A (hom A a) (temp-Z7hl-coslice-fun G) (a', f))
+      (\ G →
+        extensionality-Σ
+          A (hom A a)
+          (temp-Z7hl-coslice-fun G)
+          (a', f)
+      )
+
 ```
 
 We prove the theorem by showing that these two types are equivalent.
@@ -265,6 +295,22 @@ Constructing the backward map requires some rectification.
           = f
     ) →
     dhom-from A a a' f C c
+
+#def temp-Z7hl-family-with-comp
+  ( a'' : A)
+  ( p : a'' = a')
+  : U
+  :=
+    ( c'' : C a'') →
+    ( ĝ : hom (total-type A C) (a, c) (a'', c'')) →
+    ( γ : coslice-fun (total-type A C) A
+            (\ (a, _) → a)
+            (a, c)
+            ((a'', c''), ĝ)
+            =   (a', f)
+    ) →
+    Σ ( u : dhom-from A a a' f C c),
+      temp-Z7hl-forward u = (((a'', c''), ĝ), γ)
 
 #def temp-Z7hl-backward'
   : ( a'' : A) → ( p : a'' = a') → temp-Z7hl-family a'' p

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -173,6 +173,111 @@ logical equivalence
           ( C-is-covariant x y f u)))
 ```
 
+## Naive left fibrations
+
+For any functor `p : Ĉ → A`,
+we can make a naive definition of what it means to be a left fibration.
+
+```rzk
+#def is-naive-left-fibration
+  ( A Ĉ : U)
+  ( p : Ĉ → A)
+  : U
+  :=
+    is-homotopy-cartesian
+      Ĉ (coslice Ĉ)
+      A (coslice A)
+      p (coslice-fun Ĉ A p)
+```
+
+As a sanity check we unpack the definition of `is-naive-left-fibration`.
+
+```rzk
+#def is-naive-left-fibration-unpacked
+  ( A Ĉ : U)
+  ( p : Ĉ → A)
+  : is-naive-left-fibration A Ĉ p =
+      ((c : Ĉ) → is-equiv (coslice Ĉ c) (coslice A (p c)) (coslice-fun Ĉ A p c))
+  := refl
+```
+
+For every covariant type `#!rzk C : A → U`,
+the projection `#!rzk p : total-type A C → A` is a naive left fibration in this sense:
+
+```rzk title="The statement of RS17, Theorem 8.5"
+#def is-naive-left-fibration-is-covariant-thm
+  (A : U)
+  (C : A → U)
+  : U
+  := iff
+    (is-covariant A C)
+    (is-naive-left-fibration A (total-type A C) (\ (a, c) → a))
+```
+
+```rzk
+#section is-naive-left-fibration-is-covariant-proof
+#variable A : U
+#variable C : A → U
+#variable a : A
+#variable a' : A
+#variable f : hom A a a'
+#variable c : C a
+
+#def temp-forward
+  : dhom-from A a a' f C c
+  → fib (coslice (total-type A C) (a, c)) (coslice A a)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (a', f)
+  :=
+    \ (c', f̂) → (((a', c'), \ t → (f t, f̂ t)) , refl)
+
+#def temp-backward-1
+  : fib (coslice (total-type A C) (a, c)) (coslice A a)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (a', f)
+  → Σ (c' : C a'), hom (total-type A C) (a, c) (a', c')
+  :=
+    \ (((a'', c''), ĝ), γ) →
+    (transport A
+      (\ z → (Σ (d : C z), hom (total-type A C) (a, c) (z,d)))
+      a'' a'
+      (first-path-Σ A (\ x → hom A a x)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (a', f)
+        γ
+      )
+      (c'', ĝ)
+    )
+
+#def temp-backward-1
+  : fib (coslice (total-type A C) (a, c)) (coslice A a)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c))
+        (a', f)
+  → Σ ((c', h) : product (C a') (hom A a a')), dhom A a a' h C c c'
+  :=
+    \ (((a'', c''), ĝ), γ) →      -- ĝ : hom (total-type A C) (a, c) (a'', c'')
+    (transport A
+      (\ z → (Σ ((d, h) : product (C z) (hom A a z)), dhom A a z h C c d))
+      a'' a'
+      (first-path-Σ A (\ x → hom A a x)
+        (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+        (a', f)
+        γ
+      )
+      ((c'',
+        transport A (\ z → hom A a z)
+        (first-path-Σ A (\ x → hom A a x)
+          (coslice-fun (total-type A C) A (\ (a, c) → a) (a, c) ((a'',c''), ĝ))
+          (a', f)
+          γ
+        )
+        f
+      ), U)
+    )
+
+#end is-naive-left-fibration-is-covariant-proof
+```
+
 ## Representable covariant families
 
 If A is a Segal type and a : A is any term, then hom A a defines a covariant


### PR DESCRIPTION
1) For an arbitrary map `p : C -> A` define the notion of being a naive left fibration, capturing homotopy-unique lifting along `{0} -> \Delta^1`.

2) Prove RS17, Theorem 8.5: a type family `C : A -> U`  is covariant if and only if the projection `\Sigma C --> A` is a naive left fibration.

Notes:
- resolves #11.
- As a work-around for the lack of local variables in rzk, I have prepended the name of certain helper-terms with the random identifier "temp-b9wX" to avoid clashes in the global name space
- Ideally, this section/theorem should be a very special case of a general situation, where the inclusion `{0} -> \Delta^1` is replaced by an arbitrary subshape `\Phi -> \Psi`. The proofs should be essentially the same, except that a  lot of the helper notation (such as hom, dhom, coslice, etc) would have to be introduced first.
- Considerably simplified the proof compared to the previous version of this pull request using fiber induction.