### PR TITLE
Fiber products

### DIFF
--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -35,8 +35,8 @@ We start by fixing the data of a map between two type families
   := \ (a', c') → (α a', γ a' c')
 ```
 
-We say that such a square is homotopy cartesian
-just if it induces an equivalence componentwise.
+We say that such a square is homotopy cartesian just if it induces an
+equivalence componentwise.
 
 ```rzk
 #def is-homotopy-cartesian uses (A)
@@ -216,8 +216,8 @@ always do this (whether the square is homotopy-cartesian or not).
 
 ### Invariance under pullbacks
 
-We can pullback a homotopy cartesian square over `α : A' → A`
-along any map of maps `β → α` and obtain another homotopy cartesian square.
+We can pullback a homotopy cartesian square over `α : A' → A` along any map of
+maps `β → α` and obtain another homotopy cartesian square.
 
 ```rzk
 #def is-homotopy-cartesian-pullback
@@ -246,16 +246,15 @@ along any map of maps `β → α` and obtain another homotopy cartesian square.
 
 ## Pasting calculus for homotopy cartesian squares
 
-Currently our notion of squares is not symmetric,
-since the vertical maps are given by type families,
-i.e. they are _display maps_,
-while the horizontal maps are arbitrary.
-Therefore we distinquish between the vertical and the horizontal pasting calculus.
+Currently our notion of squares is not symmetric, since the vertical maps are
+given by type families, i.e. they are _display maps_, while the horizontal maps
+are arbitrary. Therefore we distinquish between the vertical and the horizontal
+pasting calculus.
 
 ### Vertical calculus
 
-The following vertical composition and cancellation laws follow easily from
-the corresponding statements about equivalences established above.
+The following vertical composition and cancellation laws follow easily from the
+corresponding statements about equivalences established above.
 
 ```rzk
 #section homotopy-cartesian-vertical-calculus
@@ -463,8 +462,8 @@ Given two maps `B → A` and `C → A`, we can form the relative product over `A
   := \ ((_ , c), _) → c
 ```
 
-This relative product agrees with the fiber product obtained by summing
-over the product of all fibers.
+This relative product agrees with the fiber product obtained by summing over the
+product of all fibers.
 
 ```rzk
 #def fiber-product

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -542,3 +542,29 @@ product of all fibers.
 
 #end relative-product
 ```
+
+### Fiber product with singleton type
+
+The relative product of `β : B → A` with a map `Unit → A` corresponding to
+`a : A` is nothing but the fiber `fib B A β a`.
+
+```rzk
+#def compute-relative-product-singleton
+  ( A B : U)
+  ( β : B → A)
+  ( a : A)
+  : Equiv-of-maps
+    ( fib B A β a) (Unit) (\ _ → unit)
+    ( relative-product A B β Unit (\ unit → a))
+    ( Unit) ( second-relative-product A B β Unit (\ unit → a))
+  :=
+    ( ( ( ( \ (b , p) → ((b , unit) , p))
+        , ( identity Unit))
+      , \ _ → refl)
+    , ( ( ( ( \ ((b , unit) , p) → (b, p))
+          , ( \ _ → refl))
+        , ( ( \ ((b , unit) , p) → (b, p))
+          , ( \ _ → refl)))
+      , is-equiv-identity Unit))
+
+```

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -461,6 +461,11 @@ Given two maps `B → A` and `C → A`, we can form the relative product over `A
 #def second-relative-product uses (A B β C γ)
   : relative-product → C
   := \ ((_ , c), _) → c
+
+#def homotopy-relative-product uses (A B C)
+  ( (bc, p) : relative-product )
+  : β (first-relative-product (bc,p)) = γ (second-relative-product (bc,p))
+  := p
 ```
 
 This relative product agrees with the fiber product obtained by summing over the
@@ -475,6 +480,21 @@ product of all fibers.
   : fiber-product
   = ( Σ (a : A), (product (fib B A β a) (fib C A γ a)))
   := refl
+
+#def first-fiber-product uses (A B β C γ)
+  : fiber-product → B
+  := \ (_, ((b, _), _ )) → b
+
+#def second-fiber-product uses (A B β C γ)
+  : fiber-product → C
+  := \ (_, (_, (c, _))) → c
+
+#def homotopy-fiber-product uses (A B C)
+  : ( abpcq : fiber-product )
+  → β (first-fiber-product abpcq) = γ (second-fiber-product abpcq)
+  :=
+    \ ( a, ((b, p), (c,q))) →
+      zig-zag-concat A (β b) a (γ c) p q
 
 #def relative-fiber-product uses (B C)
   ( (a, ((b, p), (c,q))) : fiber-product )

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -414,7 +414,7 @@ from composition and cancelling laws for equivalences.
 
 ## Fiber products
 
-Given two type families `B C : A → U`, we can form their fiberwise product.
+Given two type families `B C : A → U`, we can form their **fiberwise product**.
 
 ```rzk
 #def fiberwise-product
@@ -439,7 +439,7 @@ Given two type families `B C : A → U`, we can form their fiberwise product.
   := \ (_,c) → c
 ```
 
-Given two maps `B → A` and `C → A`, we can form the relative product over `A`.
+Given two maps `B → A` and `C → A`, we can form the **relative product** over `A`.
 
 ```rzk
 #section relative-product
@@ -452,7 +452,7 @@ Given two maps `B → A` and `C → A`, we can form the relative product over `A
 
 #def relative-product
   : U
-  := Σ ( (b, c) : product B C) , β b = γ c
+  := Σ ( (b, c) : product B C) , (β b = γ c)
 
 #def first-relative-product uses (A B β C γ)
   : relative-product → B
@@ -476,7 +476,7 @@ product of all fibers.
   : U
   := total-type A (fiberwise-product A (fib B A β) (fib C A γ))
 
-#def fiber-product-unpacked
+#def unpack-fiber-product
   : fiber-product
   = ( Σ (a : A), (product (fib B A β a) (fib C A γ a)))
   := refl

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -411,3 +411,114 @@ from composition and cancelling laws for equivalences.
 
 #end homotopy-cartesian-horizontal-calculus
 ```
+
+## Fiber products
+
+Given two type families `B C : A → U`, we can form their fiberwise product.
+
+```rzk
+#def fiberwise-product
+  ( A : U)
+  ( B C : A → U)
+  : A → U
+  :=
+    \ a → product (B a) (C a)
+
+#def first-fiberwise-product
+  ( A : U)
+  ( B C : A → U)
+  ( a : A)
+  : fiberwise-product A B C a → B a
+  := \ (b,_) → b
+
+#def second-fiberwise-product
+  ( A : U)
+  ( B C : A → U)
+  ( a : A)
+  : fiberwise-product A B C a → C a
+  := \ (_,c) → c
+```
+
+Given two maps `B → A` and `C → A`, we can form the relative product over `A`.
+
+```rzk
+#section relative-product
+
+#variable A : U
+#variable B : U
+#variable β : B → A
+#variable C : U
+#variable γ : C → A
+
+#def relative-product
+  : U
+  := Σ ( (b, c) : product B C) , β b = γ c
+
+#def first-relative-product uses (A B β C γ)
+  : relative-product → B
+  := \ ((b , _), _) → b
+
+#def second-relative-product uses (A B β C γ)
+  : relative-product → C
+  := \ ((_ , c), _) → c
+```
+
+This relative product agrees with the fiber product obtained by summing
+over the product of all fibers.
+
+```rzk
+#def fiber-product
+  : U
+  := total-type A (fiberwise-product A (fib B A β) (fib C A γ))
+
+#def fiber-product-unpacked
+  : fiber-product
+  = ( Σ (a : A), (product (fib B A β a) (fib C A γ a)))
+  := refl
+
+#def relative-fiber-product uses (B C)
+  ( (a, ((b, p), (c,q))) : fiber-product )
+  : relative-product
+  := ( ( b , c) , zig-zag-concat A (β b) a (γ c) p q)
+
+#def fiber-relative-product uses ( A B β C)
+  ( ((b,c), e) : relative-product)
+  : fiber-product
+  := ( γ c , ( (b , e) , (c , refl)))
+
+#def is-id-relative-fiber-relative-product
+  ( bce : relative-product)
+  : relative-fiber-product (fiber-relative-product bce) = bce
+  := refl
+
+#def is-id-fiber-relative-fiber-product
+  : ( abpcq : fiber-product)
+  → ( fiber-relative-product (relative-fiber-product abpcq)) = abpcq
+  :=
+  \ (a', (bq', cq')) →
+    ind-fib C A γ
+    ( \ a cq →
+      ( ( bq : fib B A β a)
+      → ( fiber-relative-product (relative-fiber-product (a, (bq, cq)))
+        = ( a, (bq, cq)))))
+    ( \ c bq → refl)
+    ( a')
+    ( cq')
+    ( bq')
+
+#def is-equiv-relative-fiber-product uses (A B β C γ)
+  : is-equiv fiber-product relative-product relative-fiber-product
+  :=
+    ( ( fiber-relative-product
+      , is-id-fiber-relative-fiber-product)
+    , ( fiber-relative-product
+      , is-id-relative-fiber-relative-product))
+
+#def equiv-relative-product-fiber-product uses (A B β C γ)
+  : Equiv fiber-product relative-product
+  :=
+    ( relative-fiber-product
+    , is-equiv-relative-fiber-product)
+
+#end relative-product
+```

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -439,7 +439,8 @@ Given two type families `B C : A → U`, we can form their **fiberwise product**
   := \ (_,c) → c
 ```
 
-Given two maps `B → A` and `C → A`, we can form the **relative product** over `A`.
+Given two maps `B → A` and `C → A`, we can form the **relative product** over
+`A`.
 
 ```rzk
 #section relative-product


### PR DESCRIPTION
Introduce fiber-products of maps `B -> A <- C` in two ways:

- sum over the product of all fibers
- type of triples `(b,c, b =_{A} c)`

Show that these two constructions agree.