### PR TITLE
Clean up naming in 06-contractible

### DIFF
--- a/src/CONTRIBUTORS.md
+++ b/src/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ Formalizations were contributed by the following people (listed alphabetically):
 - [Fredrik Bakke](https://github.com/fredrik-bakke),
 - [César Bardomiano Martínez](https://github.com/cesarbm03),
 - [Jonathan Campbell](https://github.com/jonalfcam),
+- [Aras Ergus](https://www.aergus.net/),
 - [Matthias Hutzler](https://github.com/MatthiasHu),
 - [Nikolai Kudasov](https://fizruk.github.io/),
 - [Kenji Maillard](https://github.com/kyoDralliam),

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -48,7 +48,7 @@ This is a literate `rzk` file:
 ```
 
 ```rzk title="A path between any pair of terms in a contractible type"
-#def eq-is-contr uses (is-contr-A)
+#def all-elements-equal-is-contr uses (is-contr-A)
   (x y : A)
   : x = y
   :=
@@ -70,10 +70,9 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
   : C x
   := C-unit
 
-#def is-prop-unit
-  ( x y : Unit)
-  : x = y
-  := refl
+#def is-contr-Unit
+  : is-contr Unit
+  := (unit, \ _ → refl)
 ```
 
 ```rzk title="The terminal projection as a constant map"
@@ -86,24 +85,24 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
 ## Identity types of unit types
 
 ```rzk
-#def terminal-map-of-path-types-of-Unit-has-retr
+#def has-retraction-terminal-map-path-types-Unit
   ( x y : Unit)
   : has-retraction (x = y) Unit (terminal-map (x = y))
   :=
     ( \ a → refl ,
       \ p → ind-path (Unit) (x) (\ y' p' → refl =_{x = y'} p') (refl) (y) (p))
 
-#def terminal-map-of-path-types-of-Unit-has-sec
+#def has-section-terminal-map-path-types-Unit
   ( x y : Unit)
   : has-section (x = y) Unit (terminal-map (x = y))
   := ( \ a → refl , \ a → refl)
 
-#def terminal-map-of-path-types-of-Unit-is-equiv
+#def is-equiv-terminal-map-path-types-Unit
   ( x y : Unit)
   : is-equiv (x = y) Unit (terminal-map (x = y))
   :=
-    ( terminal-map-of-path-types-of-Unit-has-retr x y ,
-      terminal-map-of-path-types-of-Unit-has-sec x y)
+    ( has-retraction-terminal-map-path-types-Unit x y ,
+      has-section-terminal-map-path-types-Unit x y)
 ```
 
 ## Characterization of contractibility
@@ -116,7 +115,7 @@ A type is contractible if and only if its terminal map is an equivalence.
   : U
   := is-equiv A Unit (terminal-map A)
 
-#def contr-implies-terminal-map-is-equiv-retr
+#def has-retraction-terminal-map-is-contr
   ( A : U)
   ( is-contr-A : is-contr A)
   : has-retraction A Unit (terminal-map A)
@@ -124,7 +123,7 @@ A type is contractible if and only if its terminal map is an equivalence.
     ( constant Unit A (center-contraction A is-contr-A) ,
       \ y → (homotopy-contraction A is-contr-A) y)
 
-#def contr-implies-terminal-map-is-equiv-sec
+#def has-section-terminal-map-is-contr
   ( A : U)
   ( is-contr-A : is-contr A)
   : has-section A Unit (terminal-map A)
@@ -135,21 +134,21 @@ A type is contractible if and only if its terminal map is an equivalence.
   ( is-contr-A : is-contr A)
   : is-equiv A Unit (terminal-map A)
   :=
-    ( contr-implies-terminal-map-is-equiv-retr A is-contr-A ,
-      contr-implies-terminal-map-is-equiv-sec A is-contr-A)
+    ( has-retraction-terminal-map-is-contr A is-contr-A ,
+      has-section-terminal-map-is-contr A is-contr-A)
 
-#def terminal-map-is-equiv-implies-contr
+#def is-contr-is-equiv-terminal-map
   ( A : U)
   (e : terminal-map-is-equiv A)
   : is-contr A
   := ( (first (first e)) unit , (second (first e)))
 
-#def contr-iff-terminal-map-is-equiv
+#def is-equiv-terminal-map-iff-is-contr
   ( A : U)
   : iff (is-contr A) (terminal-map-is-equiv A)
   :=
     ( ( contr-implies-terminal-map-is-equiv A) ,
-      ( terminal-map-is-equiv-implies-contr A))
+      ( is-contr-is-equiv-terminal-map A))
 
 #def equiv-with-contractible-domain-implies-contractible-codomain
   ( A B : U)
@@ -157,40 +156,19 @@ A type is contractible if and only if its terminal map is an equivalence.
   ( is-contr-A : is-contr A)
   : is-contr B
   :=
-    ( terminal-map-is-equiv-implies-contr B
+    ( is-contr-is-equiv-terminal-map B
       ( second
         ( equiv-comp B A Unit
           ( inv-equiv A B f)
           ( ( terminal-map A) ,
             ( contr-implies-terminal-map-is-equiv A is-contr-A)))))
 
-#def equiv-with-contractible-codomain-implies-contractible-domain
-  ( A B : U)
-  ( f : Equiv A B)
-  ( is-contr-B : is-contr B)
-  : is-contr A
-  :=
-    ( equiv-with-contractible-domain-implies-contractible-codomain B A
-      ( inv-equiv A B f) is-contr-B)
-
-#def equiv-then-domain-contractible-iff-codomain-contractible
-  ( A B : U)
-  ( f : Equiv A B)
-  : ( iff (is-contr A) (is-contr B))
-  :=
-    ( \ is-contr-A →
-      ( equiv-with-contractible-domain-implies-contractible-codomain
-        A B f is-contr-A) ,
-      \ is-contr-B →
-      ( equiv-with-contractible-codomain-implies-contractible-domain
-        A B f is-contr-B))
-
-#def path-types-of-Unit-are-contractible
+#def is-contr-path-types-Unit
   ( x y : Unit)
   : is-contr (x = y)
   :=
-    ( terminal-map-is-equiv-implies-contr
-      ( x = y) (terminal-map-of-path-types-of-Unit-is-equiv x y))
+    ( is-contr-is-equiv-terminal-map
+      ( x = y) (is-equiv-terminal-map-path-types-Unit x y))
 ```
 
 ## Retracts of contractible types
@@ -271,7 +249,7 @@ A retract of contractible types is contractible.
     ( ( \ b → center-contraction A is-contr-A ,
         \ a → homotopy-contraction A is-contr-A a) ,
       ( \ b → center-contraction A is-contr-A ,
-        \ b → eq-is-contr B is-contr-B
+        \ b → all-elements-equal-is-contr B is-contr-B
                 (f (center-contraction A is-contr-A)) b))
 ```
 
@@ -533,48 +511,46 @@ A type is contractible if and only if it has singleton induction.
 
 ## Identity types of contractible types
 
-We show that any two paths between the same endpoints in a contractible type are the same. 
+We show that any two paths between the same endpoints in a contractible type are the same.
 
-In a contractible type any path $p : x = y$ is equal to the path constructed in `eq-is-contr`. 
+In a contractible type any path $p : x = y$ is equal to the path constructed in `all-elements-equal-is-contr`.
 ```rzk
 #define path-eq-path-through-center-is-contr
   ( A : U)
   ( is-contr-A : is-contr A)
   ( x y : A)
   ( p : x = y)
-  : ((eq-is-contr A is-contr-A x y) = p)
-  := 
+  : ((all-elements-equal-is-contr A is-contr-A x y) = p)
+  :=
     ind-path
     ( A)
     ( x)
-    ( \ y' p' → (eq-is-contr A is-contr-A x y') = p') 
-    ( left-inverse-concat A (center-contraction A is-contr-A) x (homotopy-contraction A is-contr-A x)) 
-    ( y) 
-    ( p) 
+    ( \ y' p' → (all-elements-equal-is-contr A is-contr-A x y') = p')
+    ( left-inverse-concat A (center-contraction A is-contr-A) x (homotopy-contraction A is-contr-A x))
+    ( y)
+    ( p)
 
 ```
 
 Finally, in a contractible type any two paths between the same end points are equal. There are many possible proofs of this (e.g. identifying contractible types with the unit type where it is more transparent), but we proceed by gluing together the two identifications to the out and back path.
 
 ```rzk
-#define all-paths-eq-is-contr 
+#define all-paths-equal-is-contr
  ( A : U)
  ( is-contr-A : is-contr A)
  ( x y : A)
- ( p q : x = y) 
+ ( p q : x = y)
  : (p = q)
- := 
+ :=
   concat
     ( x = y)
     ( p)
-    ( eq-is-contr A is-contr-A x y)
+    ( all-elements-equal-is-contr A is-contr-A x y)
     ( q)
     ( rev
-      (x = y) 
-      ( eq-is-contr A is-contr-A x y)
-      ( p) 
+      (x = y)
+      ( all-elements-equal-is-contr A is-contr-A x y)
+      ( p)
       ( path-eq-path-through-center-is-contr A is-contr-A x y p))
     ( path-eq-path-through-center-is-contr A is-contr-A x y q)
 ```
-
-

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -129,7 +129,7 @@ A type is contractible if and only if its terminal map is an equivalence.
   : has-section A Unit (terminal-map A)
   := ( constant Unit A (center-contraction A is-contr-A) , \ z → refl)
 
-#def contr-implies-terminal-map-is-equiv
+#def is-equiv-terminal-map-is-contr
   ( A : U)
   ( is-contr-A : is-contr A)
   : is-equiv A Unit (terminal-map A)
@@ -147,7 +147,7 @@ A type is contractible if and only if its terminal map is an equivalence.
   ( A : U)
   : iff (is-contr A) (terminal-map-is-equiv A)
   :=
-    ( ( contr-implies-terminal-map-is-equiv A) ,
+    ( ( is-equiv-terminal-map-is-contr A) ,
       ( is-contr-is-equiv-terminal-map A))
 
 #def equiv-with-contractible-domain-implies-contractible-codomain
@@ -161,7 +161,7 @@ A type is contractible if and only if its terminal map is an equivalence.
         ( equiv-comp B A Unit
           ( inv-equiv A B f)
           ( ( terminal-map A) ,
-            ( contr-implies-terminal-map-is-equiv A is-contr-A)))))
+            ( is-equiv-terminal-map-is-contr A is-contr-A)))))
 
 #def is-contr-path-types-Unit
   ( x y : Unit)
@@ -200,21 +200,21 @@ A retract of contractible types is contractible.
 ```
 
 ```rzk title="If A is a retract of a contractible type it has a term"
-#def is-retract-of-is-contr-isInhabited uses (is-retract-of-A-B)
+#def is-inhabited-is-contr-is-retract-of uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   : A
   := is-retract-of-retraction (center-contraction B is-contr-B)
 ```
 
 ```rzk title="If A is a retract of a contractible type it has a contracting homotopy"
-#def is-retract-of-is-contr-hasHtpy uses (is-retract-of-A-B)
+#def has-homotopy-is-contr-is-retract-of uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   ( a : A)
-  : ( is-retract-of-is-contr-isInhabited is-contr-B) = a
+  : ( is-inhabited-is-contr-is-retract-of is-contr-B) = a
   :=
     concat
       ( A)
-      ( is-retract-of-is-contr-isInhabited is-contr-B)
+      ( is-inhabited-is-contr-is-retract-of is-contr-B)
       ( (comp A B A is-retract-of-retraction is-retract-of-section) a)
       ( a)
       ( ap B A (center-contraction B is-contr-B) (is-retract-of-section a)
@@ -228,8 +228,8 @@ A retract of contractible types is contractible.
   ( is-contr-B : is-contr B)
   : is-contr A
   :=
-    ( is-retract-of-is-contr-isInhabited is-contr-B ,
-      is-retract-of-is-contr-hasHtpy is-contr-B)
+    ( is-inhabited-is-contr-is-retract-of is-contr-B ,
+      has-homotopy-is-contr-is-retract-of is-contr-B)
 ```
 
 ```rzk

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -186,16 +186,16 @@ A retract of contractible types is contractible.
 #variables A B : U
 #variable is-retract-of-A-B : is-retract-of A B
 
-#def is-retract-of-section
+#def section-is-retract-of
   : A → B
   := first is-retract-of-A-B
 
-#def is-retract-of-retraction
+#def retraction-is-retract-of
   : B → A
   := first (second is-retract-of-A-B)
 
-#def is-retract-of-homotopy
-  : homotopy A A (comp A B A is-retract-of-retraction is-retract-of-section) (identity A)
+#def homotopy-is-retract-of
+  : homotopy A A (comp A B A retraction-is-retract-of section-is-retract-of) (identity A)
   := second (second is-retract-of-A-B)
 ```
 
@@ -203,7 +203,7 @@ A retract of contractible types is contractible.
 #def is-inhabited-is-contr-is-retract-of uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   : A
-  := is-retract-of-retraction (center-contraction B is-contr-B)
+  := retraction-is-retract-of (center-contraction B is-contr-B)
 ```
 
 ```rzk title="If A is a retract of a contractible type it has a contracting homotopy"
@@ -215,12 +215,12 @@ A retract of contractible types is contractible.
     concat
       ( A)
       ( is-inhabited-is-contr-is-retract-of is-contr-B)
-      ( (comp A B A is-retract-of-retraction is-retract-of-section) a)
+      ( (comp A B A retraction-is-retract-of section-is-retract-of) a)
       ( a)
-      ( ap B A (center-contraction B is-contr-B) (is-retract-of-section a)
-        ( is-retract-of-retraction)
-        ( homotopy-contraction B is-contr-B (is-retract-of-section a)))
-      ( is-retract-of-homotopy a)
+      ( ap B A (center-contraction B is-contr-B) (section-is-retract-of a)
+        ( retraction-is-retract-of)
+        ( homotopy-contraction B is-contr-B (section-is-retract-of a)))
+      ( homotopy-is-retract-of a)
 ```
 
 ```rzk title="If A is a retract of a contractible type it is contractible"

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -117,7 +117,7 @@ Contractible maps are equivalences:
   (a : A)
   : (is-contr-map-data-in-fiber a) =_{fib A B f (f a)} (a , refl)
   :=
-    eq-is-contr
+    all-elements-equal-is-contr
       ( fib A B f (f a))
       ( is-contr-f (f a))
       ( is-contr-map-data-in-fiber a)

--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -23,10 +23,15 @@ A type is a proposition when its identity types are contractible.
   (A : U)
   : U
   := (a : A) → (b : A) → is-contr (a = b)
+```
 
+For example, the type `Unit` is a proposition.
+In fact we will show below that this is true for every contractible type.
+
+```rzk
 #def is-prop-Unit
   : is-prop Unit
-  := \ x y → (path-types-of-Unit-are-contractible x y)
+  := \ x y → (is-contr-path-types-Unit x y)
 ```
 
 ## Alternative characterizations: definitions
@@ -95,7 +100,7 @@ A type is a proposition when its identity types are contractible.
     \ x y →
       ( is-contr-equiv-is-contr' (x = y) (unit = unit)
         ( (ap A Unit x y (terminal-map A)) , (f x y))
-        ( path-types-of-Unit-are-contractible unit unit))
+        ( is-contr-path-types-Unit unit unit))
 
 #def is-prop-is-contr-is-inhabited
   ( A : U)

--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -82,7 +82,7 @@ In fact we will show below that this is true for every contractible type.
   :=
     \ x →
       ( is-emb-is-equiv A Unit (terminal-map A)
-        ( contr-implies-terminal-map-is-equiv A (c x)))
+        ( is-equiv-terminal-map-is-contr A (c x)))
 
 #def terminal-map-is-emb-is-contr-is-inhabited
   ( A : U)

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -945,7 +945,7 @@ generality is needed.
   ( f : (t : ψ ) → A t [ϕ t ↦ a t])
   (is-contr-fiberwise-A : (t : ψ ) → is-contr (A t))
   : (t : ψ ) → f t = (first (htpy-ext-prop-is-fiberwise-contr htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A)) t
-  := \ t → eq-is-contr
+  := \ t → all-elements-equal-is-contr
               ( A t)
               ( is-contr-fiberwise-A t)
               ( f t )
@@ -968,7 +968,7 @@ slightly more general statement.
   ( c : (t : ψ ) → (f t = a' t))
   : (t : ϕ ) → (refl =_{f t = a' t} c t)
   :=  \ t →
-    all-paths-eq-is-contr
+    all-paths-equal-is-contr
     ( A t)
     ( is-fiberwise-contr t)
     ( f t)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1455,8 +1455,6 @@ As a special case of the above:
 
 #section is-segal-Unit
 
-#def is-contr-Unit : is-contr Unit := (unit , \ _ → refl)
-
 #def is-contr-Δ²→Unit uses (extext)
   : is-contr (Δ² → Unit)
   :=
@@ -1624,7 +1622,7 @@ The cofibration Λ²₁ → Δ² is inner anodyne
 #def is-inner-anodyne-Λ²₁
   : is-inner-anodyne (2 × 2) Δ² Λ²₁
   := \ A is-segal-A h' →
-    equiv-with-contractible-domain-implies-contractible-codomain
+    is-contr-equiv-is-contr
       ( Σ (h : hom A (h' (0₂,0₂)) (h' (1₂,1₂))) ,
           (hom2 A (h' (0₂,0₂)) (h' (1₂,0₂)) (h' (1₂,1₂))
           (\ t → h' (t,0₂)) (\ s → h' (1₂,s)) h))
@@ -1648,7 +1646,7 @@ The cofibration Λ²₁ → Δ² is inner anodyne
       (\ (t,s) → ψ t ∧ ζ s)
       (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
   := \ A is-segal-A h →
-    equiv-with-contractible-codomain-implies-contractible-domain
+    is-contr-equiv-is-contr'
       (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
       ( (s : ζ) → ((t : ψ) → A[ Φ t ↦ h (t,s)])[ χ s ↦ \ t → h (t, s)])
       (uncurry-opcurry I J ψ Φ ζ χ (\ s t → A) h)
@@ -1671,7 +1669,7 @@ The cofibration Λ²₁ → Δ² is inner anodyne
       (\ (t,s) → ψ t ∧ ζ s)
       (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
   := \ A is-segal-A h →
-    equiv-with-contractible-domain-implies-contractible-codomain
+    is-contr-equiv-is-contr
       ( (t : ψ) → ((s : ζ) → A[ χ s ↦ h (t,s)])[ Φ t ↦ \ s → h (t, s)])
       (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
       (curry-uncurry I J ψ Φ ζ χ (\ s t → A) h)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -2213,7 +2213,7 @@ commuting with the contravariant lifts.
       ( A)
       ( \ a → ( b : B ) → (C a b) )
       ( \ x y f g →
-        equiv-with-contractible-codomain-implies-contractible-domain
+        is-contr-equiv-is-contr'
           ( (t : Δ¹) → ((b : B) → C (f t) b) [  t ≡ 0₂ ↦ g ])
           ( (b : B) → (t : Δ¹) → C (f t) b [ t ≡ 0₂ ↦ g b])
           ( flip-ext-fun 2 Δ¹ (\ t → t ≡ 0₂) B ( \ t →  C (f t)) ( \ t → g))

--- a/src/simplicial-hott/13-limits.rzk.md
+++ b/src/simplicial-hott/13-limits.rzk.md
@@ -174,7 +174,7 @@ In a Segal type, initial objects are isomorphic.
   :=
     ( first (is-initial-a b) ,
       ( ( first (is-initial-b a) ,
-          eq-is-contr
+          all-elements-equal-is-contr
             ( hom A a a)
             ( is-initial-a a)
             ( comp-is-segal A is-segal-A a b a
@@ -182,7 +182,7 @@ In a Segal type, initial objects are isomorphic.
               ( first (is-initial-b a)))
             ( id-hom A a)) ,
         ( first (is-initial-b a) ,
-          eq-is-contr
+          all-elements-equal-is-contr
             ( hom A b b)
             ( is-initial-b b)
             ( comp-is-segal A is-segal-A b a b
@@ -205,7 +205,7 @@ In a Segal type, final objects are isomorphic.
   :=
     ( first (is-final-b a) ,
       ( ( first (is-final-a b) ,
-          eq-is-contr
+          all-elements-equal-is-contr
             ( hom A a a)
             ( is-final-a a)
             ( comp-is-segal A is-segal-A a b a
@@ -213,7 +213,7 @@ In a Segal type, final objects are isomorphic.
               ( first (is-final-a b)))
             ( id-hom A a)) ,
         ( first (is-final-a b) ,
-          eq-is-contr
+          all-elements-equal-is-contr
             ( hom A b b)
             ( is-final-b b)
             ( comp-is-segal A is-segal-A b a b


### PR DESCRIPTION
I noticed that many terms in `06-contractible.rzk.md` did not adhere to our naming convention and some theorems were duplicated with non-canonical names.

Tried to clean this up a bit and give more standard names to the terms. Of course this caused some ripples throughout other files.