### PR TITLE
Preservation of fibers under equivalences

### DIFF
--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -267,3 +267,28 @@ the fibers.
       ( \ a → is-contr-based-paths B (f a)))
     ( fubini-Σ A B (\ a b → f a = b))
 ```
+
+## Equivalence between fibers in equivalent domains
+
+As an application of the main theorem, we show that precomposing with an
+equivalence preserves fibers up to equivalence.
+
+```rzk
+#def equiv-fibers-equiv-domains
+  ( A B C : U)
+  ( f : A → B)
+  ( g : B → C)
+  ( is-equiv-f : is-equiv A B f)
+  ( c : C)
+  : Equiv (fib A C (comp A B C g f) c) (fib B C g c)
+  :=
+  equiv-comp
+  ( fib A C ( comp A B C g f) c)
+  ( Σ ((b, _) : fib B C g c), fib A B f b)
+  ( fib B C g c)
+  ( equiv-fiber-sum-fiber-comp A B C f g c)
+  ( ( projection-total-type (fib B C g c) (\ (b, _) → fib A B f b))
+    , second
+      ( projection-theorem (fib B C g c) (\ (b, _) → fib A B f b))
+      ( \ (b, _) → (is-contr-map-is-equiv A B f is-equiv-f) b))
+```


### PR DESCRIPTION
Here is a formalization of a fact @emilyriehl suggested on Zulip.

If a more explicit comparison map between the fibers is desirable, I could try to prove the "functoriality" of the fiber w.r.t. maps between domains and derive this fact from that.