### PR TITLE
Definition of inner anodyne map

### DIFF
--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -40,11 +40,24 @@ This is a literate `rzk` file:
     \ (t , s) → (s ≡ 0₂ ∨ t ≡ 1₂ ∨ s ≡ t)
 ```
 
-### The inner horn
+### The 2 dimensional inner horn
 
 ```rzk
 #def Λ : (2 × 2) → TOPE
   := \ (t , s) → (s ≡ 0₂ ∨ t ≡ 1₂)
+
+#def Λ²₁ : Δ² → TOPE
+  := \ (s,t) → Λ (s,t)
+```
+
+### The 3 dimensional inner horns
+
+```rzk
+#def Λ³₁ : Δ³ → TOPE
+  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t2 ≡ t1 ∨ t1 ≡ 1₂
+
+#def Λ³₂ : Δ³ → TOPE
+  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t3 ≡ t2 ∨ t1 ≡ 1₂
 ```
 
 ### Products
@@ -83,6 +96,11 @@ The product of topes defines the product of shapes.
 ```rzk title="The prism from a 2-simplex in an arrow type"
 #def Δ²×Δ¹ : (2 × 2 × 2) → TOPE
   := shape-prod (2 × 2) 2 Δ² Δ¹
+```
+
+```rzk
+#def Δ³×Δ² : ((2 × 2 × 2) × (2 × 2)) → TOPE
+  := shape-prod (2 × 2 × 2) (2 × 2) Δ³ Δ²
 ```
 
 Maps out of $Δ²$ are a retract of maps out of $Δ¹×Δ¹$.
@@ -126,6 +144,21 @@ Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
   :=
     ( Δ³-is-retract-Δ²×Δ¹-section A ,
       ( Δ³-is-retract-Δ²×Δ¹-retraction A , \ _ → refl))
+```
+
+### Pushout product
+
+Pushout product Φ×ζ ∪_{Φ×χ} ψ×χ of Φ ↪ ψ and χ ↪ ζ, domain of the co-gap map.
+
+```rzk
+#def shape-pushout-prod
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( Φ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  : (shape-prod I J ψ ζ) → TOPE
+  := \ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s)
 ```
 
 ### Intersections
@@ -237,4 +270,3 @@ The union of shapes is defined by disjunction on topes.
     }
   </style>
 </svg>
