### PR TITLE
Add autoformatting to CI (for Markdown, YAML, JSON)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,10 +26,11 @@ jobs:
 
       - name: Check formatting
         run: |
+          set -x
           FILES=$(prettier --config .prettierrc.json --list-different "**/*.{md,json,yaml,yml}")
           if [ "$FILES" ]; then
             echo "The following files are not formatted correctly:"
             echo "$FILES"
             echo "Please install Prettier locally and format these files."
-            exit 1
+            exit 2
           fi

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,17 +1,9 @@
-name: Code formatting check
+name: Code autoformatting
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '**.md'
-      - '**.json'
-      - '**.yaml'
-      - '**.yml'
 
 jobs:
   format:
@@ -19,10 +11,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          # Make sure the actual branch is checked out when running on pull requests
+          ref: ${{ github.head_ref }}
+          # This is important to fetch the changes to the previous commit
+          fetch-depth: 0
 
       - name: Run Prettier
         uses: creyD/prettier_action@v4.3
         with:
-          dry: true
-          prettier_options: --check **/*.{md,json,yaml,yml}
+          prettier_options: --write **/*.{md,json,yaml,yml}
+          # Update the current commit instead of creating a new one. Only works if checkout fetch depth is set to `0`
+          same_commit: true
+          # Prettify changed files. Only works if checkout fetch depth is set to `0`
+          only_changed: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Code Formatting Check
+name: Code formatting check
 
 on:
   pull_request:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,11 +26,10 @@ jobs:
 
       - name: Check formatting
         run: |
-          set -x
           FILES=$(prettier --config .prettierrc.json --list-different "**/*.{md,json,yaml,yml}")
           if [ "$FILES" ]; then
-            echo "The following files are not formatted correctly:"
-            echo "$FILES"
-            echo "Please install Prettier locally and format these files."
+            echo "The following files are not formatted correctly:" >&2
+            echo "$FILES" >&2
+            echo "Please install Prettier locally and format these files." >&2
             exit 2
           fi

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,9 @@
 name: Code formatting check
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -18,18 +21,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-
-      - name: Install Prettier
-        run: npm install --global prettier
-
-      - name: Check formatting
-        run: |
-          FILES=$(prettier --config .prettierrc.json --list-different "**/*.{md,json,yaml,yml}")
-          if [ "$FILES" ]; then
-            echo "The following files are not formatted correctly:" >&2
-            echo "$FILES" >&2
-            echo "Please install Prettier locally and format these files." >&2
-            exit 2
-          fi
+      - name: Run Prettier
+        uses: creyD/prettier_action@v4.3
+        with:
+          dry: true
+          prettier_options: --check **/*.{md,json,yaml,yml}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,35 @@
+name: Code Formatting Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.md'
+      - '**.json'
+      - '**.yaml'
+      - '**.yml'
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+
+      - name: Install Prettier
+        run: npm install --global prettier
+
+      - name: Check formatting
+        run: |
+          FILES=$(prettier --config .prettierrc.json --list-different "**/*.{md,json,yaml,yml}")
+          if [ "$FILES" ]; then
+            echo "The following files are not formatted correctly:"
+            echo "$FILES"
+            echo "Please install Prettier locally and format these files."
+            exit 1
+          fi

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -26,4 +26,3 @@ jobs:
         with:
           rzk-version: latest
           # rzk-version: v0.4.1.1   # example of a specific version
-          files: ''

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -1,4 +1,4 @@
-name: Check with latest Rzk
+name: Typecheck with latest Rzk
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -4,8 +4,15 @@ name: Typecheck with latest Rzk
 on:
   # Triggers the workflow on push events
   push:
+    branches:
+      - main
   # and pull request events
   pull_request:
+    branches:
+      - main
+    paths:
+      - '**.rzk.md'
+      - '**.rzk'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -17,9 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Check all files
+      - name: Typecheck Rzk files
         uses: rzk-lang/rzk-action@v1
         with:
           rzk-version: latest
           # rzk-version: v0.4.1.1   # example of a specific version
-          files: src/hott/* src/simplicial-hott/*

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Typecheck Rzk files
-        uses: rzk-lang/rzk-action@v1
+        uses: rzk-lang/rzk-action@v1.1
         with:
           rzk-version: latest
           # rzk-version: v0.4.1.1   # example of a specific version

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    name: Check formalisations
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Typecheck Rzk files
-        uses: rzk-lang/rzk-action@v1.1
+        uses: rzk-lang/rzk-action@v1.1.0
         with:
           rzk-version: latest
           # rzk-version: v0.4.1.1   # example of a specific version

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -17,7 +17,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    name: Check formalisations
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**.rzk.md'
-      - '**.rzk'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           rzk-version: latest
           # rzk-version: v0.4.1.1   # example of a specific version
+          files: ''

--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Typecheck Rzk files
-        uses: rzk-lang/rzk-action@v1.1.0
+        uses: rzk-lang/rzk-action@v1
         with:
           rzk-version: latest
           # rzk-version: v0.4.1.1   # example of a specific version

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,4 @@
 {
-  "editorconfig": true,
-
   "arrowParens": "always",
   "bracketSameLine": false,
   "bracketSpacing": true,

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,6 @@
 {
+  "editorconfig": true,
+
   "arrowParens": "always",
   "bracketSameLine": false,
   "bracketSpacing": true,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simplicial HoTT and synthetic ∞-categories
 
-[![Check with latest Rzk](https://github.com/rzk-lang/sHoTT/actions/workflows/rzk.yml/badge.svg)](https://github.com/rzk-lang/sHoTT/actions/workflows/rzk.yml)
+[![Typecheck with latest Rzk](https://github.com/rzk-lang/sHoTT/actions/workflows/rzk.yml/badge.svg)](https://github.com/rzk-lang/sHoTT/actions/workflows/rzk.yml)
 [![MkDocs to GitHub Pages](https://github.com/rzk-lang/sHoTT/actions/workflows/mkdocs.yml/badge.svg)](https://github.com/rzk-lang/sHoTT/actions/workflows/mkdocs.yml)
 
 > :information_source: This project originated as a fork of


### PR DESCRIPTION
If I didn't mess this up, it will autoformat markdown (and json and yaml) files according to our settings in `.prettierrc.json` on commits to the main branch, i.e. when merging pull requests.