### PR TITLE
Formalization of Prop 10.3 of [RS17]

### DIFF
--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -101,11 +101,11 @@ A type is a proposition when its identity types are contractible.
 
 ## Properties of propositions
 
-If some family $B$ is fiberwise a proposition, then the type of dependent
-functions over $B$ is a proposition:
+If some family `#!rzk B : A A → U` is fiberwise a proposition, then the type of
+dependent functions `#!rzk (x : A) → B x` is a proposition.
 
 ```rzk
-#def fiberwise-prop-is-prop uses (funext weakfunext)
+#def is-prop-fiberwise-prop uses (funext weakfunext)
   ( A : U)
   ( B : A → U)
   ( fiberwise-prop-B : (x : A) → is-prop (B x))
@@ -119,15 +119,14 @@ functions over $B$ is a proposition:
       ( weakfunext A (\ x → f x = g x) (\ x → fiberwise-prop-B x (f x) (g x)))
 ```
 
-If two propositions are bijective, then they are equivalent:
+If two propositions are logically equivalent, then they are equivalent:
 
 ```rzk
-#def bijective-props-are-equiv
+#def is-equiv-iff-is-prop-is-prop
   ( A B : U)
   ( is-prop-A : is-prop A)
   ( is-prop-B : is-prop B)
-  ( f : A → B)
-  ( g : B → A)
+  ( (f , g) : iff A B)
   : is-equiv A B f
   :=
     ( ( g ,
@@ -136,4 +135,12 @@ If two propositions are bijective, then they are equivalent:
       ( g ,
         \ b →
           (all-elements-equal-is-prop B is-prop-B) ((comp B A B f g) b) b))
+
+#def equiv-iff-is-prop-is-prop
+  ( A B : U)
+  ( is-prop-A : is-prop A)
+  ( is-prop-B : is-prop B)
+  ( e : iff A B)
+  : Equiv A B
+  := (first e, is-equiv-iff-is-prop-is-prop A B is-prop-A is-prop-B e)
 ```

--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -6,6 +6,14 @@ This is a literate `rzk` file:
 #lang rzk-1
 ```
 
+Some of the definitions in this file rely on function extensionality and weak
+function extensionality:
+
+```rzk
+#assume funext : FunExt
+#assume weakfunext : WeakFunExt
+```
+
 ## Propositions
 
 A type is a proposition when its identity types are contractible.
@@ -89,4 +97,43 @@ A type is a proposition when its identity types are contractible.
   :=
     ( is-prop-is-emb-terminal-map A
       ( terminal-map-is-emb-is-contr-is-inhabited A c))
+```
+
+## Properties of propositions
+
+If some family $B$ is fiberwise a proposition, then the type of dependent
+functions over $B$ is a proposition:
+
+```rzk
+#def fiberwise-prop-is-prop uses (funext weakfunext)
+  ( A : U)
+  ( B : A → U)
+  ( fiberwise-prop-B : (x : A) → is-prop (B x))
+  : is-prop ((x : A) → B x)
+  :=
+    \ f g →
+    is-contr-equiv-is-contr'
+      ( f = g)
+      ( (x : A) → f x = g x)
+      ( equiv-FunExt funext A B f g)
+      ( weakfunext A (\ x → f x = g x) (\ x → fiberwise-prop-B x (f x) (g x)))
+```
+
+If two propositions are bijective, then they are equivalent:
+
+```rzk
+#def bijective-props-are-equiv
+  ( A B : U)
+  ( is-prop-A : is-prop A)
+  ( is-prop-B : is-prop B)
+  ( f : A → B)
+  ( g : B → A)
+  : is-equiv A B f
+  :=
+    ( ( g ,
+        \ a →
+          (all-elements-equal-is-prop A is-prop-A) ((comp A B A g f) a) a) ,
+      ( g ,
+        \ b →
+          (all-elements-equal-is-prop B is-prop-B) ((comp B A B f g) b) b))
 ```

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -568,25 +568,49 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
           ( α)
           ( \ x → (second (second (H x))))))
 
-#def is-equiv-is-iso-pointwise-is-iso uses (funext extext weakfunext)
+#def iff-is-iso-pointwise-is-iso uses (funext)
   ( X : U)
   ( A : X → U)
   ( is-segal-A : (x : X) → is-segal (A x))
   ( f g : (x : X) → A x)
   ( α : nat-trans X A f g)
