### PR TITLE
Vertical calculus for homotopy cartesian squares

### DIFF
--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -178,18 +178,18 @@ notion.
 
 ## Symmetry of having an inverse
 
-The inverse of an invertible map has an inverse. 
+The inverse of an invertible map has an inverse.
 
 ```rzk
 #def has-inverse-map-inverse-has-inverse
   ( A B : U)
   ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
-  : has-inverse B A ( map-inverse-has-inverse A B f has-inverse-f)  
-  := 
-    ( f, 
+  : has-inverse B A ( map-inverse-has-inverse A B f has-inverse-f)
+  :=
+    ( f,
       ( second ( second has-inverse-f) ,
-        first ( second has-inverse-f))) 
+        first ( second has-inverse-f)))
 ```
 
 ## Composing equivalences
@@ -433,7 +433,7 @@ If a map is homotopic to an equivalence it is an equivalence.
 
 ## Reversing equivalences
 
-The section associated with an equivalence is an equivalence. 
+The section associated with an equivalence is an equivalence.
 
 ```rzk
 #def is-equiv-section-is-equiv
@@ -441,14 +441,14 @@ The section associated with an equivalence is an equivalence.
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
   : is-equiv B A ( section-is-equiv A B f is-equiv-f)
-  := 
-    is-equiv-has-inverse B A 
-      ( section-is-equiv A B f is-equiv-f) 
+  :=
+    is-equiv-has-inverse B A
+      ( section-is-equiv A B f is-equiv-f)
       ( has-inverse-map-inverse-has-inverse A B f
-        ( has-inverse-is-equiv A B f is-equiv-f))  
+        ( has-inverse-is-equiv A B f is-equiv-f))
 ```
 
-The retraction associated with an equivalence is an equivalence. 
+The retraction associated with an equivalence is an equivalence.
 
 ```rzk
 #def is-equiv-retraction-is-equiv
@@ -456,8 +456,8 @@ The retraction associated with an equivalence is an equivalence.
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
   : is-equiv B A ( retraction-is-equiv A B f is-equiv-f)
-  := 
-    is-equiv-rev-homotopy B A 
+  :=
+    is-equiv-rev-homotopy B A
       ( section-is-equiv A B f is-equiv-f)
       ( retraction-is-equiv A B f is-equiv-f)
       ( homotopy-section-retraction-is-equiv A B f is-equiv-f)

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -201,6 +201,7 @@ Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
     pair-eq-eq-pair-split
       ( first s) (second s) (first t) (first e) (second t) (second e)
 
+
 #def extensionality-Σ
   ( s t : Σ (a : A) , B a)
   : Equiv (s = t) (Eq-Σ s t)
@@ -210,6 +211,20 @@ Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
         ( eq-pair s t , pair-eq-eq-pair s t)))
 
 #end paths-in-sigma
+
+#def first-path-Σ-eq-pair
+  ( A : U)
+  ( B : A → U)
+  ( (a,b) (a',b') : Σ (a : A), B a)
+  ( (e0, e1) : Eq-Σ A B (a,b) (a',b'))
+  : first-path-Σ A B (a,b) (a',b') (eq-pair A B (a,b) (a',b') (e0, e1)) = e0
+  :=
+    first-path-Σ
+      ( a = a' )
+      ( \ p → transport A B a a' p b = b' )
+      ( pair-eq A B (a,b) (a',b') (eq-pair A B (a,b) (a',b') (e0,e1)) )
+      ( e0, e1 )
+      ( pair-eq-eq-pair A B (a,b) (a',b') (e0,e1))
 ```
 
 ## Identity types of Sigma types over a product

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -828,8 +828,13 @@ types over a product type.
   := Σ (f : A' → A), Σ (F : (a' : A') → C' a' → C (f a')),
     is-homotopy-cartesian A' C' A C f F
 
+```
 
-#section homotopy-cartesian-pasting
+Homotopy cartesian squares have a calculus of pasting and cancellation.
+We have a horizontal and a vertical version.
+
+```rzk
+#section homotopy-cartesian-horizontal-pasting
 
 #variable A'' : U
 #variable C'' : A'' → U
@@ -842,7 +847,7 @@ types over a product type.
 #variable f : A' → A
 #variable F : (a' : A') → C' a' → C (f a')
 
