### PR TITLE
Functorial shape retract

### DIFF
--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -139,7 +139,7 @@ Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
               t1 <= t3 |-> f ((t1 , t1) , t2)))
 
 #def Δ³-is-retract-Δ²×Δ¹
-  (A : U)
+  ( A : U)
   : is-retract-of (Δ³ → A) (Δ²×Δ¹ → A)
   :=
     ( Δ³-is-retract-Δ²×Δ¹-section A ,
@@ -147,7 +147,10 @@ Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
 ```
 
 For a subshape `ϕ ⊂ ψ` we have an easy way of stating that it is a retract in a
-strict and functorial way.
+strict and functorial way. Intuitively this happens when there is a map from `ψ`
+to `ϕ` that fixes the subshape `ψ`. But in the definition below we actually ask
+for a section of the family of extensions of a function `ϕ → A` to a function
+`ψ → A` and we ask for this section to be natural in the type `A`.
 
 ```rzk
 #def is-functorial-shape-retract
@@ -156,12 +159,12 @@ strict and functorial way.
   ( ϕ : ψ → TOPE )
   : U
   :=
-    (A' : U) → (A : U) → (α : A' → A) →
+    ( A' : U) → (A : U) → (α : A' → A) →
     has-section-family-over-map
-      (ϕ → A') (\ f → (t : ψ) → A' [ϕ t ↦ f t])
-      (ϕ → A) (\ f → (t : ψ) → A [ϕ t ↦ f t])
-      (\ f t → α (f t))
-      (\ _ g t → α (g t))
+      ( ϕ → A') (\ f → (t : ψ) → A' [ϕ t ↦ f t])
+      ( ϕ → A) (\ f → (t : ψ) → A [ϕ t ↦ f t])
+      ( \ f t → α (f t))
+      ( \ _ g t → α (g t))
 ```
 
 For example, this applies to `Δ² ⊂ Δ¹×Δ¹`.
@@ -172,8 +175,7 @@ For example, this applies to `Δ² ⊂ Δ¹×Δ¹`.
   :=
     \ A' A α →
       ( ( first (Δ²-is-retract-Δ¹×Δ¹ A'), first (Δ²-is-retract-Δ¹×Δ¹ A) ) ,
-        \ a' → refl
-      )
+          \ a' → refl)
 ```
 
 ### Pushout product

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -128,6 +128,36 @@ Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
       ( Δ³-is-retract-Δ²×Δ¹-retraction A , \ _ → refl))
 ```
 
+For a subshape `ϕ ⊂ ψ` we have an easy way of stating
+that it is a retract in a strict and functorial way.
+
+```rzk
+#def is-functorial-shape-retract
+  ( I : CUBE )
+  ( ψ : I → TOPE )
+  ( ϕ : ψ → TOPE )
+  : U
+  :=
+    (A' : U) → (A : U) → (α : A' → A) →
+    has-section-family-over-map
+      (ϕ → A') (\ f → (t : ψ) → A' [ϕ t ↦ f t])
+      (ϕ → A) (\ f → (t : ψ) → A [ϕ t ↦ f t])
+      (\ f t → α (f t))
+      (\ _ g t → α (g t))
+```
+
+For example, this applies to `Δ² ⊂ Δ¹×Δ¹`.
+
+```rzk
+#def Δ²-is-functorial-retract-Δ¹×Δ¹
+  : is-functorial-shape-retract (2 × 2) (Δ¹×Δ¹) (Δ²)
+  :=
+    \ A' A α →
+      ( ( first (Δ²-is-retract-Δ¹×Δ¹ A'), first (Δ²-is-retract-Δ¹×Δ¹ A) ) ,
+        \ a' → refl
+      )
+```
+
 ### Intersections
 
 The intersection of shapes is defined by conjunction on topes.
@@ -237,4 +267,3 @@ The union of shapes is defined by disjunction on topes.
     }
   </style>
 </svg>
-

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -358,7 +358,6 @@ the "Gray interchanger" built from two commutative triangles.
     ( uniqueness-comp-is-segal A is-segal-A α00 α10 α11 α*0 α1* α-diag
       ( upper-triangle-square))
 
-
 #end comp-eq-square-is-segal
 
 #def naturality-nat-trans-is-segal


### PR DESCRIPTION
Introduce a convenient way to state that a shape inclusion `\phi \subset \psi` is a retract functorially,
for example `\Delta^2 \subset \Delta^1\times\Delta^1`.

Relies on #59.