-

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1456,3 +1456,68 @@ As a special case of the above:
       (is-segal-A (h' (0₂,0₂)) (h' (1₂,0₂)) (h' (1₂,1₂))
           (\ t → h' (t,0₂)) (\ s → h' (1₂,s)))
 ```
+
+
+```rzk title="RS17, lemma 5.20"
+
+#def pushout-product-codomain
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( ζ : J → TOPE)
+  : (I × J) → TOPE
+  := \ (t,s) → ψ t ∧ ζ s
+
+#def pushout-product-domain
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( Φ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  : (pushout-product-codomain I J ψ ζ) → TOPE
+  := \ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s)
+
+#def is-inner-anodyne-pushout-product-left-is-inner-anodyne
+  (weakExtExt : WeakExtExt)
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( Φ : ψ → TOPE)
+  (is-inner-anodyne-ψ-Φ : is-inner-anodyne I ψ Φ)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  : is-inner-anodyne (I × J) (\ (t,s) → ψ t ∧ ζ s) (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
+  := \ A is-segal-A h →
+    equiv-with-contractible-codomain-implies-contractible-domain
+      (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
+      ( (s : ζ) → ((t : ψ) → A[ Φ t ↦ h (t,s)])[ χ s ↦ \ t → h (t, s)])
+      (uncurry-opcurry I J ψ Φ ζ χ (\ s t → A) h)
+      (weakExtExt
+        J
+        ζ
+        χ
+        (\ s → (t : ψ) → A[ Φ t ↦ h (t,s)])
+        (\ s → is-inner-anodyne-ψ-Φ A is-segal-A (\ t → h (t,s)))
+        (\ s t → h (t,s)))
+
+#def is-inner-anodyne-pushout-product-right-is-inner-anodyne
+  (weakExtExt : WeakExtExt)
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( Φ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  (is-inner-anodyne-ζ-χ : is-inner-anodyne J ζ χ)
+  : is-inner-anodyne (I × J) (\ (t,s) → ψ t ∧ ζ s) (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
+  := \ A is-segal-A h →
+    equiv-with-contractible-domain-implies-contractible-codomain
+      ( (t : ψ) → ((s : ζ) → A[ χ s ↦ h (t,s)])[ Φ t ↦ \ s → h (t, s)])
+      (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
+      (curry-uncurry I J ψ Φ ζ χ (\ s t → A) h)
+      (weakExtExt
+        I
+        ψ
+        Φ
+        (\ t → (s : ζ) → A[ χ s ↦ h (t,s)])
+        (\ t → is-inner-anodyne-ζ-χ A is-segal-A (\ s → h (t,s)))
+        (\ s t → h (s,t)))
+
+```

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -26,6 +26,7 @@ extension extensionality:
 
 ```rzk
 #assume funext : FunExt
+#assume weakextext : WeakExtExt
 #assume extext : ExtExt
 ```
 
@@ -416,33 +417,33 @@ We have now proven that both notions of Segal types are logically equivalent.
 
 Using the new characterization of Segal types, we can show that the type of
 functions or extensions into a family of Segal types is again a Segal type. For
-instance if $X$ is a type and $A : X → U$ is such that $A x$ is a Segal type for
-all $x$ then $(x : X) → A x$ is a Segal type.
+instance if $pushout-prod-Λ³₂-Λ²₁$ is a type and $A : pushout-prod-Λ³₂-Λ²₁ → U$ is such that $A x$ is a Segal type for
+all $x$ then $(x : pushout-prod-Λ³₂-Λ²₁) → A x$ is a Segal type.
 
 ```rzk title="RS17, Corollary 5.6(i)"
 #def is-segal-function-type uses (funext)
-  ( X : U)
-  ( A : X → U)
-  ( fiberwise-is-segal-A : (x : X) → is-local-horn-inclusion (A x))
-  : is-local-horn-inclusion ((x : X) → A x)
+  ( pushout-prod-Λ³₂-Λ²₁ : U)
+  ( A : pushout-prod-Λ³₂-Λ²₁ → U)
+  ( fiberwise-is-segal-A : (x : pushout-prod-Λ³₂-Λ²₁) → is-local-horn-inclusion (A x))
+  : is-local-horn-inclusion ((x : pushout-prod-Λ³₂-Λ²₁) → A x)
   :=
     is-equiv-triple-comp
-      ( Δ² → ((x : X) → A x))
-      ( (x : X) → Δ² → A x)
-      ( (x : X) → Λ → A x)
-      ( Λ → ((x : X) → A x))
+      ( Δ² → ((x : pushout-prod-Λ³₂-Λ²₁) → A x))
+      ( (x : pushout-prod-Λ³₂-Λ²₁) → Δ² → A x)
+      ( (x : pushout-prod-Λ³₂-Λ²₁) → Λ → A x)
+      ( Λ → ((x : pushout-prod-Λ³₂-Λ²₁) → A x))
       ( \ g x t → g t x) -- first equivalence
       ( second (flip-ext-fun
         ( 2 × 2)
         ( Δ²)
         ( \ t → BOT)
-        ( X)
+        ( pushout-prod-Λ³₂-Λ²₁)
         ( \ t → A)
         ( \ t → recBOT)))
       ( \ h x t → h x t) -- second equivalence
       ( second (equiv-function-equiv-family
         ( funext)
-        ( X)
+        ( pushout-prod-Λ³₂-Λ²₁)
         ( \ x → (Δ² → A x))
         ( \ x → (Λ → A x))
         ( \ x → (horn-restriction (A x) , fiberwise-is-segal-A x))))
@@ -451,13 +452,13 @@ all $x$ then $(x : X) → A x$ is a Segal type.
         ( 2 × 2)
         ( Λ)
         ( \ t → BOT)
-        ( X)
+        ( pushout-prod-Λ³₂-Λ²₁)
         ( \ t → A)
         ( \ t → recBOT)))
 ```
 
-If $X$ is a shape and $A : X → U$ is such that $A x$ is a Segal type for all $x$
-then $(x : X) → A x$ is a Segal type.
+If $pushout-prod-Λ³₂-Λ²₁$ is a shape and $A : pushout-prod-Λ³₂-Λ²₁ → U$ is such that $A x$ is a Segal type for all $x$
+then $(x : pushout-prod-Λ³₂-Λ²₁) → A x$ is a Segal type.
 
 ```rzk title="RS17, Corollary 5.6(ii)"
 #def is-segal-extension-type' uses (extext)
@@ -1429,7 +1430,7 @@ As a special case of the above:
 
 
 
-### Anodyne maps
+### Inner anodyne maps
 
 
 ```rzk title="RS17, definition 5.19"
@@ -1440,14 +1441,17 @@ As a special case of the above:
   (Φ : ψ → TOPE)
   : U
   := (A : U) → is-segal A → (h : Φ → A) → is-contr ((t : ψ) → A[ Φ t ↦ h t ])
+```
 
-#def Λ²₁ : Δ² → TOPE := \ (s,t) → Λ (s,t)
+The cofibration Λ²₁ → Δ² is inner anodyne
 
-#def is-inner-anodyne-Λ²₁ : is-inner-anodyne (2 × 2) Δ² Λ²₁
+```rzk
+#def is-inner-anodyne-Λ²₁
+  : is-inner-anodyne (2 × 2) Δ² Λ²₁
   := \ A is-segal-A h' →
     equiv-with-contractible-domain-implies-contractible-codomain
       ( Σ (h : hom A (h' (0₂,0₂)) (h' (1₂,1₂))) ,
-         (hom2 A (h' (0₂,0₂)) (h' (1₂,0₂)) (h' (1₂,1₂))
+          (hom2 A (h' (0₂,0₂)) (h' (1₂,0₂)) (h' (1₂,1₂))
           (\ t → h' (t,0₂)) (\ s → h' (1₂,s)) h))
       ( (t : Δ²) → A [Λ t ↦ h' t])
       (compositions-are-horn-fillings
@@ -1457,93 +1461,69 @@ As a special case of the above:
           (\ t → h' (t,0₂)) (\ s → h' (1₂,s)))
 ```
 
-
 ```rzk title="RS17, lemma 5.20"
-
-#def pushout-product-codomain
-  ( I J : CUBE)
-  ( ψ : I → TOPE)
-  ( ζ : J → TOPE)
-  : (I × J) → TOPE
-  := \ (t,s) → ψ t ∧ ζ s
-
-#def pushout-product-domain
-  ( I J : CUBE)
-  ( ψ : I → TOPE)
-  ( Φ : ψ → TOPE)
-  ( ζ : J → TOPE)
-  ( χ : ζ → TOPE)
-  : (pushout-product-codomain I J ψ ζ) → TOPE
-  := \ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s)
-
-#def is-inner-anodyne-pushout-product-left-is-inner-anodyne
-  (weakExtExt : WeakExtExt)
+#def is-inner-anodyne-pushout-product-left-is-inner-anodyne uses (weakextext)
   ( I J : CUBE)
   ( ψ : I → TOPE)
   ( Φ : ψ → TOPE)
   (is-inner-anodyne-ψ-Φ : is-inner-anodyne I ψ Φ)
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
-  : is-inner-anodyne (I × J) (\ (t,s) → ψ t ∧ ζ s) (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
+  : is-inner-anodyne (I × J)
+      (\ (t,s) → ψ t ∧ ζ s)
+      (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
   := \ A is-segal-A h →
     equiv-with-contractible-codomain-implies-contractible-domain
       (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
       ( (s : ζ) → ((t : ψ) → A[ Φ t ↦ h (t,s)])[ χ s ↦ \ t → h (t, s)])
       (uncurry-opcurry I J ψ Φ ζ χ (\ s t → A) h)
-      (weakExtExt
-        J
-        ζ
-        χ
-        (\ s → (t : ψ) → A[ Φ t ↦ h (t,s)])
-        (\ s → is-inner-anodyne-ψ-Φ A is-segal-A (\ t → h (t,s)))
-        (\ s t → h (t,s)))
+      (weakextext
+        ( J)
+        ( ζ)
+        ( χ)
+        ( \ s → (t : ψ) → A[ Φ t ↦ h (t,s)])
+        ( \ s → is-inner-anodyne-ψ-Φ A is-segal-A (\ t → h (t,s)))
+        ( \ s t → h (t,s)))
 
-#def is-inner-anodyne-pushout-product-right-is-inner-anodyne
-  (weakExtExt : WeakExtExt)
+#def is-inner-anodyne-pushout-product-right-is-inner-anodyne uses (weakextext)
   ( I J : CUBE)
   ( ψ : I → TOPE)
   ( Φ : ψ → TOPE)
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   (is-inner-anodyne-ζ-χ : is-inner-anodyne J ζ χ)
-  : is-inner-anodyne (I × J) (\ (t,s) → ψ t ∧ ζ s) (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
+  : is-inner-anodyne (I × J)
+      (\ (t,s) → ψ t ∧ ζ s)
+      (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
   := \ A is-segal-A h →
     equiv-with-contractible-domain-implies-contractible-codomain
       ( (t : ψ) → ((s : ζ) → A[ χ s ↦ h (t,s)])[ Φ t ↦ \ s → h (t, s)])
       (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
       (curry-uncurry I J ψ Φ ζ χ (\ s t → A) h)
-      (weakExtExt
-        I
-        ψ
-        Φ
-        (\ t → (s : ζ) → A[ χ s ↦ h (t,s)])
-        (\ t → is-inner-anodyne-ζ-χ A is-segal-A (\ s → h (t,s)))
-        (\ s t → h (s,t)))
-
+      (weakextext
+        ( I)
+        ( ψ)
+        ( Φ)
+        ( \ t → (s : ζ) → A[ χ s ↦ h (t,s)])
+        ( \ t → is-inner-anodyne-ζ-χ A is-segal-A (\ s → h (t,s)))
+        ( \ s t → h (s,t)))
 ```
 
 
 ```rzk title="RS17, lemma 5.21"
+#section retraction-Λ³₂-Δ³-pushout-product-Λ²₁-Δ²
 
-#def Λ³₁ : Δ³ → TOPE
-  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t2 ≡ t1 ∨ t1 ≡ 1₂
-
-#def Λ³₂ : Δ³ → TOPE
-  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t3 ≡ t2 ∨ t1 ≡ 1₂
-
-#section retraction-Δ³-Δ³×Δ²
-
-#def Δ³×Δ² : ((2 × 2 × 2) × (2 × 2)) → TOPE
-  := pushout-product-codomain (2 × 2 × 2) (2 × 2) Δ³ Δ²
-
-#def X : (Δ³×Δ²) → TOPE
-  := pushout-product-domain (2 × 2 × 2) (2 × 2) Δ³ Λ³₂ Δ² Λ²₁
+-- Δ³×Λ²₁ ∪_{Λ³₂×Λ²₁} Λ³₂×Δ²
+#def pushout-prod-Λ³₂-Λ²₁
+  : (Δ³×Δ²) → TOPE
+  := shape-pushout-prod (2 × 2 × 2) (2 × 2) Δ³ Λ³₂ Δ² Λ²₁
 
 
 #variable A : U
 #variable h : Λ³₂ → A
 
-#def h^ : X → A
+#def h^
+  : pushout-prod-Λ³₂-Λ²₁ → A
   := \ ( ((t1, t2), t3), (s1, s2) ) →
     recOR
       ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ h ((t1, t2), t3),
@@ -1554,14 +1534,20 @@ As a special case of the above:
         t1 ≤ s1 ∧ s2 ≤ t3 ↦ h ((s1, s2), s2))
 
 
-#def small : U := (t : Δ³) → A[ Λ³₂ t ↦ h t ]
-#def large uses (h) : U := (x : Δ³×Δ²) → A[ X x ↦ h^ x]
+#def extend-against-Λ³₂-Δ³
+  : U
+  := (t : Δ³) → A[ Λ³₂ t ↦ h t ]
 
-#def retract uses (A h) (f : large) : small
+#def extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² uses (h)
+  : U
+  := (x : Δ³×Δ²) → A[ pushout-prod-Λ³₂-Λ²₁ x ↦ h^ x]
+
+#def retract uses (A h) (f : extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
+  : extend-against-Λ³₂-Δ³
   := \ ((t1, t2), t3) → f ( ((t1, t2), t3), (t1, t2) )
 
 #def section uses (A h) (g : (t : Δ³) → A[ Λ³₂ t ↦ h t ])
-  : (x : Δ³×Δ²) → A[ X x ↦ h^ x]
+  : (x : Δ³×Δ²) → A[ pushout-prod-Λ³₂-Λ²₁ x ↦ h^ x]
   :=  \ ( ((t1, t2), t3), (s1, s2) ) →
     recOR
       ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ g ((t1, t2), t3),
@@ -1572,26 +1558,32 @@ As a special case of the above:
         t1 ≤ s1 ∧ s2 ≤ t3 ↦ g ((s1, s2), s2))
 
 #def homotopy-retraction-section-id uses (A h)
-  : homotopy small small
-    ( comp small large small retract section)
-    ( identity small)
+  : homotopy extend-against-Λ³₂-Δ³ extend-against-Λ³₂-Δ³
+    ( comp
+      ( extend-against-Λ³₂-Δ³)
+      ( extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
+      ( extend-against-Λ³₂-Δ³)
+      ( retract)
+      ( section))
+    ( identity extend-against-Λ³₂-Δ³)
   := \ t → refl
 
 #def is-retract-of-Δ³-Δ³×Δ² uses (A h)
-  : is-retract-of small large
+  : is-retract-of
+      extend-against-Λ³₂-Δ³
+      extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²
   := (section , (retract , homotopy-retraction-section-id))
 
-#end retraction-Δ³-Δ³×Δ²
+#end retraction-Λ³₂-Δ³-pushout-product-Λ²₁-Δ²
 
-#def lemma-5-21 (weakExtExt : WeakExtExt)
+#def is-inner-anodyne-Δ³-Λ³₂ uses (weakextext)
   : is-inner-anodyne (2 × 2 × 2) Δ³ Λ³₂
   := \ A is-segal-A h →
     is-contr-is-retract-of-is-contr
-      (small A h)
-      (large A h)
+      (extend-against-Λ³₂-Δ³ A h)
+      (extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² A h)
       (is-retract-of-Δ³-Δ³×Δ² A h)
       (is-inner-anodyne-pushout-product-right-is-inner-anodyne
-        ( weakExtExt)
         ( 2 × 2 × 2)
         ( 2 × 2)
         ( Δ³)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -52,12 +52,8 @@ Extension types are used to define the type of arrows between fixed terms:
 
 ```
 
-For each `a : A`, the total types of the representables
-`\ z → hom A a z`
-and
-`\ z → hom A z a`
-are called the coslice and slice, respectively.
-
+For each `a : A`, the total types of the representables `\ z → hom A a z` and
+`\ z → hom A z a` are called the coslice and slice, respectively.
 
 ```rzk
 #def coslice
@@ -73,8 +69,8 @@ are called the coslice and slice, respectively.
   := Σ (z : A) , (hom A z a)
 ```
 
-The types `coslice A a` and `slice A a`
-are functorial in `A` in the following sense:
+The types `coslice A a` and `slice A a` are functorial in `A` in the following
+sense:
 
 ```rzk
 #def coslice-fun
@@ -417,33 +413,33 @@ We have now proven that both notions of Segal types are logically equivalent.
 
 Using the new characterization of Segal types, we can show that the type of
 functions or extensions into a family of Segal types is again a Segal type. For
-instance if $pushout-prod-Λ³₂-Λ²₁$ is a type and $A : pushout-prod-Λ³₂-Λ²₁ → U$ is such that $A x$ is a Segal type for
-all $x$ then $(x : pushout-prod-Λ³₂-Λ²₁) → A x$ is a Segal type.
+instance if $X$ is a type and $A : X → U$ is such that $A x$ is a Segal type for
+all $x$ then $(x : X) → A x$ is a Segal type.
 
 ```rzk title="RS17, Corollary 5.6(i)"
 #def is-segal-function-type uses (funext)
-  ( pushout-prod-Λ³₂-Λ²₁ : U)
-  ( A : pushout-prod-Λ³₂-Λ²₁ → U)
-  ( fiberwise-is-segal-A : (x : pushout-prod-Λ³₂-Λ²₁) → is-local-horn-inclusion (A x))
-  : is-local-horn-inclusion ((x : pushout-prod-Λ³₂-Λ²₁) → A x)
+  ( X : U)
+  ( A : X → U)
+  ( fiberwise-is-segal-A : (x : X) → is-local-horn-inclusion (A x))
+  : is-local-horn-inclusion ((x : X) → A x)
   :=
     is-equiv-triple-comp
-      ( Δ² → ((x : pushout-prod-Λ³₂-Λ²₁) → A x))
-      ( (x : pushout-prod-Λ³₂-Λ²₁) → Δ² → A x)
-      ( (x : pushout-prod-Λ³₂-Λ²₁) → Λ → A x)
-      ( Λ → ((x : pushout-prod-Λ³₂-Λ²₁) → A x))
+      ( Δ² → ((x : X) → A x))
+      ( (x : X) → Δ² → A x)
+      ( (x : X) → Λ → A x)
+      ( Λ → ((x : X) → A x))
       ( \ g x t → g t x) -- first equivalence
       ( second (flip-ext-fun
         ( 2 × 2)
         ( Δ²)
         ( \ t → BOT)
-        ( pushout-prod-Λ³₂-Λ²₁)
+        ( X)
         ( \ t → A)
         ( \ t → recBOT)))
       ( \ h x t → h x t) -- second equivalence
       ( second (equiv-function-equiv-family
         ( funext)
-        ( pushout-prod-Λ³₂-Λ²₁)
+        ( X)
         ( \ x → (Δ² → A x))
         ( \ x → (Λ → A x))
         ( \ x → (horn-restriction (A x) , fiberwise-is-segal-A x))))
@@ -452,13 +448,13 @@ all $x$ then $(x : pushout-prod-Λ³₂-Λ²₁) → A x$ is a Segal type.
         ( 2 × 2)
         ( Λ)
         ( \ t → BOT)
-        ( pushout-prod-Λ³₂-Λ²₁)
+        ( X)
         ( \ t → A)
         ( \ t → recBOT)))
 ```
 
-If $pushout-prod-Λ³₂-Λ²₁$ is a shape and $A : pushout-prod-Λ³₂-Λ²₁ → U$ is such that $A x$ is a Segal type for all $x$
-then $(x : pushout-prod-Λ³₂-Λ²₁) → A x$ is a Segal type.
+If $X$ is a shape and $A : X → U$ is such that $A x$ is a Segal type for all $x$
+then $(x : X) → A x$ is a Segal type.
 
 ```rzk title="RS17, Corollary 5.6(ii)"
 #def is-segal-extension-type' uses (extext)
@@ -1428,10 +1424,7 @@ As a special case of the above:
   </style>
 </svg>
 
-
-
 ### Inner anodyne maps
-
 
 ```rzk title="RS17, definition 5.19"
 
@@ -1508,7 +1501,6 @@ The cofibration Λ²₁ → Δ² is inner anodyne
         ( \ t → is-inner-anodyne-ζ-χ A is-segal-A (\ s → h (t,s)))
         ( \ s t → h (s,t)))
 ```
-
 
 ```rzk title="RS17, lemma 5.21"
 #section retraction-Λ³₂-Δ³-pushout-product-Λ²₁-Δ²

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1426,3 +1426,33 @@ As a special case of the above:
     }
   </style>
 </svg>
+
+
+
+### Anodyne maps
+
+
+```rzk title="RS17, definition 5.19"
+
+#def is-inner-anodyne
+  (I : CUBE)
+  (ψ : I → TOPE)
+  (Φ : ψ → TOPE)
+  : U
+  := (A : U) → is-segal A → (h : Φ → A) → is-contr ((t : ψ) → A[ Φ t ↦ h t ])
+
+#def Λ²₁ : Δ² → TOPE := \ (s,t) → Λ (s,t)
+
+#def is-inner-anodyne-Λ²₁ : is-inner-anodyne (2 × 2) Δ² Λ²₁
+  := \ A is-segal-A h' →
+    equiv-with-contractible-domain-implies-contractible-codomain
+      ( Σ (h : hom A (h' (0₂,0₂)) (h' (1₂,1₂))) ,
+         (hom2 A (h' (0₂,0₂)) (h' (1₂,0₂)) (h' (1₂,1₂))
+          (\ t → h' (t,0₂)) (\ s → h' (1₂,s)) h))
+      ( (t : Δ²) → A [Λ t ↦ h' t])
+      (compositions-are-horn-fillings
+        A (h' (0₂,0₂)) (h' (1₂,0₂)) (h' (1₂,1₂))
+          (\ t → h' (t,0₂)) (\ s → h' (1₂,s)))
+      (is-segal-A (h' (0₂,0₂)) (h' (1₂,0₂)) (h' (1₂,1₂))
+          (\ t → h' (t,0₂)) (\ s → h' (1₂,s)))
+```

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1534,13 +1534,16 @@ The cofibration Λ²₁ → Δ² is inner anodyne
   : U
   := (x : Δ³×Δ²) → A[ pushout-prod-Λ³₂-Λ²₁ x ↦ h^ x]
 
-#def retract uses (A h) (f : extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
+#def retract-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² uses (A h)
+  (f : extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
   : extend-against-Λ³₂-Δ³
   := \ ((t1, t2), t3) → f ( ((t1, t2), t3), (t1, t2) )
 
-#def section uses (A h) (g : (t : Δ³) → A[ Λ³₂ t ↦ h t ])
+#def section-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² uses (A h)
+  (g : (t : Δ³) → A[ Λ³₂ t ↦ h t ])
   : (x : Δ³×Δ²) → A[ pushout-prod-Λ³₂-Λ²₁ x ↦ h^ x]
-  :=  \ ( ((t1, t2), t3), (s1, s2) ) →
+  :=
+    \ ( ((t1, t2), t3), (s1, s2) ) →
     recOR
       ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ g ((t1, t2), t3),
         t1 ≤ s1 ∧ t2 ≤ s2 ↦ g ((s1, t2), t3),
@@ -1549,7 +1552,7 @@ The cofibration Λ²₁ → Δ² is inner anodyne
         s1 ≤ t1 ∧ s2 ≤ t3 ↦ g ((t1, s2), s2),
         t1 ≤ s1 ∧ s2 ≤ t3 ↦ g ((s1, s2), s2))
 
-#def homotopy-retraction-section-id uses (A h)
+#def homotopy-retraction-section-id-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² uses (A h)
   : homotopy extend-against-Λ³₂-Δ³ extend-against-Λ³₂-Δ³
     ( comp
       ( extend-against-Λ³₂-Δ³)
@@ -1570,7 +1573,8 @@ The cofibration Λ²₁ → Δ² is inner anodyne
 
 #def is-inner-anodyne-Δ³-Λ³₂ uses (weakextext)
   : is-inner-anodyne (2 × 2 × 2) Δ³ Λ³₂
-  := \ A is-segal-A h →
+  :=
+    \ A is-segal-A h →
     is-contr-is-retract-of-is-contr
       (extend-against-Λ³₂-Δ³ A h)
       (extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² A h)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1521,3 +1521,85 @@ As a special case of the above:
         (\ s t → h (s,t)))
 
 ```
+
+
+```rzk title="RS17, lemma 5.21"
+
+#def Λ³₁ : Δ³ → TOPE
+  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t2 ≡ t1 ∨ t1 ≡ 1₂
+
+#def Λ³₂ : Δ³ → TOPE
+  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t3 ≡ t2 ∨ t1 ≡ 1₂
+
+#section retraction-Δ³-Δ³×Δ²
+
+#def Δ³×Δ² : ((2 × 2 × 2) × (2 × 2)) → TOPE
+  := pushout-product-codomain (2 × 2 × 2) (2 × 2) Δ³ Δ²
+
+#def X : (Δ³×Δ²) → TOPE
+  := pushout-product-domain (2 × 2 × 2) (2 × 2) Δ³ Λ³₂ Δ² Λ²₁
+
+
+#variable A : U
+#variable h : Λ³₂ → A
+
+#def h^ : X → A
+  := \ ( ((t1, t2), t3), (s1, s2) ) →
+    recOR
+      ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ h ((t1, t2), t3),
+        t1 ≤ s1 ∧ t2 ≤ s2 ↦ h ((s1, t2), t3),
+        s1 ≤ t1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ h ((t1, s2), t3),
+        t1 ≤ s1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ h ((s1, s2), t3),
+        s1 ≤ t1 ∧ s2 ≤ t3 ↦ h ((t1, s2), s2),
+        t1 ≤ s1 ∧ s2 ≤ t3 ↦ h ((s1, s2), s2))
+
+
+#def small : U := (t : Δ³) → A[ Λ³₂ t ↦ h t ]
+#def large uses (h) : U := (x : Δ³×Δ²) → A[ X x ↦ h^ x]
+
+#def retract uses (A h) (f : large) : small
+  := \ ((t1, t2), t3) → f ( ((t1, t2), t3), (t1, t2) )
+
+#def section uses (A h) (g : (t : Δ³) → A[ Λ³₂ t ↦ h t ])
+  : (x : Δ³×Δ²) → A[ X x ↦ h^ x]
+  :=  \ ( ((t1, t2), t3), (s1, s2) ) →
+    recOR
+      ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ g ((t1, t2), t3),
+        t1 ≤ s1 ∧ t2 ≤ s2 ↦ g ((s1, t2), t3),
+        s1 ≤ t1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ g ((t1, s2), t3),
+        t1 ≤ s1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ g ((s1, s2), t3),
+        s1 ≤ t1 ∧ s2 ≤ t3 ↦ g ((t1, s2), s2),
+        t1 ≤ s1 ∧ s2 ≤ t3 ↦ g ((s1, s2), s2))
+
+#def homotopy-retraction-section-id uses (A h)
+  : homotopy small small
+    ( comp small large small retract section)
+    ( identity small)
+  := \ t → refl
+
+#def is-retract-of-Δ³-Δ³×Δ² uses (A h)
+  : is-retract-of small large
+  := (section , (retract , homotopy-retraction-section-id))
+
+#end retraction-Δ³-Δ³×Δ²
+
+#def lemma-5-21 (weakExtExt : WeakExtExt)
+  : is-inner-anodyne (2 × 2 × 2) Δ³ Λ³₂
+  := \ A is-segal-A h →
+    is-contr-is-retract-of-is-contr
+      (small A h)
+      (large A h)
+      (is-retract-of-Δ³-Δ³×Δ² A h)
+      (is-inner-anodyne-pushout-product-right-is-inner-anodyne
+        ( weakExtExt)
+        ( 2 × 2 × 2)
+        ( 2 × 2)
+        ( Δ³)
+        ( Λ³₂)
+        ( Δ²)
+        ( Λ²₁)
+        ( is-inner-anodyne-Λ²₁)
+        ( A)
+        ( is-segal-A)
+        ( h^ A h))
+```

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1558,8 +1558,8 @@ The cofibration Λ²₁ → Δ² is inner anodyne
       ( extend-against-Λ³₂-Δ³)
       ( extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
       ( extend-against-Λ³₂-Δ³)
-      ( retract)
-      ( section))
+      ( retract-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
+      ( section-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²))
     ( identity extend-against-Λ³₂-Δ³)
   := \ t → refl
 
@@ -1567,7 +1567,10 @@ The cofibration Λ²₁ → Δ² is inner anodyne
   : is-retract-of
       extend-against-Λ³₂-Δ³
       extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²
-  := (section , (retract , homotopy-retraction-section-id))
+  :=
+    ( section-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² ,
+      ( retract-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² ,
+        homotopy-retraction-section-id-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²))
 
 #end retraction-Λ³₂-Δ³-pushout-product-Λ²₁-Δ²
 


### PR DESCRIPTION
Adds 
- the definition of inner anodyne maps (RS17, def 5.19), 
- a proof that `Λ²₁ → Δ²` is inner anodyne, 
- the proof that the pushout product of an inner anodyne cofibration with a cofibration is an inner cofibration (RS17, prop 5.20, also implemented the version with swapped arguments for the cofibrations)
- the proof that `Λ³₂ → Δ³` is an inner cofibration (spelled out part of RS17, prop 5.21)

Before merging this PR, various definitions should be renamedt. In particular the names `small` and `large` corresponding to the types of extensions against respectively `Λ³₂ → Δ³` and `Δ³×Λ²₁ ∪_{Λ³₂×Λ²₁} Λ³₂×Δ² → Δ³×Δ²` (the pushout product of `Λ³₂ → Δ³` and `Λ²₁ → Δ²`). The names `X` and `h^` could also be changed (but correspond to the names in the paper proof).

Wrt #8, the proof of Λ³₁ → Δ³` being inner anodyne and that of prop 5.21 are missing (~~Is there a proof of lemma 5.16 already there or should it be added too ?~~ Depends on #7).