-#def is-homotopy-cartesian-composition
+#def is-homotopy-cartesian-horizontal-composition
   : is-homotopy-cartesian A'' C'' A' C' f' F' →
     is-homotopy-cartesian A' C' A C f F →
     is-homotopy-cartesian A'' C'' A C
@@ -858,7 +863,7 @@ types over a product type.
       (F' a'') (ihc' a'')
       (F (f' a'')) (ihc (f' a''))
 
-#def is-homotopy-cartesian-cancellation
+#def is-homotopy-cartesian-horizontal-cancellation
   : is-homotopy-cartesian A' C' A C f F
   → is-homotopy-cartesian A'' C'' A C
       (comp A'' A' A f f')
@@ -874,5 +879,36 @@ types over a product type.
       (ihc (f' a''))
       (ihc'' a'')
 
-#end homotopy-cartesian-pasting
+#end homotopy-cartesian-horizontal-pasting
+```
+
+```rzk
+#section homotopy-cartesian-vertical-pasting
+#variable A' : U
+#variable C' : A' → U
+#variable D' : ( a' : A') → C' a' → U
+#variable A : U
+#variable C : A → U
+#variable D : (a : A) → C a → U
+#variable α : A' → A
+#variable γ : (a' : A') → C' a' → C (α a')
+#variable δ : (a' : A') → (c' : C' a') → D' a' c' → D (α a') (γ a' c')
+
+#def is-homotopy-cartesian-vertical-composition
+  ( is-hc-A-C : is-homotopy-cartesian A' C' A C α γ )
+  ( is-hc-C-D : is-homotopy-cartesian
+      ( total-type A' C')
+      ( \ (a', c') → D' a' c')
+      ( total-type A C)
+      ( \ (a, c) → D a c)
+      ( \ (a', c') → (α a', γ a' c'))
+      ( \ (a', c') → δ a' c'))
+  : is-homotopy-cartesian
+      A' (\ a' → total-type (C' a') (D' a'))
+      A (\ a → total-type (C a) (D a))
+      α (\ a' (c', d') → (γ a' c', δ a' c' d'))
+  :=
+    U
+
+#end homotopy-cartesian-vertical-pasting
 ```

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -828,27 +828,25 @@ types over a product type.
 #def is-homotopy-cartesian uses (A)
   : U
   :=
-    (a' : A') → is-equiv (C' a') (C (α a')) (γ a')
+    ( a' : A') → is-equiv (C' a') (C (α a')) (γ a')
 ```
 
+We implement various ways homotopy-cartesian squares interact with horizontal
+equivalences.
 
-We implement various ways homotopy-cartesian squares interact
-with horizontal equivalences.
-
-For example, if the lower map `α : A' → A` is an equivalence
-in a homotopy cartesian square,
-then so is the upper one `Σαγ : Σ C' → Σ C`.
+For example, if the lower map `α : A' → A` is an equivalence in a homotopy
+cartesian square, then so is the upper one `Σαγ : Σ C' → Σ C`.
 
 ```rzk
 #def temp-uBDx-comp
   : (total-type A' C') → (total-type A C)
-  := ( comp
-        ( total-type A' C')
-        ( Σ (a' : A'), C (α a'))
-        ( total-type A C)
-        ( \ (a', c) → (α a', c) )
-        ( total-map A' C' (\ a' → C (α a')) γ)
-     )
+  := comp
+      ( total-type A' C')
+      ( Σ (a' : A'), C (α a'))
+      ( total-type A C)
+      ( \ (a', c) → (α a', c) )
+      ( total-map A' C' (\ a' → C (α a')) γ)
+
 
 #def pull-up-equiv-is-homotopy-cartesian
   ( is-hc-α-γ : is-homotopy-cartesian)
@@ -871,8 +869,7 @@ then so is the upper one `Σαγ : Σ C' → Σ C`.
           ( C' )
           ( \ a' → C (α a') )
           ( γ)
-          ( \ a' → is-hc-α-γ a')
-        )
+          ( \ a' → is-hc-α-γ a'))
         ( \ (a', c) → (α a', c) )
         ( second
           ( total-equiv-pullback-is-equiv
@@ -880,14 +877,11 @@ then so is the upper one `Σαγ : Σ C' → Σ C`.
             ( A )
             ( α )
             ( is-equiv-α )
-            ( C )
-          )
-        )
-      )
+            ( C ))))
 ```
 
-Conversely, if both the upper and the lower maps are equivalences,
-then the square is homotopy-cartesian.
+Conversely, if both the upper and the lower maps are equivalences, then the
+square is homotopy-cartesian.
 
 ```rzk
 #def is-homotopy-cartesian-is-horizontal-equiv
