### PR TITLE
Prove that NaiveExtExt implies WeakExtExt

### DIFF
--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -63,6 +63,13 @@ A type is a proposition when its identity types are contractible.
   : is-contr-is-inhabited A
   := \ a → (a , all-elements-equal-A a)
 
+#def is-contr-is-inhabited-is-prop
+  ( A : U)
+  ( is-prop-A : is-prop A)
+  : is-contr-is-inhabited A
+  :=
+    \ a → (a, \ b → first (is-prop-A a b))
+
 #def terminal-map-is-emb-is-inhabited-is-contr-is-inhabited
   ( A : U)
   ( c : is-contr-is-inhabited A)
@@ -216,6 +223,12 @@ In particular, propositions are closed under equivalences:
   ( (f, (rec-f, _)) : Equiv A B)
   : is-prop B → is-prop A
   := is-prop-is-retract-of-is-prop A B (f, rec-f)
+
+#def is-prop-Equiv-is-prop'
+  ( A B : U)
+  ( A≃B : Equiv A B)
+  : is-prop A → is-prop B
+  := is-prop-Equiv-is-prop B A (inv-equiv A B A≃B)
 ```
 
 ### Product types

--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -97,6 +97,14 @@ A type is a proposition when its identity types are contractible.
   :=
     ( is-prop-is-emb-terminal-map A
       ( terminal-map-is-emb-is-contr-is-inhabited A c))
+
+#def is-prop-all-elements-equal
+  ( A : U)
+  ( all-elements-equal-A : all-elements-equal A)
+  : is-prop A
+  :=
+    is-prop-is-contr-is-inhabited A
+    (  is-contr-is-inhabited-all-elements-equal A all-elements-equal-A)
 ```
 
 ## Properties of propositions
@@ -143,4 +151,107 @@ If two propositions are logically equivalent, then they are equivalent:
   ( e : iff A B)
   : Equiv A B
   := (first e, is-equiv-iff-is-prop-is-prop A B is-prop-A is-prop-B e)
+```
+
+Every contractible type is a proposition:
+
+```rzk
+#def is-prop-is-contr
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  : is-prop A
+  :=
+    is-prop-is-contr-is-inhabited A ( \ _ → is-contr-A)
+```
+
+All parallel paths in a proposition are equal.
+
+```rzk
+#def all-paths-equal-is-prop
+  ( A : U)
+  ( is-prop-A : is-prop A)
+  ( a b : A)
+  : ( p : a = b) → (q : a = b) → p = q
+  :=
+    all-elements-equal-is-prop (a = b)
+    ( is-prop-is-contr (a = b)
+      ( is-prop-A a b))
+```
+
+## Proposition induction
+
+```rzk
+#def ind-prop
+  ( A : U)
+  ( is-prop-A : is-prop A)
+  ( B : A → U)
+  ( a : A)
+  ( b : B a)
+  ( x : A)
+  : B x
+  :=
+    transport A B a x (first (is-prop-A a x)) b
+```
+
+It is convenient to able to apply this to contractible types
+without explicitly invoking `is-prop-is-contr`.
+
+```rzk
+#def ind-prop-is-contr
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  : ( B : A → U) → ( a : A) → ( b : B a) → ( x : A) →  B x
+  := ind-prop A (is-prop-is-contr A is-contr-A)
+```
+
+## Families of propositions over a propositions
+
+We consider a type family `C : A → U` over a proposition `A`.
+
+```rzk
+#section families-over-propositions
+#variable A : U
+#variable is-prop-A : is-prop A
+#variable C : A → U
+```
+
+If each `C a` is a proposition, then so is the total type `total-type A C`.
+
+```rzk
+#def is-prop-total-type-is-fiberwise-prop-is-prop-base uses (is-prop-A)
+  ( is-fiberwise-prop-C : (a : A) → is-prop (C a))
+  : is-prop (total-type A C)
+  :=
+    is-prop-all-elements-equal (total-type A C)
+    ( \ (a, c) (a', c') →
+      eq-pair A C (a, c) (a', c')
+      ( first ( is-prop-A a a')
+      , first
+        ( is-fiberwise-prop-C a'
+          ( transport A C a a' (first (is-prop-A a a')) c)
+          ( c'))))
+```
+
+Conversely, if the total type `total-type A C` is a proposition,
+then so is every fiber `C a`.
+
+```rzk
+#def is-fiberwise-prop-is-prop-total-type-is-prop-base uses (is-prop-A)
+  ( is-prop-ΣC : is-prop (total-type A C))
+  ( a : A)
+  : is-prop (C a)
+  :=
+    is-prop-all-elements-equal (C a)
+    ( \ c c' →
+      transport
+      ( a = a)
+      ( \ p → transport A C a a p c = c')
+      ( first-path-Σ A C (a, c) (a, c') ( first (is-prop-ΣC (a, c) (a, c'))))
+      ( refl)
+      ( all-paths-equal-is-prop A is-prop-A a a
+        ( first-path-Σ A C (a, c) (a, c') ( first (is-prop-ΣC (a, c) (a, c'))))
+        ( refl))
+      ( second-path-Σ A C (a, c) (a, c') ( first (is-prop-ΣC (a, c) (a, c')))))
+
+#end families-over-propositions
 ```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -414,6 +414,8 @@ We refer to another form as an "extension extensionality" axiom.
   := (ext-htpy-eq I ψ ϕ A a f g , extext I ψ ϕ A a f g)
 ```
 