-  : is-equiv
-      ( is-iso-arrow ((x : X) → A x) (is-segal-function-type funext X A is-segal-A) f g α)
-      ( ( x : X) →
+  : iff
+    ( is-iso-arrow
+      ( (x : X) → A x)
+      ( is-segal-function-type funext X A is-segal-A) f g α)
+    ( ( x : X) →
         ( is-iso-arrow
           ( A x)
           ( is-segal-A x)
           ( f x)
           ( g x)
           ( ev-components-nat-trans X A f g α x)))
-      ( ev-components-nat-trans-preserves-iso X A is-segal-A f g α)
   :=
-    bijective-props-are-equiv
-      ( is-iso-arrow ((x : X) → A x) (is-segal-function-type funext X A is-segal-A) f g α)
+    ( ev-components-nat-trans-preserves-iso X A is-segal-A f g α,
+      nat-trans-nat-trans-components-preserves-iso X A is-segal-A f g α)
+
+#def equiv-is-iso-pointwise-is-iso uses (extext funext weakfunext)
+  ( X : U)
+  ( A : X → U)
+  ( is-segal-A : (x : X) → is-segal (A x))
+  ( f g : (x : X) → A x)
+  ( α : nat-trans X A f g)
+  : Equiv
+    ( is-iso-arrow
+      ( (x : X) → A x)
+      ( is-segal-function-type funext X A is-segal-A) f g α)
+    ( ( x : X) →
+        ( is-iso-arrow
+          ( A x)
+          ( is-segal-A x)
+          ( f x)
+          ( g x)
+          ( ev-components-nat-trans X A f g α x)))
+  :=
+    equiv-iff-is-prop-is-prop
+      ( is-iso-arrow
+        ( (x : X) → A x)
+        ( is-segal-function-type funext X A is-segal-A) f g α)
       ( ( x : X) →
         ( is-iso-arrow
           ( A x)
@@ -600,7 +624,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
         ( f)
         ( g)
         ( α))
-      ( fiberwise-prop-is-prop funext weakfunext
+      ( is-prop-fiberwise-prop funext weakfunext
         ( X)
         ( \ x →
           ( is-iso-arrow
@@ -616,8 +640,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
             ( f x)
             ( g x)
             ( ev-components-nat-trans X A f g α x)))
-      ( ev-components-nat-trans-preserves-iso X A is-segal-A f g α)
-      ( nat-trans-nat-trans-components-preserves-iso X A is-segal-A f g α)
+      ( iff-is-iso-pointwise-is-iso X A is-segal-A f g α)
 ```
 
 ## Rezk types

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -593,7 +593,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
                   ( id-arr-components-id-nat-trans X A g x))))))))
 
 
-#def TODO uses (funext extext weakfunext)
+#def is-equiv-is-iso-pointwise-is-iso uses (funext extext weakfunext)
   ( X : U)
   ( A : X → U)
   ( is-segal-A : (x : X) → is-segal (A x))

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -414,7 +414,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
     \ x →
     ( ( ( ev-components-nat-trans X A g f β x) ,
         ( triple-concat
-          (hom (A x) (f x) (f x))
+          ( hom (A x) (f x) (f x))
           ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
             ( ev-components-nat-trans X A f g α x)
             ( ev-components-nat-trans X A g f β x))
@@ -428,7 +428,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
           ( comp-components-comp-nat-trans-is-segal
             funext X A is-segal-A f g f α β x)
           ( ap
-            ( hom ((x' : X) → (A x')) f f)
+            ( nat-trans X A f f)
             ( hom (A x) (f x) (f x))
             ( comp-is-segal
               ( (x' : X) → (A x'))
@@ -453,7 +453,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
           ( comp-components-comp-nat-trans-is-segal
             funext X A is-segal-A g f g γ α x)
           ( ap
-            ( hom ((x' : X) → (A x')) g g)
+            ( nat-trans X A g g)
             ( hom (A x) (g x) (g x))
             ( comp-is-segal
               ( (x' : X) → (A x'))
@@ -462,6 +462,86 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
             ( \ α' → ev-components-nat-trans X A g g α' x)
             ( q))
           ( id-arr-components-id-nat-trans X A g x))))
+
+#def nat-trans-nat-trans-components-preserves-iso-helper uses (funext)
+  ( X : U)
+  ( A : X → U)
+  ( is-segal-A : (x : X) → is-segal (A x))
+  ( f g : (x : X) → A x)
+  ( α : nat-trans X A f g)
+  ( β : nat-trans X A g f)
+  : ( ( x : X) →
+      ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
+        ( ev-components-nat-trans X A f g α x)
+        ( ev-components-nat-trans X A g f β x)) =
+      (id-hom (A x) (f x))) →
+    ( comp-is-segal
+      ( (x' : X) → A x')
+      ( is-segal-function-type funext X A is-segal-A)
+      f g f α β) =
+    (id-hom ((x' : X) → A x') f)
+  :=
+    \ H →
+    ap
+      ( nat-trans-components X A f f)
+      ( nat-trans X A f f)
+      ( \ x →
+        ev-components-nat-trans X A f f
+          ( comp-is-segal
+            ( (x' : X) → A x')
+            ( is-segal-function-type funext X A is-segal-A)
+            f g f α β)
+          ( x))
+      ( \ x → ev-components-nat-trans X A f f (id-hom ((x' : X) → A x') f) x)
+      ( first
+        ( has-inverse-is-equiv
+          ( hom ((x' : X) → A x') f f)
+          ( (x : X) → hom (A x) (f x) (f x))
+          ( ev-components-nat-trans X A f f)
+          ( is-equiv-ev-components-nat-trans X A f f)))
+      ( eq-htpy funext X
+        ( \ x → (hom (A x) (f x) (f x)))
+        ( \ x →
+          ( ev-components-nat-trans X A f f
+            ( comp-is-segal
+              ( (x' : X) → A x')
+              ( is-segal-function-type funext X A is-segal-A)
+              f g f α β)
+            ( x)))
+        ( \ x → (id-hom (A x) (f x)))
+        ( \ x →
+          ( triple-concat
+            ( hom (A x) (f x) (f x))
+            ( ev-components-nat-trans X A f f
+              ( comp-is-segal
+                ( (x' : X) → A x')
+                ( is-segal-function-type funext X A is-segal-A)
+                f g f α β)
+              ( x))
+            ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
+              ( ev-components-nat-trans X A f g α x)
+              ( ev-components-nat-trans X A g f β x))
+            ( id-hom (A x) (f x))
+            ( ev-components-nat-trans X A f f (id-hom ((x' : X) → A x') f) x)
+            ( rev
+              (hom (A x) (f x) (f x))
+              ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
+                ( ev-components-nat-trans X A f g α x)
+                ( ev-components-nat-trans X A g f β x))
+              ( ev-components-nat-trans X A f f
+                ( comp-is-segal
+                  ( (x' : X) → A x')
+                  ( is-segal-function-type funext X A is-segal-A)
+                  f g f α β)
+                ( x))
+              ( comp-components-comp-nat-trans-is-segal
+                funext X A is-segal-A f g f α β x))
+            ( H x)
+            ( rev
+              ( hom (A x) (f x) (f x))
+              ( ev-components-nat-trans X A f f (id-hom ((x' : X) → A x') f) x)
+              ( id-hom (A x) (f x))
+              ( id-arr-components-id-nat-trans X A f x)))))
 
 #def nat-trans-nat-trans-components-preserves-iso uses (funext)
   ( X : U)
@@ -478,120 +558,15 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   :=
     \ H →
     ( ( \ t x → (first (first (H x))) t ,
-        ( ap
-          ( (x : X) → hom (A x) (f x) (f x))
-          ( hom ((x' : X) → (A x')) f f)
-          ( \ x → ev-components-nat-trans X A f f
-              ( comp-is-segal
-                ( (x' : X) → (A x'))
-                ( is-segal-function-type funext X A is-segal-A) f g f α (\ t x' → (first (first (H x'))) t))
-              ( x))
-          ( \ x → ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
-          ( first
-            ( has-inverse-is-equiv
-              ( hom ((x' : X) → (A x')) f f)
-              ( (x : X) → hom (A x) (f x) (f x))
-              ( ev-components-nat-trans X A f f)
-              ( is-equiv-ev-components-nat-trans X A f f)))
-          ( eq-htpy funext X
-            ( \ x → (hom (A x) (f x) (f x)))
-            ( \ x →
-              ( ev-components-nat-trans X A f f
-                ( comp-is-segal
-                  ( (x' : X) → A x')
-                  ( is-segal-function-type funext X A is-segal-A)
-                  f g f α (\ t x' → (first (first (H x'))) t))
-                ( x)))
-            ( \ x → ( id-hom (A x) (f x)))
-            ( \ x →
-              ( triple-concat
-                ( hom (A x) (f x) (f x))
-                ( ev-components-nat-trans X A f f
-                  ( comp-is-segal
-                    ( (x' : X) → (A x'))
-                    ( is-segal-function-type funext X A is-segal-A) f g f α (\ t x' → (first (first (H x'))) t))
-                  ( x))
-                ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
-                  ( ev-components-nat-trans X A f g α x)
-                  ( ev-components-nat-trans X A g f (\ t x' → (first (first (H x'))) t) x))
-                ( id-hom (A x) (f x))
-                ( ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
-                ( rev
-                  (hom (A x) (f x) (f x))
-                  ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
-                    ( ev-components-nat-trans X A f g α x)
-                    ( ev-components-nat-trans X A g f (\ t x' → (first (first (H x'))) t) x))
-                  ( ev-components-nat-trans X A f f
-                    ( comp-is-segal
-                      ( (x' : X) → (A x'))
-                      ( is-segal-function-type funext X A is-segal-A) f g f α (\ t x' → (first (first (H x'))) t))
-                    ( x))
-                  ( comp-components-comp-nat-trans-is-segal
-                    funext X A is-segal-A f g f α (\ t x' → (first (first (H x'))) t) x))
-                ( second (first (H x)))
-                ( rev
-                  ( hom (A x) (f x) (f x))
-                  ( ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
-                  ( id-hom (A x) (f x))
-                  ( id-arr-components-id-nat-trans X A f x))))))) ,
-        ( \ t x → (first (second (H x))) t ,
-          ( ap
-          ( (x : X) → hom (A x) (g x) (g x))
-          ( hom ((x' : X) → (A x')) g g)
-          ( \ x → ev-components-nat-trans X A g g
-              ( comp-is-segal
-                ( (x' : X) → (A x'))
-                ( is-segal-function-type funext X A is-segal-A) g f g (\ t x' → (first (second (H x'))) t) α)
-              ( x))
-          ( \ x → ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
-          ( first
-            ( has-inverse-is-equiv
-              ( hom ((x' : X) → (A x')) g g)
-              ( (x : X) → hom (A x) (g x) (g x))
-              ( ev-components-nat-trans X A g g)
-              ( is-equiv-ev-components-nat-trans X A g g)))
-          ( eq-htpy funext X
-            ( \ x → (hom (A x) (g x) (g x)))
-            ( \ x →
-              ( ev-components-nat-trans X A g g
-                ( comp-is-segal
-                  ( (x' : X) → A x')
-                  ( is-segal-function-type funext X A is-segal-A)
-                  g f g (\ t x' → (first (second (H x'))) t) α)
-                ( x)))
-            ( \ x → ( id-hom (A x) (g x)))
-            ( \ x →
-              ( triple-concat
-                ( hom (A x) (g x) (g x))
-                ( ev-components-nat-trans X A g g
-                  ( comp-is-segal
-                    ( (x' : X) → (A x'))
-                    ( is-segal-function-type funext X A is-segal-A) g f g (\ t x' → (first (second (H x'))) t) α)
-                  ( x))
-                ( comp-is-segal (A x) (is-segal-A x) (g x) (f x) (g x)
-                  ( ev-components-nat-trans X A g f (\ t x' → (first (second (H x'))) t) x)
-                  ( ev-components-nat-trans X A f g α x))
-                ( id-hom (A x) (g x))
-                ( ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
-                ( rev
-                  (hom (A x) (g x) (g x))
-                  ( comp-is-segal (A x) (is-segal-A x) (g x) (f x) (g x)
-                    ( ev-components-nat-trans X A g f (\ t x' → (first (second (H x'))) t) x)
-                    ( ev-components-nat-trans X A f g α x))
-                  ( ev-components-nat-trans X A g g
-                    ( comp-is-segal
-                      ( (x' : X) → (A x'))
-                      ( is-segal-function-type funext X A is-segal-A) g f g (\ t x' → (first (second (H x'))) t) α)
-                    ( x))
-                  ( comp-components-comp-nat-trans-is-segal
-                    funext X A is-segal-A g f g (\ t x' → (first (second (H x'))) t) α x))
-                ( second (second (H x)))
-                ( rev
-                  ( hom (A x) (g x) (g x))
-                  ( ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
-                  ( id-hom (A x) (g x))
-                  ( id-arr-components-id-nat-trans X A g x))))))))
-
+        nat-trans-nat-trans-components-preserves-iso-helper X A is-segal-A f g
+          ( α)
+          ( \ t x → (first (first (H x))) t)
+          ( \ x → (second (first (H x))))) ,
+      ( \ t x → (first (second (H x))) t ,
+        nat-trans-nat-trans-components-preserves-iso-helper X A is-segal-A g f
+          ( \ t x → (first (second (H x))) t)
+          ( α)
+          ( \ x → (second (second (H x))))))
 
 #def is-equiv-is-iso-pointwise-is-iso uses (funext extext weakfunext)
   ( X : U)

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -6,10 +6,13 @@ This is a literate `rzk` file:
 #lang rzk-1
 ```
 
-Some of the definitions in this file rely on extension extensionality:
+Some of the definitions in this file rely on function extensionality, extension
+extensionality and weak function extensionality:
 
 ```rzk
+#assume funext : FunExt
 #assume extext : ExtExt
+#assume weakfunext : WeakFunExt
 ```
 
 ## Isomorphisms
@@ -389,6 +392,257 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
           ( second (first is-isof))
           ( first (second is-isof))
           ( second (second is-isof)))))
+```
+
+## Isomorphism extensionality
+
+```rzk title="RS17, Proposition 10.3"
+#def ev-components-nat-trans-preserves-iso uses (funext)
+  ( X : U)
+  ( A : X → U)
+  ( is-segal-A : (x : X) → is-segal (A x))
+  ( f g : (x : X) → A x)
+  ( α : nat-trans X A f g)
+  : ( is-iso-arrow
+      ( (x : X) → A x)
+      ( is-segal-function-type funext X A is-segal-A) f g α) →
+    ( x : X) →
+    ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
+      ( ev-components-nat-trans X A f g α x))
+  :=
+    \ ((β , p) , (γ , q)) →
+    \ x →
+    ( ( ( ev-components-nat-trans X A g f β x) ,
+        ( triple-concat
+          (hom (A x) (f x) (f x))
+          ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
+            ( ev-components-nat-trans X A f g α x)
+            ( ev-components-nat-trans X A g f β x))
+          ( ev-components-nat-trans X A f f
+            ( comp-is-segal
+              ( (x' : X) → (A x'))
+              ( is-segal-function-type funext X A is-segal-A) f g f α β)
+            ( x))
+          ( ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
+          ( id-hom (A x) (f x))
+          ( comp-components-comp-nat-trans-is-segal
+            funext X A is-segal-A f g f α β x)
+          ( ap
+            ( hom ((x' : X) → (A x')) f f)
+            ( hom (A x) (f x) (f x))
+            ( comp-is-segal
+              ( (x' : X) → (A x'))
+              ( is-segal-function-type funext X A is-segal-A) f g f α β)
+            ( id-hom ((x' : X) → (A x')) f)
+            (\ α' → ev-components-nat-trans X A f f α' x)
+            ( p))
+          ( id-arr-components-id-nat-trans X A f x))) ,
+      ( ( ev-components-nat-trans X A g f γ x) ,
+        ( triple-concat
+          (hom (A x) (g x) (g x))
+          ( comp-is-segal (A x) (is-segal-A x) (g x) (f x) (g x)
+            ( ev-components-nat-trans X A g f γ x)
+            ( ev-components-nat-trans X A f g α x))
+          ( ev-components-nat-trans X A g g
+            ( comp-is-segal
+              ( (x' : X) → (A x'))
+              ( is-segal-function-type funext X A is-segal-A) g f g γ α)
+            ( x))
+          ( ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
+          ( id-hom (A x) (g x))
+          ( comp-components-comp-nat-trans-is-segal
+            funext X A is-segal-A g f g γ α x)
+          ( ap
+            ( hom ((x' : X) → (A x')) g g)
+            ( hom (A x) (g x) (g x))
+            ( comp-is-segal
+              ( (x' : X) → (A x'))
+              ( is-segal-function-type funext X A is-segal-A) g f g γ α)
+            ( id-hom ((x' : X) → (A x')) g)
+            ( \ α' → ev-components-nat-trans X A g g α' x)
+            ( q))
+          ( id-arr-components-id-nat-trans X A g x))))
+
+#def nat-trans-nat-trans-components-preserves-iso uses (funext)
+  ( X : U)
+  ( A : X → U)
+  ( is-segal-A : (x : X) → is-segal (A x))
+  ( f g : (x : X) → A x)
+  ( α : nat-trans X A f g)
+  : ( ( x : X) →
+      ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
+        ( ev-components-nat-trans X A f g α x))) →
+    ( is-iso-arrow
+      ( (x' : X) → A x')
+      ( is-segal-function-type funext X A is-segal-A) f g α)
+  :=
+    \ H →
+    ( ( \ t x → (first (first (H x))) t ,
+        ( ap
+          ( (x : X) → hom (A x) (f x) (f x))
+          ( hom ((x' : X) → (A x')) f f)
+          ( \ x → ev-components-nat-trans X A f f
+              ( comp-is-segal
+                ( (x' : X) → (A x'))
+                ( is-segal-function-type funext X A is-segal-A) f g f α (\ t x' → (first (first (H x'))) t))
+              ( x))
+          ( \ x → ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
+          ( first
+            ( has-inverse-is-equiv
+              ( hom ((x' : X) → (A x')) f f)
+              ( (x : X) → hom (A x) (f x) (f x))
+              ( ev-components-nat-trans X A f f)
+              ( is-equiv-ev-components-nat-trans X A f f)))
+          ( eq-htpy funext X
+            ( \ x → (hom (A x) (f x) (f x)))
+            ( \ x →
+              ( ev-components-nat-trans X A f f
+                ( comp-is-segal
+                  ( (x' : X) → A x')
+                  ( is-segal-function-type funext X A is-segal-A)
+                  f g f α (\ t x' → (first (first (H x'))) t))
+                ( x)))
+            ( \ x → ( id-hom (A x) (f x)))
+            ( \ x →
+              ( triple-concat
+                ( hom (A x) (f x) (f x))
+                ( ev-components-nat-trans X A f f
+                  ( comp-is-segal
+                    ( (x' : X) → (A x'))
+                    ( is-segal-function-type funext X A is-segal-A) f g f α (\ t x' → (first (first (H x'))) t))
+                  ( x))
+                ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
+                  ( ev-components-nat-trans X A f g α x)
+                  ( ev-components-nat-trans X A g f (\ t x' → (first (first (H x'))) t) x))
+                ( id-hom (A x) (f x))
+                ( ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
+                ( rev
+                  (hom (A x) (f x) (f x))
+                  ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
+                    ( ev-components-nat-trans X A f g α x)
+                    ( ev-components-nat-trans X A g f (\ t x' → (first (first (H x'))) t) x))
+                  ( ev-components-nat-trans X A f f
+                    ( comp-is-segal
+                      ( (x' : X) → (A x'))
+                      ( is-segal-function-type funext X A is-segal-A) f g f α (\ t x' → (first (first (H x'))) t))
+                    ( x))
+                  ( comp-components-comp-nat-trans-is-segal
+                    funext X A is-segal-A f g f α (\ t x' → (first (first (H x'))) t) x))
+                ( second (first (H x)))
+                ( rev
+                  ( hom (A x) (f x) (f x))
+                  ( ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
+                  ( id-hom (A x) (f x))
+                  ( id-arr-components-id-nat-trans X A f x))))))) ,
+        ( \ t x → (first (second (H x))) t ,
+          ( ap
+          ( (x : X) → hom (A x) (g x) (g x))
+          ( hom ((x' : X) → (A x')) g g)
+          ( \ x → ev-components-nat-trans X A g g
+              ( comp-is-segal
+                ( (x' : X) → (A x'))
+                ( is-segal-function-type funext X A is-segal-A) g f g (\ t x' → (first (second (H x'))) t) α)
+              ( x))
+          ( \ x → ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
+          ( first
+            ( has-inverse-is-equiv
+              ( hom ((x' : X) → (A x')) g g)
+              ( (x : X) → hom (A x) (g x) (g x))
+              ( ev-components-nat-trans X A g g)
+              ( is-equiv-ev-components-nat-trans X A g g)))
+          ( eq-htpy funext X
+            ( \ x → (hom (A x) (g x) (g x)))
+            ( \ x →
+              ( ev-components-nat-trans X A g g
+                ( comp-is-segal
+                  ( (x' : X) → A x')
+                  ( is-segal-function-type funext X A is-segal-A)
+                  g f g (\ t x' → (first (second (H x'))) t) α)
+                ( x)))
+            ( \ x → ( id-hom (A x) (g x)))
+            ( \ x →
+              ( triple-concat
+                ( hom (A x) (g x) (g x))
+                ( ev-components-nat-trans X A g g
+                  ( comp-is-segal
+                    ( (x' : X) → (A x'))
+                    ( is-segal-function-type funext X A is-segal-A) g f g (\ t x' → (first (second (H x'))) t) α)
+                  ( x))
+                ( comp-is-segal (A x) (is-segal-A x) (g x) (f x) (g x)
+                  ( ev-components-nat-trans X A g f (\ t x' → (first (second (H x'))) t) x)
+                  ( ev-components-nat-trans X A f g α x))
+                ( id-hom (A x) (g x))
+                ( ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
+                ( rev
+                  (hom (A x) (g x) (g x))
+                  ( comp-is-segal (A x) (is-segal-A x) (g x) (f x) (g x)
+                    ( ev-components-nat-trans X A g f (\ t x' → (first (second (H x'))) t) x)
+                    ( ev-components-nat-trans X A f g α x))
+                  ( ev-components-nat-trans X A g g
+                    ( comp-is-segal
+                      ( (x' : X) → (A x'))
+                      ( is-segal-function-type funext X A is-segal-A) g f g (\ t x' → (first (second (H x'))) t) α)
+                    ( x))
+                  ( comp-components-comp-nat-trans-is-segal
+                    funext X A is-segal-A g f g (\ t x' → (first (second (H x'))) t) α x))
+                ( second (second (H x)))
+                ( rev
+                  ( hom (A x) (g x) (g x))
+                  ( ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
+                  ( id-hom (A x) (g x))
+                  ( id-arr-components-id-nat-trans X A g x))))))))
+
+
+#def TODO uses (funext extext weakfunext)
+  ( X : U)
+  ( A : X → U)
+  ( is-segal-A : (x : X) → is-segal (A x))
+  ( f g : (x : X) → A x)
+  ( α : nat-trans X A f g)
+  : is-equiv
+      ( is-iso-arrow ((x : X) → A x) (is-segal-function-type funext X A is-segal-A) f g α)
+      ( ( x : X) →
+        ( is-iso-arrow
+          ( A x)
+          ( is-segal-A x)
+          ( f x)
+          ( g x)
+          ( ev-components-nat-trans X A f g α x)))
+      ( ev-components-nat-trans-preserves-iso X A is-segal-A f g α)
+  :=
+    bijective-props-are-equiv
+      ( is-iso-arrow ((x : X) → A x) (is-segal-function-type funext X A is-segal-A) f g α)
+      ( ( x : X) →
+        ( is-iso-arrow
+          ( A x)
+          ( is-segal-A x)
+          ( f x)
+          ( g x)
+          ( ev-components-nat-trans X A f g α x)))
+      ( is-prop-is-iso-arrow
+        ( (x : X) → A x)
+        ( is-segal-function-type funext X A is-segal-A)
+        ( f)
+        ( g)
+        ( α))
+      ( fiberwise-prop-is-prop funext weakfunext
+        ( X)
+        ( \ x →
+          ( is-iso-arrow
+            ( A x)
+            ( is-segal-A x)
+            ( f x)
+            ( g x)
+            ( ev-components-nat-trans X A f g α x)))
+        ( \ x →
+          is-prop-is-iso-arrow
+            ( A x)
+            ( is-segal-A x)
+            ( f x)
+            ( g x)
+            ( ev-components-nat-trans X A f g α x)))
+      ( ev-components-nat-trans-preserves-iso X A is-segal-A f g α)
+      ( nat-trans-nat-trans-components-preserves-iso X A is-segal-A f g α)
 ```
 
 ## Rezk types


### PR DESCRIPTION
Closes #22 . Depends on some helper definitions in #55 , so it should not be merged before that one. 

The PR also contains some basic results about propositions that I couldn't find in the library. Proof of 10.3 is split into three definitions: the map from natural isos to pointwise natural isos, the inverse map, and the proof of the equivalence. I am not sure of the names, please feel free to suggest better ones!