### PR TITLE
Naive extext

### DIFF
--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -265,6 +265,30 @@ We refer to another form as an "extension extensionality" axiom.
   := (ext-htpy-eq I ψ ϕ A a f g , extext I ψ ϕ A a f g)
 ```
 
+Sometimes, an even weaker form of extension extensionality suffices.
+
+```rzk title="Very weak extension extensionality"
+#def NaiveExtExt
+  : U
+  :=
+    ( I : CUBE) →
+    ( ψ : I → TOPE) →
+    ( ϕ : ψ → TOPE) →
+    ( A : ψ → U) →
+    ( a : (t : ϕ) → A t) →
+    ( f : (t : ψ) → A t [ϕ t ↦ a t]) →
+    ( g : (t : ψ) → A t [ϕ t ↦ a t]) →
+    ( (t : ψ) → (f t = g t) [ϕ t ↦ refl]) →
+    ( f = g)
+
+#def naiveweakext-extext
+  ( extext : ExtExt)
+  : NaiveExtExt
+  :=
+    \ I ψ ϕ A a f g →
+      ( first (first (extext I ψ ϕ A a f g)))
+```
+
 Weak extension extensionality implies extension extensionality; this is the
 context of RS17 Proposition 4.8 (i). We prove this in a series of lemmas. The
 `ext-projection-temp` function is a (hopefully temporary) helper that explicitly

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -281,7 +281,7 @@ Sometimes, an even weaker form of extension extensionality suffices.
     ( (t : ψ) → (f t = g t) [ϕ t ↦ refl]) →
     ( f = g)
 
-#def naiveweakext-extext
+#def naiveextext-extext
   ( extext : ExtExt)
   : NaiveExtExt
   :=


### PR DESCRIPTION
For some applications an even weaker version of extension extensionality suffices, which just that pointwise equality of extensions can always be glued to an equality. (Without asserting that this reconstruction be an equivalence).

I have added a type for this, called `NaiveExtExt`.