### PR TITLE
clean up 03-extension-types

### DIFF
--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -17,6 +17,13 @@ The homotopy fiber of a map is the following type:
   ( b : B)
   : U
   := Σ (a : A) , (f a) = b
+
+#def rev-fib
+  ( A B : U)
+  ( f : A → B)
+  ( b : B)
+  : U
+  := Σ (a : A) , b = (f a)
 ```
 
 We calculate the transport of `#!rzk (a , q) : fib b` along `#!rzk p : a = a'`:
@@ -62,6 +69,17 @@ of the form `#!rzk (a, refl : f a = f a) : fib A B f`.
   : C b (a, q)
   :=
     ind-path B (f a) (\ b p → C b (a, p)) (s a) b q
+
+#def ind-rev-fib
+  ( A B : U)
+  ( f : A → B)
+  ( C : (b : B) → rev-fib A B f b → U)
+  ( s : (a : A) → C (f a) (a, refl))
+  ( b : B)
+  ( (a, q) : rev-fib A B f b)
+  : C b (a, q)
+  :=
+    ind-path-end B (f a) (\ b p → C b (a, p)) (s a) b q
 
 #def ind-fib-computation
   ( A B : U)

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -820,12 +820,12 @@ the point of contraction for weak extension extensionality.
         ( \ t → ( a t , e t) )))
 ```
 
-For completeness, we give a short direct proof that
-extension extensionality also implies the homotopy extension property
-without passing through weak extension extensionality.
+For completeness, we give a short direct proof that extension extensionality
+also implies the homotopy extension property without passing through weak
+extension extensionality.
 
 ```rzk
-#def htpy-ext-prop-naive-extext
+#def htpy-ext-prop-extext
   ( extext : ExtExt)
   : HtpyExtProperty
   :=
@@ -847,10 +847,10 @@ without passing through weak extension extensionality.
 
 ### Homotopy extension property and NaiveExtExt imply WeakExtExt
 
-This section contains the original proof of RS17, Proposition 4.11
-stating that NaiveExtExt and HptyExtProperty jointly imply WeakExtExt.
-In light of `weakextext-naiveextext`, this is now redundant.
-We keep it around since some intermediate statements might still be useful.
+This section contains the original proof of RS17, Proposition 4.11 stating that
+NaiveExtExt and HptyExtProperty jointly imply WeakExtExt. In light of
+`weakextext-naiveextext`, this is now redundant. We keep it around since some
+intermediate statements might still be useful.
 
 In an extension type of a dependent type that is pointwise contractible, then we
 have an inhabitant of the extension type witnessing the contraction, at every
@@ -1020,7 +1020,7 @@ f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
         ( is-contr-fiberwise-A ))))
 ```
 
-```rzk  title="RS17, Proposition 4.11"
+```rzk title="RS17, Proposition 4.11"
 #define weak-extext-naiveextext-htpy-ext-property
  ( naiveextext : NaiveExtExt)
  ( htpy-ext-prop : HtpyExtProperty)

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -34,8 +34,7 @@ restriction map `(ψ → A) → (ϕ → A)`, which we can view as the types of
 #def extension-type
   ( σ : (t : ϕ) → A t)
   : U
-  :=
-    ( t : ψ) → A t [ϕ t ↦ σ t]
+  := ( t : ψ) → A t [ϕ t ↦ σ t]
 
 #def homotopy-extension-type
   ( σ : (t : ϕ) → A t)
@@ -45,8 +44,7 @@ restriction map `(ψ → A) → (ϕ → A)`, which we can view as the types of
 #def extension-type-weakening-map
   ( σ : (t : ϕ) → A t)
   : extension-type σ → homotopy-extension-type σ
-  :=
-    \ τ → ( τ, refl)
+  := \ τ → ( τ, refl)
 
 #def section-extension-type-weakening'
   : ( σ : (t : ϕ) → A t)
@@ -101,24 +99,24 @@ This equivalence is functorial in the following sense:
   ( α : (t : ψ) → A' t → A t)
   ( σ' : (t : ϕ) → A' t)
   : Equiv-of-maps
-      ( extension-type I ψ ϕ A' σ')
-      ( extension-type I ψ ϕ A (\ t → α t (σ' t)))
-      ( \ τ' t → α t (τ' t))
-      ( homotopy-extension-type I ψ ϕ A' σ')
-      ( homotopy-extension-type I ψ ϕ A (\ t → α t (σ' t)))
-      ( \ (τ', p) →
-          ( \ t → α t (τ' t),
-            ap ((t : ϕ) → A' t) ((t : ϕ) → A t)
-               ( \ (t : ϕ) → τ' t)
-               ( \ (t : ϕ) → σ' t)
-               ( \ σ'' t → α t (σ'' t))
-               ( p)))
+    ( extension-type I ψ ϕ A' σ')
+    ( extension-type I ψ ϕ A (\ t → α t (σ' t)))
+    ( \ τ' t → α t (τ' t))
+    ( homotopy-extension-type I ψ ϕ A' σ')
+    ( homotopy-extension-type I ψ ϕ A (\ t → α t (σ' t)))
+    ( \ (τ', p) →
+      ( \ t → α t (τ' t)
+      , ap
+        ( (t : ϕ) → A' t)
+        ( (t : ϕ) → A t)
+        ( \ (t : ϕ) → τ' t)
+        ( \ (t : ϕ) → σ' t)
+        ( \ σ'' t → α t (σ'' t))
+        ( p)))
   :=
     ( ( ( extension-type-weakening-map I ψ ϕ A' σ'
-        , extension-type-weakening-map I ψ ϕ A (\ t → α t (σ' t))
-        )
-      , \ _ → refl
-      )
+        , extension-type-weakening-map I ψ ϕ A (\ t → α t (σ' t)))
+      , ( \ _ → refl))
     , ( is-equiv-extension-type-weakening I ψ ϕ A' σ'
       , is-equiv-extension-type-weakening I ψ ϕ A (\ t → α t (σ' t))))
 ```
@@ -137,11 +135,9 @@ This equivalence is functorial in the following sense:
       ( (t : ψ) → ((x : X) → Y t x) [ϕ t ↦ f t])
       ( (x : X) → (t : ψ) → Y t x [ϕ t ↦ f t x])
   :=
-    ( \ g x t → g t x ,
-      ( ( \ h t x → (h x) t ,
-          \ g → refl) ,
-        ( \ h t x → (h x) t ,
-          \ h → refl)))
+    ( ( \ g x t → g t x)
+    , ( ( \ h t x → (h x) t , \ g → refl)
+      , ( \ h t x → (h x) t , \ h → refl)))
 
 #def flip-ext-fun-inv
   ( I : CUBE)