+### Naive extension extensionality
+
 For readability of code, it is useful to the function that supplies an equality
 between terms of an extension type from a pointwise equality extending refl. In
 fact, sometimes only this weaker form of the axiom is needed.
@@ -439,6 +441,43 @@ fact, sometimes only this weaker form of the axiom is needed.
     \ I ψ ϕ A a f g →
       ( first (first (extext I ψ ϕ A a f g)))
 ```
+
+Naive extension extensionality implies weak extension extensionality.
+
+```rzk
+#assume hole : (A : U) → A
+
+#assume naiveextext : NaiveExtExt
+#def is-prop-shape-type-is-locally-prop uses (naiveextext)
+  ( I : CUBE)
+  ( ϕ : I → TOPE)
+  ( A : ϕ → U)
+  ( is-locally-prop-A : (t : ϕ) → is-prop (A t))
+  : is-prop ((t : ϕ) → A t)
+  :=
+    is-prop-all-elements-equal ((t : ϕ) → A t)
+    ( \ a a' →
+      naiveextext I (\ t → ϕ t) (\ _ → ⊥) (\ t → A t) (\ _ → recBOT) a a'
+      ( \ t → first ( is-locally-prop-A t (a t) (a' t))))
+
+#def is-prop-extension-type-is-locally-prop uses (naiveextext)
+  ( naiveextext : NaiveExtExt)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : ψ → U)
+  ( is-locally-prop-A : (t : ψ) → is-prop (A t))
+  : ( a : (t : ϕ) → A t) → is-prop ((t : ψ) → A t [ϕ t ↦ a t])
+  :=
+    is-fiberwise-prop-is-prop-total-type-is-prop-base
+    ( ( t : ϕ) → A t)
+    ( is-prop-shape-type-is-locally-prop I (\ t → ϕ t) (\ t → A t)
+      ( \ t → is-locally-prop-A t))
+    ( \ a → (t : ψ) → A t [ϕ t ↦ a t])
+    ( hole (is-prop (Σ (a : (t : ϕ) → A t), (t : ψ) → A t [ϕ t ↦ a t])))
+```
+
+### Weak extension extensionality implies extension extensionality
 
 Weak extension extensionality implies extension extensionality; this is the
 context of RS17 Proposition 4.8 (i). We prove this in a series of lemmas. The
@@ -670,7 +709,6 @@ arguments below.
   ( f : (t : ψ) → A t [ϕ t ↦ a t])
   : (t : ψ ) → A t
   := f
-
 ```
 
 The homotopy extension property has the following signature. We state this

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -30,48 +30,54 @@ which we can view as the types  of "extension up to homotopy".
 #variable I : CUBE
 #variable ψ : I → TOPE
 #variable ϕ : ψ → TOPE
-#variable A : U
+#variable A : (t : ψ) → U
 
 #def extension-type
-  ( σ : ϕ → A)
+  ( σ : (t : ϕ) → A t)
   : U
   :=
-    ( t : ψ) → A [ϕ t ↦ σ t]
+    ( t : ψ) → A t [ϕ t ↦ σ t]
 
 #def homotopy-extension-type
-  ( σ : ϕ → A)
+  ( σ : (t : ϕ) → A t)
   : U
-  := fib (ψ → A) (ϕ → A) (\ τ t → τ t) (σ)
+  := fib ((t : ψ) → A t) ((t : ϕ) → A t) (\ τ t → τ t) (σ)
 
 #def extension-type-weakening-map
-  ( σ : ϕ → A)
+  ( σ : (t : ϕ) → A t)
   : extension-type σ → homotopy-extension-type σ
   :=
     \ τ → ( τ, refl)
 
 #def extension-type-weakening-section
-  : ( σ : ϕ → A) →
-    ( th : homotopy-extension-type σ) →
-    Σ (τ : extension-type σ), (( τ, refl) =_{homotopy-extension-type σ} th)
+  : ( σ : (t : ϕ) → A t)
+  → ( th : homotopy-extension-type σ)
+  → Σ (τ : extension-type σ), (( τ, refl) =_{homotopy-extension-type σ} th)
   :=
-    ind-fib (ψ → A) (ϕ → A) (\ τ t → τ t)
+    ind-fib ((t : ψ) → A t) ((t : ϕ) → A t) (\ τ t → τ t)
       ( \ σ th →
           Σ (τ : extension-type σ),
             ( τ, refl) =_{homotopy-extension-type σ} th)
-      ( \ (τ : ψ → A) → (τ, refl))
+      ( \ (τ : (t : ψ) → A t) → (τ, refl))
+
+#def extension-strictification
+  ( σ : (t : ϕ) → A t)
+  : (homotopy-extension-type σ) → (extension-type σ)
+  :=
+    \ th → first (extension-type-weakening-section σ th)
 
 #def is-equiv-extension-type-weakening
-  ( σ : ϕ → A)
+  ( σ : (t : ϕ) → A t)
   : is-equiv (extension-type σ) (homotopy-extension-type σ)
       (extension-type-weakening-map σ)
   :=
-    ( ( \ th → first (extension-type-weakening-section σ th),
+    ( ( extension-strictification σ ,
         \ _ → refl),
-      ( \ th → ( first (extension-type-weakening-section σ th)),
+      ( extension-strictification σ,
         \ th → ( second (extension-type-weakening-section σ th))))
 
 #def extension-type-weakening
-  ( σ : ϕ → A)
+  ( σ : (t : ϕ) → A t)
   : Equiv (extension-type σ) (homotopy-extension-type σ)
   := ( extension-type-weakening-map σ , is-equiv-extension-type-weakening σ)
 
@@ -85,30 +91,30 @@ This equivalence is functorial in the following sense:
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
-  ( A' A : U)
-  ( α : A' → A)
-  ( σ' : ϕ → A')
+  ( A' A : (t : ψ) → U)
+  ( α : (t : ψ) → A' t → A t)
+  ( σ' : (t : ϕ) → A' t)
   : Equiv-of-maps
       ( extension-type I ψ ϕ A' σ')
-      ( extension-type I ψ ϕ A (\ t → α (σ' t)))
-      ( \ τ' t → α (τ' t))
+      ( extension-type I ψ ϕ A (\ t → α t (σ' t)))
+      ( \ τ' t → α t (τ' t))
       ( homotopy-extension-type I ψ ϕ A' σ')
-      ( homotopy-extension-type I ψ ϕ A (\ t → α (σ' t)))
+      ( homotopy-extension-type I ψ ϕ A (\ t → α t (σ' t)))
       ( \ (τ', p) →
-          ( \ t → α (τ' t),
-            ap (ϕ → A') (ϕ → A)
+          ( \ t → α t (τ' t),
+            ap ((t : ϕ) → A' t) ((t : ϕ) → A t)
                ( \ (t : ϕ) → τ' t)
                ( \ (t : ϕ) → σ' t)
-               ( \ σ'' t → α (σ'' t))
+               ( \ σ'' t → α t (σ'' t))
                ( p)))
   :=
     ( ( ( extension-type-weakening-map I ψ ϕ A' σ'
-        , extension-type-weakening-map I ψ ϕ A (\ t → α (σ' t))
+        , extension-type-weakening-map I ψ ϕ A (\ t → α t (σ' t))
         )
       , \ _ → refl
       )
     , ( is-equiv-extension-type-weakening I ψ ϕ A' σ'
-      , is-equiv-extension-type-weakening I ψ ϕ A (\ t → α (σ' t))
+      , is-equiv-extension-type-weakening I ψ ϕ A (\ t → α t (σ' t))
       )
     )
 
@@ -478,6 +484,23 @@ proposition are propositions.
       ( Σ (a : (t : ϕ) → A t), (t : ψ) → A t [ϕ t ↦ a t])
       ( cofibration-composition I ψ ϕ (\ _ → BOT) (\ t → A t) (\ _ → recBOT))
       ( is-prop-shape-type-is-locally-prop I ψ A is-locally-prop-A))
+```
+
+In a fiberwise contractible family, every extension type is always inhabited.
+This does not use any form of extension extensionality.
+
+```rzk
+#def is-inhabited-extension-type-is-locally-contr
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : ψ → U)
+  ( is-locally-contr-A : (t : ψ) → is-contr (A t))
+  ( a : (t : ϕ) → A t)
+  : (t : ψ) → A t [ϕ t ↦ a t]
+  :=
+    ( undefined)
+
 
 #def weakextext-naiveextext uses (naiveextext)
   : WeakExtExt

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -507,26 +507,26 @@ in a fiberwise contractible family, every extension type is always inhabited.
       ( \ ( t : ϕ) → first (is-locally-contr-A t) )
       ( \ ( t : ϕ) → a t)
       ( \ ( t : ϕ) → second (is-locally-contr-A t) (a t)))
+
+#end weakextext-naiveextext
 ```
 
 We conclude that naive extension extensionality implies
 weak extension extensionality.
 
 ```rzk
-#def weakextext-naiveextext uses (naiveextext)
-  : WeakExtExt
+#def weakextext-naiveextext
+  : NaiveExtExt → WeakExtExt
   :=
-    \ I ψ ϕ A is-locally-contr-A a →
+    \ naiveextext I ψ ϕ A is-locally-contr-A a →
     ( is-contr-is-inhabited-is-prop
       ( (t : ψ) → A t [ϕ t ↦ a t])
-      ( is-prop-extension-type-is-locally-prop
+      ( is-prop-extension-type-is-locally-prop naiveextext
         ( I) ( ψ) ( ϕ) (A)
         ( \ t → is-prop-is-contr (A t) ( is-locally-contr-A t))
         ( a))
-      ( is-inhabited-extension-type-is-locally-contr I ψ ϕ A
+      ( is-inhabited-extension-type-is-locally-contr naiveextext I ψ ϕ A
         ( is-locally-contr-A) ( a)))
-
-#end weakextext-naiveextext
 ```
 
 For convenience we also provide the composite implication

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -442,11 +442,10 @@ fact, sometimes only this weaker form of the axiom is needed.
       ( first (first (extext I ψ ϕ A a f g)))
 ```
 
-Naive extension extensionality implies weak extension extensionality.
+Naive extension extensionality implies that all extension types in a
+proposition are propositions.
 
 ```rzk
-#assume hole : (A : U) → A
-
 #assume naiveextext : NaiveExtExt
 #def is-prop-shape-type-is-locally-prop uses (naiveextext)
   ( I : CUBE)
@@ -474,7 +473,25 @@ Naive extension extensionality implies weak extension extensionality.
     ( is-prop-shape-type-is-locally-prop I (\ t → ϕ t) (\ t → A t)
       ( \ t → is-locally-prop-A t))
     ( \ a → (t : ψ) → A t [ϕ t ↦ a t])
-    ( hole (is-prop (Σ (a : (t : ϕ) → A t), (t : ψ) → A t [ϕ t ↦ a t])))
+    ( is-prop-Equiv-is-prop'
+      ( ( t : ψ) → A t)
+      ( Σ (a : (t : ϕ) → A t), (t : ψ) → A t [ϕ t ↦ a t])
+      ( cofibration-composition I ψ ϕ (\ _ → BOT) (\ t → A t) (\ _ → recBOT))
+      ( is-prop-shape-type-is-locally-prop I ψ A is-locally-prop-A))
+
+#def weakextext-naiveextext uses (naiveextext)
+  : WeakExtExt
+  :=
+    \ I ψ ϕ A is-locally-contr-A a →
+    ( is-contr-is-inhabited-is-prop
+      ( (t : ψ) → A t [ϕ t ↦ a t])
+      ( is-prop-extension-type-is-locally-prop
+        ( naiveextext)
+        ( I) ( ψ) ( ϕ) (A)
+        ( \ t → is-prop-is-contr (A t) ( is-locally-contr-A t))
+        ( a))
+      ( undefined)
+    )
 ```
 
 ### Weak extension extensionality implies extension extensionality

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -689,9 +689,8 @@ extension extensionality that we get by extraccting the fiberwise equivalence.
 
 ```rzk title="RS17 Proposition 4.8(i)"
 #define extext-weakextext
-  (weakextext : WeakExtExt)
-  :  ExtExt
-  := \ I ψ ϕ A a f g →
+  : WeakExtExt → ExtExt
+  := \ weakextext I ψ ϕ A a f g →
       extext-weakextext' weakextext I ψ ϕ A a f g
 ```
 


### PR DESCRIPTION
This completes the cycle of equivalence between NaiveExtExt, WeakExtExt and ExtExt.

As an intermediate step, I deduce from NaiveExtExt that all extension types in a family of propositions are themselves propositions.

Note: relies on #104 and #105 .