@@ -897,8 +891,7 @@ then the square is homotopy-cartesian.
   )
   : is-homotopy-cartesian
   :=
-    \ a' →
-      total-equiv-family-of-equiv
+    total-equiv-family-of-equiv
         A' C' ( \ x → C (α x) ) γ    -- use x instead of a' to avoid shadowing
         ( is-equiv-right-factor
             ( total-type A' C')
@@ -913,16 +906,12 @@ then the square is homotopy-cartesian.
                 ( temp-uBDx-comp )
                 ( temp-uBDx-Σαγ )
                 ( \ _ → refl)
-                ( is-equiv-Σαγ)
-            )
-        )
-      ( a' )
+                ( is-equiv-Σαγ)))
 ```
 
-In a general homotopy-cartesian square we cannot
-deduce `is-equiv α` from `is-equiv (Σγ)`.
-However, if the square has a vertical section
-then we can always do this (whether the square is homotopy-cartesian or not).
+In a general homotopy-cartesian square we cannot deduce `is-equiv α` from
+`is-equiv (Σγ)`. However, if the square has a vertical section then we can
+always do this (whether the square is homotopy-cartesian or not).
 
 ```rzk
 #def has-section-family-over-map
@@ -936,8 +925,7 @@ then we can always do this (whether the square is homotopy-cartesian or not).
   ( (ĉ', q̂) : fib
                 (total-type A' C') (total-type A C)
                 (\ (a', c') → (α a', γ a' c'))
-                ĉ
-  )
+                ĉ)
   : fib A' A α (first ĉ)
   :=
     (first ĉ', first-path-Σ A C (temp-uBDx-Σαγ ĉ') ĉ q̂)
@@ -958,25 +946,22 @@ then we can always do this (whether the square is homotopy-cartesian or not).
     temp-uBDx-helper-type ((s',s), η) a (a', p)
   :=
     ind-fib A' A α
-      (temp-uBDx-helper-type ((s',s), η))
-      ( \ a' →
-        ( eq-pair A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ) ,
-          eq-pair
-            ( A')
-            ( \ x → α x = α a')
-            ( a' ,
-              first-path-Σ A C
-                ( α a', γ a' (s' a'))
-                ( α a', s (α a'))
-                ( eq-pair A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ))
-            )
-            ( a' , refl)
-            ( refl ,
-              first-path-Σ-eq-pair
-                A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' )
-            )
-        )
-      )
+    ( temp-uBDx-helper-type ((s',s), η))
+    ( \ a' →
+      ( eq-pair A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ) ,
+        eq-pair
+        ( A')
+        ( \ x → α x = α a')
+        ( a' ,
+          first-path-Σ A C
+          ( α a', γ a' (s' a'))
+          ( α a', s (α a'))
+          ( eq-pair A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' )))
+        ( a' , refl)
+        ( refl ,
+          first-path-Σ-eq-pair
+            A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ))))
+
 
 #def induced-retraction-on-fibers-with-section uses (γ)
   ( ((s',s),η) : has-section-family-over-map)
@@ -986,40 +971,32 @@ then we can always do this (whether the square is homotopy-cartesian or not).
       ( fib
         ( total-type A' C') (total-type A C)
         ( \ (a', c') → (α a', γ a' c'))
-        ( a, s a)
-      )
-    )
+        ( a, s a)))
   :=
     ( \ (a', p) → ( (a', s' a'), first (temp-uBDx-helper ((s',s),η) a (a',p))),
       ( induced-map-on-fibers-Σ (a, s a) ,
-        \ (a', p) → second (temp-uBDx-helper ((s',s),η) a (a',p))
-      )
-    )
+        \ (a', p) → second (temp-uBDx-helper ((s',s),η) a (a',p))))
 
 #def push-down-equiv-with-section uses (γ)
   ( ((s',s),η) : has-section-family-over-map)
   ( is-equiv-Σαγ : is-equiv
-      (total-type A' C') (total-type A C) temp-uBDx-Σαγ
-  )
+      (total-type A' C') (total-type A C) temp-uBDx-Σαγ)
   : is-equiv A' A α
   :=
     is-equiv-is-contr-map A' A α
-      ( \ a →
-        is-contr-is-retract-of-is-contr
-          ( fib A' A α a)
-          ( fib (total-type A' C') (total-type A C) (temp-uBDx-Σαγ) (a, s a))
-          ( induced-retraction-on-fibers-with-section ((s',s),η) a)
-          ( is-contr-map-is-equiv
-            ( total-type A' C') (total-type A C)
-            (temp-uBDx-Σαγ)
-            ( is-equiv-Σαγ )
-            (a, s a)
-          )
-      )
+    ( \ a →
+      is-contr-is-retract-of-is-contr
+      ( fib A' A α a)
+      ( fib (total-type A' C') (total-type A C) (temp-uBDx-Σαγ) (a, s a))
+      ( induced-retraction-on-fibers-with-section ((s',s),η) a)
+      ( is-contr-map-is-equiv
+        ( total-type A' C') (total-type A C)
+        (temp-uBDx-Σαγ)
+        ( is-equiv-Σαγ )
+        (a, s a)))
 
 #end homotopy-cartesian
 ```
-
 
 Form this interaction with equivalences we deduce corresponding facts about
 vertical pasting and cancellation of homotopy cartesian squares.
@@ -1045,8 +1022,7 @@ vertical pasting and cancellation of homotopy cartesian squares.
        ( total-type A C)
        ( \ (a, c) → D a c)
        ( \ (a', c') → (α a', γ a' c'))
-       ( \ (a', c') → δ a' c')
-     )
+       ( \ (a', c') → δ a' c'))
 
 #def is-homotopy-cartesian-upper-to-fibers uses (A)
   ( is-hc-γ-δ : is-homotopy-cartesian-upper)
@@ -1058,18 +1034,18 @@ vertical pasting and cancellation of homotopy cartesian squares.
 #def is-homotopy-cartesian-upper-from-fibers uses (A)
   ( is-fiberwise-hc-γ-δ
     : ( a' : A') →
-      is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
-  )
+      is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
   : is-homotopy-cartesian-upper
   :=
     \ (a', c') → is-fiberwise-hc-γ-δ a' c'
 
 #def is-homotopy-cartesian-vertical-pasted
   : U
-  := is-homotopy-cartesian
-       A' (\ a' → total-type (C' a') (D' a'))
-       A (\ a → total-type (C a) (D a))
-       α (\ a' (c', d') → (γ a' c', δ a' c' d'))
+  :=
+    is-homotopy-cartesian
+      A' (\ a' → total-type (C' a') (D' a'))
+      A (\ a → total-type (C a) (D a))
+      α (\ a' (c', d') → (γ a' c', δ a' c' d'))
 
 #def is-homotopy-cartesian-vertical-pasting
   ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ )
@@ -1089,32 +1065,30 @@ vertical pasting and cancellation of homotopy cartesian squares.
   : is-homotopy-cartesian-upper
   :=
     is-homotopy-cartesian-upper-from-fibers
-      ( \ a' →
+    ( \ a' →
         is-homotopy-cartesian-is-horizontal-equiv
-          (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
-          ( is-hc-α-γ a')
-          ( is-hc-α-δ a')
-      )
+        ( C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
+        ( is-hc-α-γ a')
+        ( is-hc-α-δ a'))
 
 #def is-homotopy-cartesian-upper-cancellation-with-section
   ( has-sec-γ-δ : (a' : A') →
       has-section-family-over-map
-        (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
-  )
+        (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
   ( is-hc-α-δ : is-homotopy-cartesian-vertical-pasted)
   : is-homotopy-cartesian A' C' A C α γ
   :=
     \ a' →
       push-down-equiv-with-section
-        (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
-        (has-sec-γ-δ a')
-        (is-hc-α-δ a')
+      ( C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
+      ( has-sec-γ-δ a')
+      ( is-hc-α-δ a')
 
 #end homotopy-cartesian-vertical-calculus
 ```
 
-We also have the horizontal version of pasting and cancellation
-which follows from composition and cancelling laws for equivalences.
+We also have the horizontal version of pasting and cancellation which follows
+from composition and cancelling laws for equivalences.
 
 ```rzk
 #section homotopy-cartesian-horizontal-calculus
@@ -1134,11 +1108,10 @@ which follows from composition and cancelling laws for equivalences.
   ( ihc : is-homotopy-cartesian A' C' A C f F)
   ( ihc' : is-homotopy-cartesian A'' C'' A' C' f' F')
   : is-homotopy-cartesian A'' C'' A C
-      ( comp A'' A' A f f')
-      ( \ a'' →
+    ( comp A'' A' A f f')
+    ( \ a'' →
         comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-         (F (f' a'')) (F' a'')
-      )
+         (F (f' a'')) (F' a''))
   :=
     \ a'' →
     is-equiv-comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
@@ -1151,16 +1124,14 @@ which follows from composition and cancelling laws for equivalences.
               ( comp A'' A' A f f')
               ( \ a'' →
                 comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-                  (F (f' a'')) (F' a'')
-              )
-   )
-   : is-homotopy-cartesian A'' C'' A' C' f' F'
+                  (F (f' a'')) (F' a'')))
+  : is-homotopy-cartesian A'' C'' A' C' f' F'
   :=
     \ a'' →
     is-equiv-right-cancel (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-      (F' a'') (F (f' a''))
-      (ihc (f' a''))
-      (ihc'' a'')
+    ( F' a'') (F (f' a''))
+    ( ihc (f' a''))
+    ( ihc'' a'')
 
 #end homotopy-cartesian-horizontal-calculus
 ```

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -831,10 +831,11 @@ types over a product type.
 ```
 
 Homotopy cartesian squares have a calculus of pasting and cancellation.
-We have a horizontal and a vertical version.
+
+We have the horizontal version of pasting and cancellation.
 
 ```rzk
-#section homotopy-cartesian-horizontal-pasting
+#section homotopy-cartesian-horizontal-calculus
 
 #variable A'' : U
 #variable C'' : A'' → U
@@ -847,7 +848,7 @@ We have a horizontal and a vertical version.
 #variable f : A' → A
 #variable F : (a' : A') → C' a' → C (f a')
 
-#def is-homotopy-cartesian-horizontal-composition
+#def is-homotopy-cartesian-horizontal-pasting
   : is-homotopy-cartesian A'' C'' A' C' f' F' →
     is-homotopy-cartesian A' C' A C f F →
     is-homotopy-cartesian A'' C'' A C
@@ -879,11 +880,13 @@ We have a horizontal and a vertical version.
       (ihc (f' a''))
       (ihc'' a'')
 
-#end homotopy-cartesian-horizontal-pasting
+#end homotopy-cartesian-horizontal-calculus
 ```
 
+And we have the vertical version of pasting and cancellation.
+
 ```rzk
-#section homotopy-cartesian-vertical-pasting
+#section homotopy-cartesian-vertical-calculus
 #variable A' : U
 #variable C' : A' → U
 #variable D' : ( a' : A') → C' a' → U
@@ -894,7 +897,24 @@ We have a horizontal and a vertical version.
 #variable γ : (a' : A') → C' a' → C (α a')
 #variable δ : (a' : A') → (c' : C' a') → D' a' c' → D (α a') (γ a' c')
 
-#def is-homotopy-cartesian-vertical-composition
+#def temp-1y5f-Σγδ uses (A)
+  ( a' : A')
+  : total-type (C' a') (D' a') → total-type (C (α a')) (D (α a'))
+  :=
+    \ (c', d') → (γ a' c', δ a' c' d')
+
+#def temp-1y5f-comp uses (A)
+  (a' : A')
+  : ( total-type (C' a') (D' a')) → ( total-type (C (α a')) (D (α a')))
+  := ( comp
+       ( total-type (C' a') (D' a'))
+       ( Σ (c' : C' a'), D (α a') (γ a' c'))
+       ( total-type (C (α a')) (D (α a')))
+       ( \ (c', d) → (γ a' c', d) )
+       ( total-map (C' a') (D' a') (\ c' → D (α a') (γ a' c')) ( δ a'))
+     )
+
+#def is-homotopy-cartesian-vertical-pasting
   ( is-hc-A-C : is-homotopy-cartesian A' C' A C α γ )
   ( is-hc-C-D : is-homotopy-cartesian
       ( total-type A' C')
@@ -902,13 +922,91 @@ We have a horizontal and a vertical version.
       ( total-type A C)
       ( \ (a, c) → D a c)
       ( \ (a', c') → (α a', γ a' c'))
-      ( \ (a', c') → δ a' c'))
+      ( \ (a', c') → δ a' c')
+  )
   : is-homotopy-cartesian
       A' (\ a' → total-type (C' a') (D' a'))
       A (\ a → total-type (C a) (D a))
       α (\ a' (c', d') → (γ a' c', δ a' c' d'))
   :=
-    U
+    \ a' →
+      ( is-equiv-homotopy
+        ( total-type (C' a') (D' a'))
+        ( total-type (C (α a')) (D (α a')))
+        ( temp-1y5f-Σγδ a')
+        ( temp-1y5f-comp a')
+        ( \ _ → refl)
+        ( is-equiv-comp
+          ( total-type (C' a') (D' a'))
+          ( Σ (c' : C' a'), D (α a') (γ a' c'))
+          ( total-type (C (α a')) (D (α a')))
+          ( total-map ( C' a') ( D' a') ( \ c' → D (α a') (γ a' c')) ( δ a'))
+          ( family-of-equiv-total-equiv
+            ( C' a')
+            ( D' a')
+            ( \ c' → D (α a') (γ a' c'))
+            ( δ a')
+            ( \ c' → is-hc-C-D (a', c'))
+          )
+          ( \ (c', d) → (γ a' c', d) )
+          ( second
+            ( total-equiv-pullback-is-equiv
+              ( C' a')
+              ( C (α a'))
+              ( γ a')
+              ( is-hc-A-C a')
+              ( D (α a'))
+            )
+          )
+        )
+      )
 
-#end homotopy-cartesian-vertical-pasting
+#def is-homotopy-cartesian-vertical-cancellation
+  ( is-hc-A-C : is-homotopy-cartesian A' C' A C α γ )
+  ( is-hc-A-D : is-homotopy-cartesian
+      A'(\ a' → total-type (C' a') (D' a'))
+      A (\ a → total-type (C a) (D a))
+      α (\ a' (c', d') → (γ a' c', δ a' c' d'))
+  )
+  : is-homotopy-cartesian
+      ( total-type A' C')
+      ( \ (a', c') → D' a' c')
+      ( total-type A C)
+      ( \ (a, c) → D a c)
+      ( \ (a', c') → (α a', γ a' c'))
+      ( \ (a', c') → δ a' c')
+  :=
+    \ ( a', c') →
+      total-equiv-family-of-equiv
+        ( C' a')
+        ( D' a')
+        ( \ x → D (α a') (γ a' x))
+        ( δ a')
+        ( is-equiv-right-factor
+            ( total-type (C' a') (D' a'))
+            ( Σ (c' : C' a'), D (α a') (γ a' c'))
+            ( total-type (C (α a')) (D (α a')))
+            ( total-map (C' a') (D' a') (\ c' → D (α a') (γ a' c')) ( δ a'))
+            ( \ (c', d) → (γ a' c', d) )
+            ( second
+              ( total-equiv-pullback-is-equiv
+                ( C' a')
+                ( C (α a'))
+                ( γ a')
+                ( is-hc-A-C a')
+                ( D (α a'))
+              )
+            )
+            ( is-equiv-homotopy
+                ( total-type (C' a') (D' a'))
+                ( total-type (C (α a')) (D (α a')))
+                ( temp-1y5f-comp a')
+                ( temp-1y5f-Σγδ a')
+                ( \ _ → refl)
+                ( is-hc-A-D a')
+            )
+        )
+        ( c')
+
+#end homotopy-cartesian-vertical-calculus
 ```


### PR DESCRIPTION
Establish vertical pasting and cancellation laws for homotopy cartesian squares.

Additionally to the two standard laws (lower cancellation and pasting), I also formalized a statement allowing upper cancellation in the case where the upper square has a section.

I plan to use these laws to formalize the "category theoretic proof" of RS17, Theorem 8.8. This is in parallel with Cesar's #58, who will formalize the "type theoretic proof".

EDIT: I separated out the separate pull-request #61 which is minor and can be merged independently.