@@ -154,11 +150,9 @@ This equivalence is functorial in the following sense:
     ( (x : X) → (t : ψ) → Y t x [ϕ t ↦ f t x])
     ( (t : ψ) → ((x : X) → Y t x) [ϕ t ↦ f t])
   :=
-    ( \ h t x → (h x) t ,
-      ( ( \ g x t → g t x ,
-          \ h → refl) ,
-        ( \ g x t → g t x ,
-          \ g → refl)))
+    ( ( \ h t x → (h x) t)
+    , ( ( \ g x t → g t x , \ h → refl)
+      , ( \ g x t → g t x , \ g → refl)))
 ```
 
 ```rzk title="RS17, Theorem 4.2"
@@ -171,16 +165,15 @@ This equivalence is functorial in the following sense:
   ( X : ψ → ζ → U)
   ( f : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → X t s)
   : Equiv
-    ( (t : ψ) →
-      ( (s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
-    ( ((t , s) : I × J | ψ t ∧ ζ s) →
-      X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
+    ( ( t : ψ)
+    → ( (s : ζ) → X t s [χ s ↦ f (t , s)])
+      [ ϕ t ↦ \ s → f (t , s)])
+    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    → ( X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)]))
   :=
-    ( \ g (t , s) → (g t) s ,
-      ( ( \ h t s → h (t , s) ,
-          \ g → refl) ,
-        ( \ h t s → h (t , s) ,
-          \ h → refl)))
+    ( ( \ g (t , s) → (g t) s)
+    , ( ( \ h t s → h (t , s) , \ g → refl)
+      , ( \ h t s → h (t , s) , \ h → refl)))
 
 #def uncurry-opcurry
   ( I J : CUBE)
@@ -191,16 +184,15 @@ This equivalence is functorial in the following sense:
   ( X : ψ → ζ → U)
   ( f : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → X t s)
   : Equiv
-    ( ((t , s) : I × J | ψ t ∧ ζ s) →
-      X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
-    ( ( s : ζ) →
-      ( (t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
+    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    → ( X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)]))
+    ( ( s : ζ)
+    → ( (t : ψ) → X t s [ϕ t ↦ f (t , s)])
+      [ χ s ↦ \ t → f (t , s)])
   :=
-    ( \ h s t → h (t , s) ,
-      ( ( \ g (t , s) → (g s) t ,
-          \ h → refl) ,
-        ( \ g (t , s) → (g s) t ,
-          \ g → refl)))
+    ( ( \ h s t → h (t , s))
+    , ( ( \ g (t , s) → (g s) t , \ h → refl)
+      , ( \ g (t , s) → (g s) t , \ g → refl)))
 
 #def fubini
   ( I J : CUBE)
@@ -211,20 +203,113 @@ This equivalence is functorial in the following sense:
   ( X : ψ → ζ → U)
   ( f : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → X t s)
   : Equiv
-    ( ( t : ψ) →
-      ( (s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
-    ( ( s : ζ) →
-      ( (t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
+    ( ( t : ψ)
+    → ( (s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
+    ( ( s : ζ)
+    → ( (t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
   :=
     equiv-comp
-      ( ( t : ψ) →
-        ( (s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
-      ( ( (t , s) : I × J | ψ t ∧ ζ s) →
-        X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
-      ( ( s : ζ) →
-        ( (t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
+      ( ( t : ψ)
+      → ( (s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
+      ( ( (t , s) : I × J | ψ t ∧ ζ s)
+      → X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
+      ( ( s : ζ)
+      → ( (t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
       ( curry-uncurry I J ψ ϕ ζ χ X f)
       ( uncurry-opcurry I J ψ ϕ ζ χ X f)
+```
+
+For each of these we provide a corresponding functorial instance
+
+```rzk
+#def curry-uncurry-functorial
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  ( A' A : ψ → ζ → U)
+  ( α : (t : ψ) → (s : ζ) → A' t s → A t s)
+  ( σ' : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → A' t s)
+  : Equiv-of-maps
+    ( ( t : ψ)
+    → ( (s : ζ) → A' t s [χ s ↦ σ' (t , s)])
+      [ ϕ t ↦ \ s → σ' (t , s)])
+    ( ( t : ψ)
+    → ( (s : ζ) → A t s [χ s ↦ α t s (σ' (t , s))])
+      [ ϕ t ↦ \ s → α t s (σ' (t , s))])
+    ( \ τ' t s → α t s (τ' t s))
+    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    → ( A' t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ σ' (t , s)])
+    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    → ( A t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ α t s (σ' (t , s))])
+    ( \ uτ' (t , s) → α t s (uτ' (t , s)))
+  :=
+  ( ( ( first (curry-uncurry I J ψ ϕ ζ χ A' σ')
+      , first (curry-uncurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s)))))
+    , ( \ _ → refl))
+  , ( second (curry-uncurry I J ψ ϕ ζ χ A' σ')
+    , second (curry-uncurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s))))))
+
+#def uncurry-opcurry-functorial
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  ( A' A : ψ → ζ → U)
+  ( α : (t : ψ) → (s : ζ) → A' t s → A t s)
+  ( σ' : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → A' t s)
+  : Equiv-of-maps
+    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    → ( A' t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ σ' (t , s)])
+    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    →  ( A t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ α t s (σ' (t , s))])
+    ( \ uτ' (t , s) → α t s (uτ' (t , s)))
+    ( ( s : ζ)
+    → ( (t : ψ) → A' t s [ϕ t ↦ σ' (t , s)])
+      [ χ s ↦ \ t → σ' (t , s)])
+    ( ( s : ζ)
+    → ( (t : ψ) → A t s [ϕ t ↦ α t s ( σ' (t , s))])
+      [ χ s ↦ \ t → α t s (σ' (t , s))])
+    ( \ τ' s t → α t s (τ' s t))
+  :=
+  ( ( ( first (uncurry-opcurry I J ψ ϕ ζ χ A' σ')
+      , first (uncurry-opcurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s)))))
+    , ( \ _ → refl))
+  , ( second (uncurry-opcurry I J ψ ϕ ζ χ A' σ')
+    , second (uncurry-opcurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s))))))
+
+#def fubini-functorial
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  ( A' A : ψ → ζ → U)
+  ( α : (t : ψ) → (s : ζ) → A' t s → A t s)
+  ( σ' : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → A' t s)
+  : Equiv-of-maps
+    ( ( t : ψ)
+    → ( (s : ζ) → A' t s [χ s ↦ σ' (t , s)])
+      [ ϕ t ↦ \ s → σ' (t , s)])
+    ( ( t : ψ)
+    → ( (s : ζ) → A t s [χ s ↦ α t s (σ' (t , s))])
+      [ ϕ t ↦ \ s → α t s (σ' (t , s))])
+    ( \ τ' t s → α t s (τ' t s))
+    ( ( s : ζ)
+    → ( (t : ψ) → A' t s [ϕ t ↦ σ' (t , s)])
+      [ χ s ↦ \ t → σ' (t , s)])
+    ( ( s : ζ)
+    → ( (t : ψ) → A t s [ϕ t ↦ α t s( σ' (t , s))])
+      [ χ s ↦ \ t → α t s (σ' (t , s))])
+    ( \ τ' s t → α t s (τ' s t))
+  :=
+  ( ( ( first (fubini I J ψ ϕ ζ χ A' σ')
+      , first (fubini I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s)))))
+    , ( \ _ → refl))
+  , ( second (fubini I J ψ ϕ ζ χ A' σ')
+    , second (fubini I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s))))))
 ```
 
 ## Extending into Σ-types (the non-axiom of choice)
@@ -240,14 +325,12 @@ This equivalence is functorial in the following sense:
   ( b : (t : ϕ) → Y t (a t))
   : Equiv
     ( (t : ψ) → (Σ (x : X t) , Y t x) [ϕ t ↦ (a t , b t)])
-    ( Σ ( f : ((t : ψ) → X t [ϕ t ↦ a t])) ,
-        ( (t : ψ) → Y t (f t) [ϕ t ↦ b t]))
+    ( Σ ( f : ((t : ψ) → X t [ϕ t ↦ a t]))
+      , ( (t : ψ) → Y t (f t) [ϕ t ↦ b t]))
     :=
-      ( \ g → (\ t → (first (g t)) , \ t → second (g t)) ,
-        ( ( \ (f , h) t → (f t , h t) ,
-            \ _ → refl) ,
-          ( \ (f , h) t → (f t , h t) ,
-            \ _ → refl)))
+      ( ( \ g → (\ t → (first (g t)) , \ t → second (g t)))
+      , ( ( \ (f , h) t → (f t , h t) , \ _ → refl)
+        , ( \ (f , h) t → (f t , h t) , \ _ → refl)))
 ```
 
 ## Composites and unions of cofibrations
@@ -267,9 +350,9 @@ The original form.
     ( Σ ( f : (t : ψ) → X t [ϕ t ↦ a t]) ,
         ( (t : χ) → X t [ψ t ↦ f t]))
   :=
-    ( \ h → (\ t → h t , \ t → h t) ,
-      ( ( \ (_f , g) t → g t , \ h → refl) ,
-        ( ( \ (_f , g) t → g t , \ h → refl))))
+    ( ( \ h → (\ t → h t , \ t → h t))
+    , ( ( \ (_f , g) t → g t , \ h → refl)
+      , ( ( \ (_f , g) t → g t , \ h → refl))))
 
 #def cofibration-composition-functorial
   ( I : CUBE)
@@ -280,21 +363,21 @@ The original form.
   ( α : (t : χ) → A' t → A t)
   ( σ' : (t : ϕ) → A' t)
   : Equiv-of-maps
-     ( (t : χ) → A' t [ϕ t ↦ σ' t])
-     ( (t : χ) → A t [ϕ t ↦ α t (σ' t)])
-     ( \ τ' t → α t (τ' t))
-     ( Σ ( τ' : (t : ψ) → A' t [ϕ t ↦ σ' t]) ,
-        ( (t : χ) → A' t [ψ t ↦ τ' t]))
-     ( Σ ( τ : (t : ψ) → A t [ϕ t ↦ α t (σ' t)]) ,
-        ( (t : χ) → A t [ψ t ↦ τ t]))
-     ( \ (τ', υ') → ( \ t → α t (τ' t), \t → α t (υ' t)))
+    ( (t : χ) → A' t [ϕ t ↦ σ' t])
+    ( (t : χ) → A t [ϕ t ↦ α t (σ' t)])
+    ( \ τ' t → α t (τ' t))
+    ( Σ ( τ' : (t : ψ) → A' t [ϕ t ↦ σ' t])
+      , ( (t : χ) → A' t [ψ t ↦ τ' t]))
+    ( Σ ( τ : (t : ψ) → A t [ϕ t ↦ α t (σ' t)])
+      , ( (t : χ) → A t [ψ t ↦ τ t]))
+    ( \ (τ', υ') → ( \ t → α t (τ' t), \t → α t (υ' t)))
   :=
-    ( ( ( \ h → (\ t → h t , \ t → h t) , \ h → (\ t → h t , \ t → h t)),
-        \ _ → refl),
-      ( ( ( \ (_f , g) t → g t , \ h → refl) ,
-          ( ( \ (_f , g) t → g t , \ h → refl))),
-        ( ( \ (_f , g) t → g t , \ h → refl) ,
-          ( ( \ (_f , g) t → g t , \ h → refl)))))
+    ( ( ( \ h → (\ t → h t , \ t → h t) , \ h → (\ t → h t , \ t → h t))
+      , ( \ _ → refl))
+    , ( ( ( \ (_f , g) t → g t , \ h → refl)
+        , ( ( \ (_f , g) t → g t , \ h → refl)))
+      , ( ( \ (_f , g) t → g t , \ h → refl)
+        , ( ( \ (_f , g) t → g t , \ h → refl)))))
 ```
 
 A reformulated version via tope disjunction instead of inclusion (see
@@ -308,12 +391,12 @@ A reformulated version via tope disjunction instead of inclusion (see
   ( a : (t : I | χ t ∧ ψ t ∧ ϕ t) → X t)
   : Equiv
       ( (t : χ) → X t [χ t ∧ ψ t ∧ ϕ t ↦ a t])
-      ( Σ ( f : (t : I | χ t ∧ ψ t) → X t [χ t ∧ ψ t ∧ ϕ t ↦ a t]) ,
-          ( (t : χ) → X t [χ t ∧ ψ t ↦ f t]))
+      ( Σ ( f : (t : I | χ t ∧ ψ t) → X t [χ t ∧ ψ t ∧ ϕ t ↦ a t])
+        , ( (t : χ) → X t [χ t ∧ ψ t ↦ f t]))
   :=
-    ( \ h → (\ t → h t , \ t → h t) ,
-      ( ( \ (_f , g) t → g t , \ h → refl) ,
-        ( \ (_f , g) t → g t , \ h → refl)))
+    ( ( \ h → (\ t → h t , \ t → h t))
+    , ( ( \ (_f , g) t → g t , \ h → refl)
+      , ( \ (_f , g) t → g t , \ h → refl)))
 ```
 
 ```rzk title="RS17, Theorem 4.5"
@@ -326,9 +409,9 @@ A reformulated version via tope disjunction instead of inclusion (see
       ( (t : I | ϕ t ∨ ψ t) → X t [ψ t ↦ a t])
       ( (t : ϕ) → X t [ϕ t ∧ ψ t ↦ a t])
   :=
-    (\ h t → h t ,
-      ( ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl) ,
-        ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)))
+    ( \ h t → h t
+    , ( ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)
+      , ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)))
 
 #def cofibration-union-functorial
   ( I : CUBE)
@@ -344,16 +427,10 @@ A reformulated version via tope disjunction instead of inclusion (see
       ( (t : ϕ) → A t [ϕ t ∧ ψ t ↦ α t (τ' t)])
       ( \ ν' t → α t (ν' t))
   :=
-     ( ( ( \ υ' t → υ' t
-         , \ υ t → υ t
-         )
-       , \ _ → refl
-       )
-     , ( second (cofibration-union I ϕ ψ A' τ')
-       ,
-         second (cofibration-union I ϕ ψ A ( \ t → α t (τ' t)))
-       )
-     )
+     ( ( ( \ υ' t → υ' t , \ υ t → υ t)
+       , ( \ _ → refl))
+     , ( ( second (cofibration-union I ϕ ψ A' τ'))
+       , ( second (cofibration-union I ϕ ψ A ( \ t → α t (τ' t))))))
 ```
 
 ## Extension extensionality
@@ -388,7 +465,7 @@ We refer to another form as an "extension extensionality" axiom.
       ( (t : ψ) → A t [ϕ t ↦ a t])
       ( f)
       ( \ g' p' → (t : ψ) → (f t = g' t) [ϕ t ↦ refl])
-      ( \ t → refl)
+      ( \ _ → refl)
       ( g)
       ( p)
 ```
@@ -397,17 +474,17 @@ We refer to another form as an "extension extensionality" axiom.
 #def ExtExt
   : U
   :=
-    ( I : CUBE) →
-    ( ψ : I → TOPE) →
-    ( ϕ : ψ → TOPE) →
-    ( A : ψ → U) →
-    ( a : (t : ϕ) → A t) →
-    ( f  : (t : ψ) → A t [ϕ t ↦ a t]) →
-    ( g : (t : ψ ) → A t [ϕ t ↦ a t]) →
-    is-equiv
+    ( ( I : CUBE)
+    → ( ψ : I → TOPE)
+    → ( ϕ : ψ → TOPE)
+    → ( A : ψ → U)
+    → ( a : (t : ϕ) → A t)
+    → ( f : (t : ψ) → A t [ϕ t ↦ a t])
+    → ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+    → is-equiv
       ( f = g)
       ( (t : ψ) → (f t = g t) [ϕ t ↦ refl])
-      ( ext-htpy-eq I ψ ϕ A a f g)
+      ( ext-htpy-eq I ψ ϕ A a f g))
 ```
 
 ```rzk title="The equivalence provided by extension extensionality"
@@ -433,7 +510,7 @@ fact, sometimes only this weaker form of the axiom is needed.
 #def NaiveExtExt
   : U
   :=
-    ( I : CUBE)
+  ( ( I : CUBE)
   → ( ψ : I → TOPE)
   → ( ϕ : ψ → TOPE)
   → ( A : ψ → U)
@@ -441,14 +518,12 @@ fact, sometimes only this weaker form of the axiom is needed.
   → ( f : (t : ψ) → A t [ϕ t ↦ a t])
   → ( g : (t : ψ) → A t [ϕ t ↦ a t])
   → ( (t : ψ) → (f t = g t) [ϕ t ↦ refl])
-  → ( f = g)
+  → ( f = g))
 
 #def naiveextext-extext
   ( extext : ExtExt)
   : NaiveExtExt
-  :=
-    \ I ψ ϕ A a f g →
-      ( first (first (extext I ψ ϕ A a f g)))
+  := \ I ψ ϕ A a f g → ( first (first (extext I ψ ϕ A a f g)))
 ```
 
 We show that naive extension extensionality implies weak extension
@@ -541,7 +616,7 @@ extensionality to weak extension extensionality:
   : ExtExt → WeakExtExt
   :=
     comp ExtExt NaiveExtExt WeakExtExt
-    ( weakextext-naiveextext) ( naiveextext-extext)
+    ( weakextext-naiveextext) (naiveextext-extext)
 ```
 
 ### Weak extension extensionality implies extension extensionality
@@ -567,45 +642,38 @@ cases an extension type to a function type.
   := f
 
 #define is-contr-ext-based-paths uses (weakextext f)
-  : is-contr ((t : ψ ) → (Σ (y : A t) ,
-              ((ext-projection-temp) t = y))[ϕ t ↦ (a t , refl)])
+  : is-contr
+    ( ( t : ψ )
+    → ( Σ (y : A t) , ((ext-projection-temp) t = y))
+      [ ϕ t ↦ (a t , refl)])
   :=
-    weakextext
-    ( I )
-    ( ψ )
-    ( ϕ )
+    weakextext I ψ ϕ
     ( \ t → (Σ (y : A t) , ((ext-projection-temp) t = y)))
-    ( \ t →
-      is-contr-based-paths (A t ) ((ext-projection-temp) t))
+    ( \ t → is-contr-based-paths (A t ) ((ext-projection-temp) t))
     ( \ t → (a t , refl) )
 
 #define is-contr-ext-endpoint-based-paths uses (weakextext f)
   : is-contr
-    ( ( t : ψ) →
-      ( Σ (y : A t) , (y = ext-projection-temp t)) [ ϕ t ↦ (a t , refl)])
+    ( ( t : ψ)
+    → ( Σ (y : A t) , (y = ext-projection-temp t))
+      [ ϕ t ↦ (a t , refl)])
   :=
-    weakextext
-    ( I)
-    ( ψ)
-    ( ϕ)
+    weakextext I ψ ϕ
     ( \ t → (Σ (y : A t) , y = ext-projection-temp t))
     ( \ t → is-contr-endpoint-based-paths (A t) (ext-projection-temp t))
     ( \ t → (a t , refl))
 
 #define is-contr-based-paths-ext uses (weakextext)
-  : is-contr (Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]) ,
-              (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
+  : is-contr
+    ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+      , ( (t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
   :=
     is-contr-equiv-is-contr
     ( (t : ψ ) → (Σ (y : A t),
                      ((ext-projection-temp ) t = y)) [ϕ t ↦ (a t , refl)] )
     ( Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]) ,
                 (t : ψ ) → (f t = g t) [ϕ t ↦ refl] )
-    ( axiom-choice
-      ( I )
-      ( ψ )
-      ( ϕ )
-      ( A )
+    ( axiom-choice I ψ ϕ A
       ( \ t y → (ext-projection-temp) t = y)
       ( a )
       ( \t → refl ))
@@ -624,9 +692,9 @@ The map that defines extension extensionality
   ( A : ψ → U)
   ( a : (t : ϕ ) → A t)
   ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  : ((Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]), (f = g)) →
-      Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]) ,
-        ((t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
+  : ( ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t]), (f = g))
+    → ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+      , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])))
   :=
     total-map
     ( (t : ψ ) → A t [ϕ t ↦ a t])
@@ -646,18 +714,17 @@ The total bundle version of extension extensionality
   ( A : ψ → U)
   ( a : (t : ϕ ) → A t)
   ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  : is-equiv ((Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]), (f = g)))
-               (Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]) ,
-                  ((t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
-               (extext-weakextext-map I ψ ϕ A a f)
+  : is-equiv
+    ( ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t]), (f = g)))
+    ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+      , ( ( t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
+    ( extext-weakextext-map I ψ ϕ A a f)
   :=
     is-equiv-are-contr
-    ( Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]), (f = g)  )
-    ( Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]) ,
-      ((t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
-    ( is-contr-based-paths
-      ( (t : ψ ) → A t [ϕ t ↦ a t])
-      ( f ))
+    ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]), (f = g))
+    ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
+    , ( ( t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
+    ( is-contr-based-paths ((t : ψ) → A t [ϕ t ↦ a t]) (f))
     ( is-contr-based-paths-ext weakextext I ψ ϕ A a f)
     ( extext-weakextext-map I ψ ϕ A a f)
 ```
@@ -675,11 +742,11 @@ extensionality. The following is statement the as proved in RS17.
   ( A : ψ → U)
   ( a : (t : ϕ ) → A t)
   ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  : (g : (t : ψ ) → A t [ϕ t ↦ a t]) →
-      is-equiv
+  : ( ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+    → is-equiv
         ( f = g)
         ( (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
-        ( ext-htpy-eq I ψ ϕ A a f g)
+        ( ext-htpy-eq I ψ ϕ A a f g))
   := total-equiv-family-of-equiv
       ( (t : ψ ) → A t [ϕ t ↦ a t] )
       ( \ g → (f = g) )
@@ -689,7 +756,7 @@ extensionality. The following is statement the as proved in RS17.
 ```
 
 The following is the literal statement of weak extension extensionality implying
-extension extensionality that we get by extraccting the fiberwise equivalence.
+extension extensionality that we get by extracting the fiberwise equivalence.
 
 ```rzk title="RS17 Proposition 4.8(i)"
 #define extext-weakextext
@@ -698,107 +765,14 @@ extension extensionality that we get by extraccting the fiberwise equivalence.
       extext-weakextext' weakextext I ψ ϕ A a f g
 ```
 
-## Applications of extension extensionality
-
-We now assume extension extensionality and derive a few consequences.
-
-```rzk
-#assume extext : ExtExt
-#assume naiveextext : NaiveExtExt
-```
-
-In particular, extension extensionality implies that homotopies give rise to
-identifications. This definition defines `#!rzk eq-ext-htpy` to be the
-retraction to `#!rzk ext-htpy-eq`.
-
-```rzk
-#def eq-ext-htpy uses (extext)
-  ( I : CUBE)
-  ( ψ : I → TOPE)
-  ( ϕ : ψ → TOPE)
-  ( A : ψ → U)
-  ( a : (t : ϕ) → A t)
-  ( f g : (t : ψ) → A t [ϕ t ↦ a t])
-  : ((t : ψ) → (f t = g t) [ϕ t ↦ refl]) → (f = g)
-  := first (first (extext I ψ ϕ A a f g))
-```
-
-### Homotopy extension property
-
-We have a homotopy extension property.
-
-The following code is another instantiation of casting, necessary for some
-arguments below.
-
-```rzk
-#define restrict
-  ( I : CUBE)
-  ( ψ : I → TOPE)
-  ( ϕ : ψ → TOPE)
-  ( A : ψ → U)
-  ( a : (t : ϕ) → A t)
-  ( f : (t : ψ) → A t [ϕ t ↦ a t])
-  : (t : ψ ) → A t
-  := f
-
-```
+## Homotopy extension property
 
 The homotopy extension property has the following signature. We state this
-separately since below we will will both show that this follows from extension
-extensionality, but we will also show that extension extensionality follows from
-the homotopy extension property together with extra hypotheses.
+separately since below we will will show that this follows from extension
+extensionality.
 
 ```rzk
-#define HtpyExtProperty
-  : U
-  :=
-    ( I : CUBE) →
-    ( ψ : I → TOPE) →
-    ( ϕ : ψ → TOPE) →
-    ( A : ψ → U) →
-    ( b : (t : ψ) → A t) →
-    ( a : (t : ϕ) → A t) →
-    ( e : (t : ϕ) → a t = b t) →
-      Σ (a' : (t : ψ) → A t [ϕ t ↦ a t]) ,
-      ((t : ψ) → (restrict I ψ ϕ A a a' t = b t) [ϕ t ↦ e t])
-
-```
-
-If we assume weak extension extensionality, then then homotopy extension
-property follows from a straightforward application of the axiom of choice to
-the point of contraction for weak extension extensionality.
-
-```rzk title="RS17 Proposition 4.10"
-#define htpy-ext-property-weakextext
-  ( weakextext : WeakExtExt)
-  : HtpyExtProperty
-  :=
-    \ I ψ ϕ A b a e →
-    first
-    ( axiom-choice
-      ( I)
-      ( ψ)
-      ( ϕ)
-      ( A)
-      ( \ t y → y = b t)
-      ( a)
-      ( e))
-    ( first
-      ( weakextext
-        ( I)
-        ( ψ)
-        ( ϕ)
-        ( \ t → (Σ (y : A t) , y = b t))
-        ( \ t → is-contr-endpoint-based-paths
-                ( A t)
-                ( b t))
-        ( \ t → ( a t , e t) )))
-
-```
-
-```rzk title="RS17 Proposition 4.10"
-#define htpy-ext-prop-weakextext
-  ( weakextext : WeakExtExt)
+#def instance-HtpyExtProperty
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
@@ -806,29 +780,77 @@ the point of contraction for weak extension extensionality.
   ( b : (t : ψ) → A t)
   ( a : (t : ϕ) → A t)
   ( e : (t : ϕ) → a t = b t)
-  : Σ (a' : (t : ψ) → A t [ϕ t ↦ a t]) ,
-      ((t : ψ) → (restrict I ψ ϕ A a a' t = b t) [ϕ t ↦ e t])
+  : U
   :=
+    Σ (a' : (t : ψ) → A t [ϕ t ↦ a t])
+    , ((t : ψ) → (a' t =_{ A t} b t) [ϕ t ↦ e t])
+
+#def HtpyExtProperty
+  : U
+  :=
+    ( ( I : CUBE)
+    → ( ψ : I → TOPE)
+    → ( ϕ : ψ → TOPE)
+    → ( A : ψ → U)
+    → ( b : (t : ψ) → A t)
+    → ( a : (t : ϕ) → A t)
+    → ( e : (t : ϕ) → a t = b t)
+    → ( instance-HtpyExtProperty I ψ ϕ A b a e ))
+```
+
+If we assume weak extension extensionality, then then homotopy extension
+property follows from a straightforward application of the axiom of choice to
+the point of contraction for weak extension extensionality.
+
+```rzk title="RS17 Proposition 4.10"
+#define htpy-ext-prop-weakextext
+  ( weakextext : WeakExtExt)
+  : HtpyExtProperty
+  :=
+  \ I ψ ϕ A b a e →
     first
-    ( axiom-choice
-      ( I)
-      ( ψ)
-      ( ϕ)
-      ( A)
+    ( axiom-choice I ψ ϕ A
       ( \ t y → y = b t)
       ( a)
       ( e))
     ( first
-      ( weakextext
-        ( I)
-        ( ψ)
-        ( ϕ)
+      ( weakextext I ψ ϕ
         ( \ t → (Σ (y : A t) , y = b t))
-        ( \ t → is-contr-endpoint-based-paths
-                ( A t)
-                ( b t))
+        ( \ t → is-contr-endpoint-based-paths ( A t) ( b t))
         ( \ t → ( a t , e t) )))
 ```
+
+For completeness, we give a short direct proof that
+extension extensionality also implies the homotopy extension property
+without passing through weak extension extensionality.
+
+```rzk
+#def htpy-ext-prop-naive-extext
+  ( extext : ExtExt)
+  : HtpyExtProperty
+  :=
+  \ I ψ ϕ A b a →
+  ind-has-section-equiv (a = (\ (t : ϕ) → b t)) ((t : ϕ) → a t = b t)
+  ( equiv-ExtExt extext I (\ t → ϕ t) (\ _ → BOT) (\ t → A t) (\ _ → recBOT)
+    ( a) (\ (t : ϕ) → b t))
+  ( instance-HtpyExtProperty I ψ ϕ A b a)
+  ( \ e' →
+    ind-rev-fib
+    ( (t : ψ) → A t) ((t : ϕ) → A t) (\ b' t → b' t)
+    ( \ a' (b', p) →
+      instance-HtpyExtProperty I ψ ϕ A b' a'
+      ( ext-htpy-eq I (\ t → ϕ t) (\ _ → BOT) (\ t → A t) (\ _ → recBOT)
+        ( a') (\ (t : ϕ) → b' t) ( p)))
+    ( \ b' → ( b' , \ _ → refl))
+    ( a) (b , e'))
+```
+
+### Homotopy extension property and NaiveExtExt imply WeakExtExt
+
+This section contains the original proof of RS17, Proposition 4.11
+stating that NaiveExtExt and HptyExtProperty jointly imply WeakExtExt.
+In light of `weakextext-naiveextext`, this is now redundant.
+We keep it around since some intermediate statements might still be useful.
 
 In an extension type of a dependent type that is pointwise contractible, then we
 have an inhabitant of the extension type witnessing the contraction, at every
@@ -836,7 +858,6 @@ inhabitant of the base, of each point in the fiber to the center of the fiber.
 Both directions of this statement will be needed.
 
 ```rzk
-
 #def eq-ext-is-contr
   ( I : CUBE)
   ( ψ : I → TOPE)
@@ -845,7 +866,7 @@ Both directions of this statement will be needed.
   ( a : (t : ϕ ) → A t)
   ( is-contr-fiberwise-A : (t : ψ ) → is-contr ( A t))
   : (t : ϕ ) → ((first (is-contr-fiberwise-A t)) = a t)
-  :=  \ t → ( second (is-contr-fiberwise-A t) (a t))
+  := \ t → ( second (is-contr-fiberwise-A t) (a t))
 
 #def codomain-eq-ext-is-contr
   ( I : CUBE)
@@ -855,17 +876,19 @@ Both directions of this statement will be needed.
   ( a : (t : ϕ ) → A t)
   ( is-contr-fiberwise-A : (t : ψ ) → is-contr ( A t))
   : (t : ϕ ) → (a t = first (is-contr-fiberwise-A t))
-  :=  \ t →
-          rev
-            ( A t )
-            ( first (is-contr-fiberwise-A t) )
-            ( a t)
-            ( second (is-contr-fiberwise-A t) (a t))
-
+  :=
+    \ t →
+      rev
+      ( A t )
+      ( first (is-contr-fiberwise-A t) )
+      ( a t)
+      ( second (is-contr-fiberwise-A t) (a t))
 ```
 
 The below gives us the inhabitant
-$(a', e') : \sum_{\left\langle\prod_{t : I|\psi} A (t) \biggr|^\phi_a\right\rangle} \left\langle \prod_{t: I |\psi} a'(t) = b(t)\biggr|^\phi_e \right\rangle$
+$(a', e')
+: \sum_{\left\langle\prod_{t : I|\psi} A (t) \biggr|^\phi_a\right\rangle}
+\left\langle \prod_{t: I |\psi} a'(t) = b(t)\biggr|^\phi_e \right\rangle$
 from the first part of the proof of RS Prop 4.11. It amounts to the fact that
 parameterized contractibility, i.e. `#!rzk A : ψ → U` such that each `A t` is
 contractible, implies the hypotheses of the homotopy extension property are
@@ -873,7 +896,6 @@ satisfied, and so assuming homotopy extension property, we are entitled to the
 conclusion.
 
 ```rzk
-
 #define htpy-ext-prop-is-fiberwise-contr
   (htpy-ext-property : HtpyExtProperty)
   ( I : CUBE)
@@ -882,17 +904,12 @@ conclusion.
   ( A : ψ → U)
   ( a : (t : ϕ ) → A t)
   (is-contr-fiberwise-A : (t : ψ ) → is-contr (A t))
-  : Σ (a' : (t : ψ ) → A t [ϕ t ↦ a t]),
-           ((t : ψ ) →
-            (restrict I ψ ϕ A a a' t =
-              first (is-contr-fiberwise-A t))
-              [ϕ t ↦ codomain-eq-ext-is-contr I ψ ϕ A a is-contr-fiberwise-A t] )
+  : Σ ( a' : (t : ψ ) → A t [ϕ t ↦ a t])
+    , ( ( t : ψ )
+      → ( ( a' t) =_{ A t} first (is-contr-fiberwise-A t))
+        [ ϕ t ↦ codomain-eq-ext-is-contr I ψ ϕ A a is-contr-fiberwise-A t] )
   :=
-    htpy-ext-property
-    ( I )
-    ( ψ )
-    ( ϕ )
-    ( A )
+    htpy-ext-property I ψ ϕ A
     (\ t →  first (is-contr-fiberwise-A t))
     ( a)
     ( codomain-eq-ext-is-contr I ψ ϕ A a is-contr-fiberwise-A)
@@ -913,12 +930,26 @@ generality is needed.
   ( a : (t : ϕ ) → A t)
   ( f : (t : ψ ) → A t [ϕ t ↦ a t])
   (is-contr-fiberwise-A : (t : ψ ) → is-contr (A t))
-  : (t : ψ ) → f t = (first (htpy-ext-prop-is-fiberwise-contr htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A)) t
-  := \ t → all-elements-equal-is-contr
-              ( A t)
-              ( is-contr-fiberwise-A t)
-              ( f t )
-              ( restrict I ψ ϕ A a (first (htpy-ext-prop-is-fiberwise-contr htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A)) t)
+  : ( t : ψ )
+  → ( f t
+    = first
+      ( htpy-ext-prop-is-fiberwise-contr
+        htpy-ext-prop
+        I ψ ϕ A a
+        is-contr-fiberwise-A)
+      ( t))
+  :=
+    \ t →
+    all-elements-equal-is-contr
+    ( A t)
+    ( is-contr-fiberwise-A t)
+    ( f t )
+    ( ( first
+        ( htpy-ext-prop-is-fiberwise-contr
+          htpy-ext-prop
+          I ψ ϕ A a
+          is-contr-fiberwise-A))
+      ( t))
 ```
 
 And below proves that `#!rzk c(t) = refl`. Again, this is a consequence of a
@@ -938,16 +969,13 @@ slightly more general statement.
   : (t : ϕ ) → (refl =_{f t = a' t} c t)
   :=  \ t →
     all-paths-equal-is-contr
-    ( A t)
-    ( is-fiberwise-contr t)
-    ( f t)
-    ( a' t)
-    ( refl )
-    ( c t )
+    (A t) ( is-fiberwise-contr t)
+    ( f t) ( a' t) ( refl ) ( c t )
 ```
 
 Given the `#!rzk a'` produced above, the following gives an inhabitant of
-$\left \langle_{t : I |\psi} f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
+$\left \langle_{t : I |\psi}
+f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
 
 ```rzk
 #define is-fiberwise-contr-ext-is-fiberwise-contr
@@ -957,7 +985,6 @@ $\left \langle_{t : I |\psi} f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\r
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
   ( is-contr-fiberwise-A : (t : ψ ) → is-contr (A t))
- -- ( b : (t : ψ) → A t)
   ( a : (t : ϕ) → A t)
   ( f : (t : ψ ) → A t [ϕ t ↦ a t])
   : (t : ψ ) →
@@ -966,38 +993,37 @@ $\left \langle_{t : I |\psi} f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\r
                 htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A)) t)[ϕ t ↦ refl]
   :=
   first(
-    htpy-ext-prop
-    ( I )
-    ( ψ )
-    ( ϕ )
-    ( \ t → f t = first
-                  (htpy-ext-prop-is-fiberwise-contr
-                    htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A) t)
+    htpy-ext-prop I ψ ϕ
+    ( \ t →
+      ( ( f t)
+      = first
+        ( htpy-ext-prop-is-fiberwise-contr
+          htpy-ext-prop
+          I ψ ϕ A a
+          is-contr-fiberwise-A)
+        ( t)))
     ( RS-4-11-c
       htpy-ext-prop I ψ ϕ A a f is-contr-fiberwise-A)
     ( \ t → refl )
-    ( RS-4-11-c-is-refl
-      ( I)
-      ( ψ)
-      ( ϕ)
-      ( A)
+    ( RS-4-11-c-is-refl I ψ ϕ A
       ( is-contr-fiberwise-A)
       ( a )
       ( f )
-      ( first (htpy-ext-prop-is-fiberwise-contr htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A))
+      ( first
+        ( htpy-ext-prop-is-fiberwise-contr
+          htpy-ext-prop
+          I ψ ϕ A a
+          is-contr-fiberwise-A))
       ( RS-4-11-c
         ( htpy-ext-prop)
-        ( I)
-        ( ψ)
-        ( ϕ)
-        ( A)
-        ( a)
-        ( f)
+        ( I) ( ψ) ( ϕ) ( A) ( a) ( f)
         ( is-contr-fiberwise-A ))))
+```
 
-#define weak-ext-ext-from-eq-ext-htpy-htpy-ext-property
- (naiveextext : NaiveExtExt)
- (htpy-ext-prop : HtpyExtProperty)
+```rzk  title="RS17, Proposition 4.11"
+#define weak-extext-naiveextext-htpy-ext-property
+ ( naiveextext : NaiveExtExt)
+ ( htpy-ext-prop : HtpyExtProperty)
  : WeakExtExt
   := \ I ψ ϕ A is-contr-fiberwise-A a →
     (first (htpy-ext-prop-is-fiberwise-contr htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A),
@@ -1007,24 +1033,24 @@ $\left \langle_{t : I |\psi} f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\r
       ( f )
       ( first (htpy-ext-prop-is-fiberwise-contr
                 htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A))
-      (naiveextext
-      ( I)
-      ( ψ )
-      ( ϕ )
-      ( A)
-      ( a)
-      ( f)
+      ( naiveextext I ψ ϕ A a f
       ( first (htpy-ext-prop-is-fiberwise-contr
                 htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A))
       ( is-fiberwise-contr-ext-is-fiberwise-contr
         ( htpy-ext-prop)
-        ( I)
-        ( ψ )
-        ( ϕ )
-        ( A)
+        ( I) ( ψ ) ( ϕ ) ( A)
         ( is-contr-fiberwise-A)
         ( a)
         ( f))))
+```
+
+## Applications of extension extensionality
+
+We now assume extension extensionality and derive a few consequences.
+
+```rzk
+#assume extext : ExtExt
+#assume naiveextext : NaiveExtExt
 ```
 
 ### Pointwise homotopy extension types
@@ -1044,7 +1070,8 @@ pointwise.
   ( σ : (t : ϕ) → A t)
   : U
   :=
-    Σ ( τ : (t : ψ) → A t) , ( (t : ϕ) → (τ t =_{ A t} σ t))
+    Σ ( τ : (t : ψ) → A t)
+    , ( (t : ϕ) → (τ t =_{ A t} σ t))
 
 #def equiv-pointwise-homotopy-extension-type uses (extext)
   ( σ : (t : ϕ) → A t)
@@ -1057,7 +1084,8 @@ pointwise.
     ( \ τ → (\ t → τ t) =_{ (t : ϕ) → A t} σ)
     ( \ τ → (t : ϕ) → (τ t = σ t))
     ( \ τ →
-      equiv-ExtExt extext I (\ t → ϕ t) (\ _ → BOT) (\ t → A t)
+      equiv-ExtExt extext
+      ( I) (\ t → ϕ t) (\ _ → BOT) (\ t → A t)
       ( \ _ → recBOT) (\ t → τ t) σ)
 
 #def extension-type-pointwise-weakening uses (extext)
@@ -1116,8 +1144,9 @@ Given a map `α : A' → A`, there is also a notion of relative extension types.
     ( \ τ' → (\ t → α t (τ' t)) =_{ (t : ψ) → A t [ϕ t ↦ α t (σ' t)]} τ)
     ( \ τ' → (t : ψ) → (α t (τ' t) = τ t) [ϕ t ↦ refl])
     ( \ τ' →
-      equiv-ExtExt extext I ψ ϕ A (\ t → α t (σ' t))
-        ( \ t → α t (τ' t)) ( τ))
+      equiv-ExtExt extext I ψ ϕ A
+      ( \ t → α t (σ' t))
+      ( \ t → α t (τ' t)) ( τ))
 #end relative-extension-types
 ```
 
@@ -1152,17 +1181,17 @@ extension types are also contractible.
 #def has-contr-relative-extension-types
   : U
   :=
-  ( ( σ' : (t : ϕ) → A' t)
-  → ( τ : (t : ψ) → A t [ϕ t ↦ α t (σ' t)])
-  → ( is-contr (relative-extension-type I ψ ϕ A' A α σ' τ)))
+    ( ( σ' : (t : ϕ) → A' t)
+    → ( τ : (t : ψ) → A t [ϕ t ↦ α t (σ' t)])
+    → ( is-contr (relative-extension-type I ψ ϕ A' A α σ' τ)))
 
 #def has-contr-general-relative-extension-types
   : U
   :=
-  ( ( σ' : (t : ϕ) → A' t)
-  → ( τ : (t : ψ) → A t)
-  → ( h : (t : ϕ) → α t (σ' t) = τ t)
-  → ( is-contr ( general-relative-extension-type σ' τ h)))
+    ( ( σ' : (t : ϕ) → A' t)
+    → ( τ : (t : ψ) → A t)
+    → ( h : (t : ϕ) → α t (σ' t) = τ t)
+    → ( is-contr ( general-relative-extension-type σ' τ h)))
 
 #def has-contr-relative-extension-types-generalize' uses (extext)
   ( has-contr-relext-α : has-contr-relative-extension-types)
@@ -1171,7 +1200,8 @@ extension types are also contractible.
   ( h : (t : ϕ) → α t (σ' t) = τ t)
   : is-contr
     ( general-relative-extension-type σ' τ
-      ( \ t → rev (A t) (τ t) (α t (σ' t)) (rev (A t) (α t (σ' t)) (τ t) (h t))))
+      ( \ t →
+        rev (A t) (τ t) (α t (σ' t)) (rev (A t) (α t (σ' t)) (τ t) (h t))))
   :=
     ind-has-section-equiv
     ( extension-type I ψ ϕ A (\ t → α t (σ' t)))
@@ -1208,9 +1238,8 @@ The converse is of course trivial.
 ```rzk
 #def has-contr-relative-extension-types-specialize
   ( has-contr-gen-relext-α : has-contr-general-relative-extension-types)
-  :  has-contr-relative-extension-types
-  :=
-    \ σ' τ → has-contr-gen-relext-α σ' τ (\ _ → refl)
+  : has-contr-relative-extension-types
+  := \ σ' τ → has-contr-gen-relext-α σ' τ (\ _ → refl)
 
 #end general-extension-types
 ```
@@ -1275,7 +1304,7 @@ then so is the map of maps `map-of-restriction-maps`.
   : is-equiv ((t : ψ) → A t) ((t : ψ) → B t) ( \ a t → f t (a t))
   :=  ( ( ( \ b t → (first (first (is-equiv-f t))) (b t))
         , ( \ a →
-            eq-ext-htpy I ψ ( \ t → BOT)
+            naiveextext-extext extext I ψ ( \ t → BOT)
               ( A)
               ( \ u → recBOT)
               ( \ t → first (first (is-equiv-f t)) (f t (a t)))
@@ -1283,7 +1312,7 @@ then so is the map of maps `map-of-restriction-maps`.
               ( \ t → second (first (is-equiv-f t)) (a t))))
       , ( ( \ b t → first (second (is-equiv-f t)) (b t))
         , ( \ b →
-            eq-ext-htpy I ψ ( \ t → BOT)
+            naiveextext-extext extext I ψ ( \ t → BOT)
               ( B)
               ( \ u → recBOT)
               ( \ t → f t (first (second (is-equiv-f t)) (b t)))

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1490,7 +1490,7 @@ As a special case of the above:
   :=
     ( \ _ → unit ,
       \ k →
-      eq-ext-htpy extext
+      naiveextext-extext extext
         ( 2 × 2) Δ² (\ _ → BOT)
         ( \ _ → Unit) (\ _ → recBOT)
         ( \ _ → unit) k

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -62,7 +62,7 @@ pointwise equal.
   ( x : A)
   : ( ap-hom A B F x x (id-hom A x)) = (id-hom B (F x))
   :=
-    eq-ext-htpy
+    naiveextext-extext
       ( extext)
       ( 2)
       ( Δ¹)


### PR DESCRIPTION
This is mostly a housekeeping PR cleaning up 03-extension-types.

- Formatting improvements
- Restructured the section about homotopy extension property a bit and added subheaders.
- The proof of RS-4.11 is now in its own subsection. We might consider removing this subsection, since it is kinda redundant given the direct implication `weakextext-naiveextext`. Maybe @emilyriehl wants to weigh in on this?
- Removed the redundant term `eq-ext-htpy`, which is the same as `naiveextext-extext`.
- Removed one copy of Prop 4.10. For some reason this formalization was duplicated.

In terms of new formalizations:
- Added functorial instances of `curry-uncurry`, `uncurry-opcurry`, `fubini`.
- Added a very short direct proof `htpy-ext-prop-extext` that extension extensionality implies the homotopy extension property.