### PR TITLE
more on left orthogonal calculus

### DIFF
--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -278,6 +278,47 @@ shape retract, then `ϕ ⊂ ψ` is left orthogonal to `α : A' → A`.
 #end left-orthogonal-calculus-1
 ```
 
+### Transposition
+
+Inside a product of cube `I × J`, we can interchange the two factors without
+affecting left orthogonality.
+
+```rzk
+#def is-right-orthogonal-to-shape-transpose
+  ( A' A : U)
+  ( α : A' → A)
+  ( I J : CUBE)
+  ( ψ : (I × J) → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape (I × J)
+    ( \ (s , t) → ψ (s , t))
+    ( \ (s , t) → ϕ (s , t))
+    ( A') ( A) ( α))
+  : is-right-orthogonal-to-shape (J × I)
+    ( \ (t , s) → ψ (s , t))
+    ( \ (t , s) → ϕ (s , t))
+    ( A') (A) (α)
+  :=
+    \ σ' →
+    is-equiv-Equiv-is-equiv
+    ( ( (t , s) : J × I | ψ (s , t)) → A' [ϕ (s , t) ↦ σ' (t , s)])
+    ( ( (t , s) : J × I | ψ (s , t)) → A [ϕ (s , t) ↦ α (σ' (t , s))])
+    ( \ τ' ts → α (τ' ts))
+    ( ((s , t) : I × J | ψ (s , t)) → A' [ϕ (s , t) ↦ σ' (t , s)])
+    ( ((s , t) : I × J | ψ (s , t)) → A [ϕ (s , t) ↦ α (σ' (t , s))])
+    ( \ τ' st → α (τ' st))
+    ( ( ( ( \ v (x , y) → v (y , x))
+        , ( \ v (x , y) → v (y , x))
+        )
+      , ( \ _ → refl)
+      )
+    , ( ( ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl))
+        , ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl)))
+      , ( ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl))
+        , ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl)))))
+    ( is-orth-ψ-ϕ (\ (s , t) → σ' (t , s)))
+```
+
 ### Stability under exponentiation
 
 If `ϕ ⊂ ψ` is left orthogonal to `α : A' → A` then so is `χ × ϕ ⊂ χ × ψ` for
@@ -342,6 +383,23 @@ extensionality.
                   ( ( second ( second (is-orth-ψ-ϕ (\ s' → σ' (t, s')))))
                     ( \ s' → τ (t, s')))
                   ( s))))
+
+#def is-right-orthogonal-to-shape-product' uses (naiveextext)
+  ( A' A : U)
+  ( α : A' → A)
+  ( I : CUBE)
+  ( ψ : I → TOPE )
+  ( ϕ : ψ → TOPE )
+  ( J : CUBE)
+  ( χ : J → TOPE)
+  ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ ϕ A' A α)
+  : is-right-orthogonal-to-shape
+      ( I × J) ( \ (s , t) → ψ s ∧ χ t) ( \ (s , t) → ϕ s ∧ χ t) A' A α
+  :=
+    is-right-orthogonal-to-shape-transpose A' A α J I
+    ( \ (t , s) → χ t ∧ ψ s)
+    ( \ (t , s) → χ t ∧ ϕ s)
+    ( is-right-orthogonal-to-shape-product A' A α J χ I ψ ϕ is-orth-ψ-ϕ)
 ```
 
 ### Stability under exact pushouts
@@ -397,13 +455,30 @@ stability under pushout products.
     ( is-right-orthogonal-to-shape-pushout A' A α (J × I)
       ( \ (t,s) → ζ t ∧ ψ s)
       ( \ (t,s) → χ t ∧ ϕ s)
-      ( is-right-orthogonal-to-shape-product A' A α
-        ( J) ( \ t → ζ t)
-        ( I) ( ψ) ( ϕ)
+      ( is-right-orthogonal-to-shape-product A' A α J ( \ t → ζ t) I ψ ϕ
         (is-orth-ψ-ϕ)))
-    ( is-right-orthogonal-to-shape-product A' A α
-      ( J) ( χ)
-      ( I) ( ψ) ( ϕ)
+    ( is-right-orthogonal-to-shape-product A' A α J χ I ψ ϕ
+      ( is-orth-ψ-ϕ))
+
+#def is-right-orthogonal-to-shape-pushout-product' uses (naiveextext)
+  ( A' A : U)
+  ( α : A' → A)
+  ( I : CUBE)
+  ( ψ : I → TOPE )
+  ( ϕ : ψ → TOPE )
+  ( J : CUBE)
+  ( χ : J → TOPE)
+  ( ζ : χ → TOPE)
+  ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ ϕ A' A α)
+  : is-right-orthogonal-to-shape (I × J)
+    ( \ (s , t) → ψ s ∧ χ t)
+    ( \ (s , t) → (ϕ s ∧ χ t) ∨ (ψ s ∧ ζ t))
+    ( A') ( A) ( α)
+  :=
+    is-right-orthogonal-to-shape-transpose A' A α J I
+    ( \ (t,s) → χ t ∧ ψ s)
+    ( \ (t,s) → (ζ t ∧ ψ s) ∨ (χ t ∧ ϕ s))
+    ( is-right-orthogonal-to-shape-pushout-product A' A α J χ ζ I ψ ϕ
       ( is-orth-ψ-ϕ))
 ```
 

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -283,12 +283,11 @@ shape retract, then `ϕ ⊂ ψ` is left orthogonal to `α : A' → A`.
 If `ϕ ⊂ ψ` is left orthogonal to `α : A' → A` then so is `χ × ϕ ⊂ χ × ψ` for
 every other shape `χ`.
 
-The following proof uses a lot of currying and uncurrying and relies on (the
-naive form of) extension extensionality.
+The following proof uses a lot of currying and uncurrying and relies extension
+extensionality.
 
 ```rzk
-#def is-right-orthogonal-to-shape-× uses (naiveextext)
--- this should be refactored by introducing cofibration-product-functorial
+#def is-right-orthogonal-to-shape-product uses (naiveextext)
   ( A' A : U)
   ( α : A' → A)
   ( J : CUBE)
@@ -368,6 +367,44 @@ For any two shapes `ϕ, ψ ⊂ I`, if `ϕ ∩ ψ ⊂ ϕ` is left orthogonal to
          ( \ ν' t → α (ν' t))
          ( cofibration-union-functorial I ϕ ψ (\ _ → A') (\ _ → A) (\ _ → α) τ')
          ( is-orth-ϕ-ψ∧ϕ ( \ t → τ' t))
+```
+
+### Pushout products
+
+Combining the stability under pushouts and crossing with a shape, we get
+stability under pushout products.
+
+```rzk
+#def is-right-orthogonal-to-shape-pushout-product uses (naiveextext)
+  ( A' A : U)
+  ( α : A' → A)
+  ( J : CUBE)
+  ( χ : J → TOPE)
+  ( ζ : χ → TOPE)
+  ( I : CUBE)
+  ( ψ : I → TOPE )
+  ( ϕ : ψ → TOPE )
+  ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ ϕ A' A α)
+  : is-right-orthogonal-to-shape (J × I)
+    ( \ (t,s) → χ t ∧ ψ s)
+    ( \ (t,s) → (ζ t ∧ ψ s) ∨ (χ t ∧ ϕ s))
+    ( A') ( A) ( α)
+  :=
+    is-right-orthogonal-to-shape-left-cancel A' A α (J × I)
+    ( \ (t,s) → χ t ∧ ψ s)
+    ( \ (t,s) → (ζ t ∧ ψ s) ∨ (χ t ∧ ϕ s))
+    ( \ (t,s) → χ t ∧ ϕ s)
+    ( is-right-orthogonal-to-shape-pushout A' A α (J × I)
+      ( \ (t,s) → ζ t ∧ ψ s)
+      ( \ (t,s) → χ t ∧ ϕ s)
+      ( is-right-orthogonal-to-shape-product A' A α
+        ( J) ( \ t → ζ t)
+        ( I) ( ψ) ( ϕ)
+        (is-orth-ψ-ϕ)))
+    ( is-right-orthogonal-to-shape-product A' A α
+      ( J) ( χ)
+      ( I) ( ψ) ( ϕ)
+      ( is-orth-ψ-ϕ))
 ```
 
 ## Stability properties of right orthogonal maps

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -368,7 +368,7 @@ Furthermore, we observe that the pair `left-leg-of-Δ ⊂ Δ¹×Δ¹` is the pro
   : is-right-orthogonal-to-shape
       ( 2 × 2) ( \ ts → Δ¹×Δ¹ ts) ( \ ts → left-leg-of-Λ ts) A' A α
   :=
-    is-right-orthogonal-to-shape-× naiveextext A' A α
+    is-right-orthogonal-to-shape-product naiveextext A' A α
       2 Δ¹ 2 Δ¹ ( \ s → s ≡ 0₂) is-left-fib-α
 ```
 


### PR DESCRIPTION
Left orthogonal shape inclusions are closed under
- transposing the two arguments in a subshape of a product of cubes
- product from the right (previously only from the left)
- pushout product from the left and right.