### PR TITLE
Extension types up to homotopy

### DIFF
--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -15,6 +15,69 @@ This is a literate `rzk` file:
 - the file `hott/4-equivalences.rzk` relies in turn on the previous files in
   `hott/`
 
+## Extension up to homotopy
+
+For a shape inclusion `ϕ ⊂ ψ` and any type `A`,
+we have the inbuild extension types `(t : ψ) → A [ϕ t ↦ σ t]`
+(for every `σ : ϕ → A`).
+
+We show that these extensions types are equivalent to the fibers
+of the canonical restriction map `(ψ → A) → (ϕ → A)`,
+which we can view as the types  of "extension up to homotopy".
+
+```rzk
+#section extensions-up-to-homotopy
+#variable I : CUBE
+#variable ψ : I → TOPE
+#variable ϕ : ψ → TOPE
+#variable A : U
+
+#def extension-type
+  ( σ : ϕ → A)
+  : U
+  :=
+    ( t : ψ) → A [ϕ t ↦ σ t]
+
+#def homotopy-extension-type
+  ( σ : ϕ → A)
+  : U
+  := fib (ψ → A) (ϕ → A) (\ τ t → τ t) (σ)
+
+#def extension-type-weakening
+  ( σ : ϕ → A)
+  : extension-type σ → homotopy-extension-type σ
+  :=
+    \ τ → ( τ, refl)
+
+#def extension-type-weakening-section
+  : ( σ : ϕ → A) →
+    ( th : homotopy-extension-type σ) →
+    Σ (τ : extension-type σ), (( τ, refl) =_{homotopy-extension-type σ} th)
+  :=
+    ind-fib (ψ → A) (ϕ → A) (\ τ t → τ t)
+      ( \ σ th →
+          Σ (τ : extension-type σ),
+            ( τ, refl) =_{homotopy-extension-type σ} th)
+      ( \ (τ : ψ → A) → (τ, refl))
+
+#def is-equiv-extension-type-weakening
+  ( σ : ϕ → A)
+  : is-equiv (extension-type σ) (homotopy-extension-type σ)
+      (extension-type-weakening σ)
+  :=
+    ( ( \ th → first (extension-type-weakening-section σ th),
+        \ _ → refl),
+      ( \ th → ( first (extension-type-weakening-section σ th)),
+        \ th → ( second (extension-type-weakening-section σ th))))
+
+#def extension-type-weakening-equivalence
+  ( σ : ϕ → A)
+  : Equiv (extension-type σ) (homotopy-extension-type σ)
+  := ( extension-type-weakening σ , is-equiv-extension-type-weakening σ)
+
+#end extensions-up-to-homotopy
+```
+
 ## Commutation of arguments and currying
 
 ```rzk title="RS17, Theorem 4.1"

--- a/src/simplicial-hott/04a-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04a-right-orthogonal.rzk.md
@@ -339,3 +339,54 @@ can be pulled back along any right orthogonal map.
         ( \ τ' t → α (τ' t) , is-orth-ψ-ϕ-α σ')
         ( has-ue-A (\ t → α (σ' t)))
 ```
+
+Alternatively, we can ask that the canonical restriction map `(ψ → A) → (ϕ → A)`
+is an equivalence.
+
+```rzk
+#section is-local-type
+#variable I : CUBE
+#variable ψ : I → TOPE
+#variable ϕ : ψ → TOPE
+#variable A : U
+
+#def is-local-type
+  : U
+  :=
+    is-equiv (ψ → A) (ϕ → A) ( \ τ t → τ t)
+```
+
+This follows straightforwardly from the fact that for every `σ : ϕ → A`
+we have an equivalence between the extension type `(t : ψ) → A [ϕ t ↦ σ t]`
+and the fiber of the restriction map `(ψ → A) → (ϕ → A)`.
+
+
+```rzk
+#def is-local-type-has-unique-extensions
+  ( has-ue-ψ-ϕ-A : has-unique-extensions I ψ ϕ A)
+  : is-local-type
+  :=
+    is-equiv-is-contr-map (ψ → A) (ϕ → A) ( \ τ t → τ t)
+      ( \ ( σ : ϕ → A) →
+          is-contr-equiv-is-contr
+            ( extension-type I ψ ϕ A σ)
+            ( homotopy-extension-type I ψ ϕ A σ)
+            ( extension-type-weakening-equivalence I ψ ϕ A σ)
+            ( has-ue-ψ-ϕ-A σ))
+
+#def has-unique-extensions-is-local-type
+  ( is-lt-ψ-ϕ-A : is-local-type)
+  : has-unique-extensions I ψ ϕ A
+  :=
+    \ σ →
+      is-contr-equiv-is-contr'
+        ( extension-type I ψ ϕ A σ)
+        ( homotopy-extension-type I ψ ϕ A σ)
+        ( extension-type-weakening-equivalence I ψ ϕ A σ)
+        ( is-contr-map-is-equiv
+            ( ψ → A) (ϕ → A) ( \ τ t → τ t)
+            ( is-lt-ψ-ϕ-A)
+            ( σ))
+
+#end is-local-type
+```

--- a/src/simplicial-hott/04a-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04a-right-orthogonal.rzk.md
@@ -302,3 +302,40 @@ then so is `ψ ⊂ ϕ ∪ ψ`.
          ( cofibration-union-functorial I ϕ ψ (\ _ → A') (\ _ → A) (\ _ → α) τ')
          ( is-orth-ϕ-ψ∧ϕ ( \ t → τ' t))
 ```
+
+## Types with unique extension
+
+We say that an type `A` has unique extensions for a shape inclusion `ϕ ⊂ ψ`,
+if for each `σ : ϕ → A` the type of `ψ`-extensions is contractible.
+
+```rzk
+#def has-unique-extensions
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : U)
+  : U
+  :=
+    ( σ : ϕ → A) → is-contr ( (t : ψ) → A [ϕ t ↦ σ t])
+```
+
+The property of having unique extension
+can be pulled back along any right orthogonal map.
+
+```rzk
+#def has-unique-extensions-right-orthogonal-has-unique-extensions
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A' A : U)
+  ( α : A' → A)
+  ( is-orth-ψ-ϕ-α : is-right-orthogonal-to-shape I ψ ϕ A' A α)
+  : has-unique-extensions I ψ ϕ A → has-unique-extensions I ψ ϕ A'
+  :=
+    \ has-ue-A ( σ' : ϕ → A') →
+      is-contr-equiv-is-contr'
+        ( ( t : ψ) → A' [ϕ t ↦ σ' t])
+        ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
+        ( \ τ' t → α (τ' t) , is-orth-ψ-ϕ-α σ')
+        ( has-ue-A (\ t → α (σ' t)))
+```


### PR DESCRIPTION
In a conversation with @emilyriehl, we discussed the comparison between the (inbuilt, strict) extension types along `\phi \subset \psi` and the weak extension types, i.e. the fibers of the restriction map `(\psi -> A) -> (\phi -> A)`.

1) Via fiber induction, implement an easy proof that these are equivalent.

2) Deduce that a type having unique extensions along `\phi -> \psi` is equivalent to being local for the inclusion `\phi –> \psi`.