### PR TITLE
Clean up 08-family-of-maps

### DIFF
--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -16,109 +16,100 @@ maps.
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  : ( Σ (x : A) , B x) → (Σ (x : A) , C x)
-  := \ z → (first z , f (first z) (second z))
+  : ( total-type A B) → (total-type A C)
+  := \ (a , b) → (a , f a b)
 
 #def total-map-to-fiber
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( w : (Σ (x : A) , C x))
-  : fib (B (first w)) (C (first w)) (f (first w)) (second w) →
-    ( fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f) w)
-  :=
-    \ (b , p) →
-      ( (first w , b) ,
-        eq-eq-fiber-Σ A C (first w) (f (first w) b) (second w) p)
+  ( (a , c) : total-type A C)
+  : fib (B a) (C a) (f a) (c)
+  → fib (total-type A B) (total-type A C) (total-map A B C f) (a , c)
+  := \ (b , p) → ((a , b) , eq-eq-fiber-Σ A C a (f a b) c p)
 
 #def total-map-from-fiber
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( w : (Σ (x : A) , C x))
-  : fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f) w →
-    fib (B (first w)) (C (first w)) (f (first w)) (second w)
+  : ( (a , c) : total-type A C)
+  → fib (total-type A B) (total-type A C) (total-map A B C f) (a , c)
+  → fib (B a) (C a) (f a) (c)
   :=
-    \ (z , p) →
-    ind-path
-      ( Σ (x : A) , C x)
-      ( total-map A B C f z)
-      ( \ w' p' → fib (B (first w')) (C (first w')) (f (first w')) (second w'))
-      ( second z , refl)
-      ( w)
-      ( p)
+    ind-fib (total-type A B) (total-type A C) (total-map A B C f)
+    ( \ (a' , c') _ → fib (B a') (C a') (f a') c')
+    ( \ (_ , b') → (b' , refl))
+
+
 
 #def total-map-to-fiber-retraction
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( w : (Σ (x : A) , C x))
+  ( (a , c) : total-type A C)
   : has-retraction
-    ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
-    ( fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f) w)
-    ( total-map-to-fiber A B C f w)
+    ( fib (B a) (C a) (f a) (c))
+    ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
+    ( total-map-to-fiber A B C f (a , c))
   :=
-    ( ( total-map-from-fiber A B C f w) ,
-      ( \ (b , p) →
-        ind-path
-          ( C (first w))
-          ( f (first w) b)
-          ( \ w1 p' →
-            ( ( total-map-from-fiber A B C f ((first w , w1)))
-              ( (total-map-to-fiber A B C f (first w , w1)) (b , p')))
-            =_{(fib (B (first w)) (C (first w)) (f (first w)) (w1))}
-            ( b , p'))
-          ( refl)
-          ( second w)
-          ( p)))
+    ( ( total-map-from-fiber A B C f (a , c))
+    , ( \ (b , p) →
+        ind-path ( C a) ( f a b)
+        ( \ c' p' →
+          ( ( total-map-from-fiber A B C f ((a , c')))
+            ( (total-map-to-fiber A B C f (a , c')) (b , p'))
+          = ( b , p')))
+        ( refl)
+        ( c)
+        ( p)))
 
 #def total-map-to-fiber-section
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( w : (Σ (x : A) , C x))
+  ( (a , c) : (Σ (x : A) , C x))
   : has-section
-    ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
-    ( fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f) w)
-    ( total-map-to-fiber A B C f w)
+    ( fib (B a) (C a) (f a) c)
+    ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
+    ( total-map-to-fiber A B C f (a , c))
   :=
-    ( ( total-map-from-fiber A B C f w) ,
-      ( \ (z , p) →
+    ( ( total-map-from-fiber A B C f (a , c))
+    , ( \ ((a', b') , p) →
         ind-path
-          ( Σ (x : A) , C x)
-          ( first z , f (first z) (second z))
+          ( total-type A C)
+          ( a' , f a' b')
           ( \ w' p' →
             ( ( total-map-to-fiber A B C f w')
-              ( ( total-map-from-fiber A B C f w') (z , p'))) =
-            ( z , p'))
+              ( ( total-map-from-fiber A B C f w') ((a' , b') , p'))
+            = ( (a' , b') , p')))
           ( refl)
-          ( w)
+          ( a , c)
           ( p)))
 
-#def total-map-to-fiber-is-equiv
+#def is-equiv-total-map-to-fiber
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( w : (Σ (x : A) , C x))
+  ( (a , c) : total-type A C)
   : is-equiv
-    ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
-    ( fib (Σ (x : A) , B x) (Σ (x : A) , C x)
-      ( total-map A B C f) w)
-    ( total-map-to-fiber A B C f w)
+    ( fib (B a) (C a) (f a) c)
+    ( fib (total-type A B) (total-type A C) ( total-map A B C f) (a , c))
+    ( total-map-to-fiber A B C f (a , c))
   :=
-    ( total-map-to-fiber-retraction A B C f w ,
-      total-map-to-fiber-section A B C f w)
+    ( total-map-to-fiber-retraction A B C f (a , c)
+    , total-map-to-fiber-section A B C f (a , c))
 
-#def total-map-fiber-equiv
+#def equiv-total-map-fiber
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( w : (Σ (x : A) , C x))
+  ( (a , c) : total-type A C)
   : Equiv
-    ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
-    ( fib (Σ (x : A) , B x) (Σ (x : A) , C x)
-      ( total-map A B C f) w)
-  := (total-map-to-fiber A B C f w , total-map-to-fiber-is-equiv A B C f w)
+    ( fib (B a) (C a) (f a) c)
+    ( fib (total-type A B) (total-type A C) ( total-map A B C f) (a , c))
+  :=
+    ( total-map-to-fiber A B C f (a , c)
+    , is-equiv-total-map-to-fiber A B C f (a, c))
 ```
 
 ## Families of equivalences
@@ -127,120 +118,110 @@ A family of equivalences induces an equivalence on total spaces and conversely.
 It will be easiest to work with the incoherent notion of two-sided-inverses.
 
 ```rzk
-#def invertible-family-total-inverse
+#def map-inverse-total-have-inverse-family
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
-  : ( Σ (x : A) , C x) → (Σ (x : A) , B x)
-  := \ (a , c) → (a , (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)
-
-#def invertible-family-total-retraction
-  ( A : U)
-  ( B C : A → U)
-  ( f : (a : A) → (B a) → (C a))
-  ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
-  : has-retraction
-    ( Σ (x : A) , B x)
-    ( Σ (x : A) , C x)
-    ( total-map A B C f)
+  : (total-type A C) → (total-type A B)
   :=
-    ( invertible-family-total-inverse A B C f invfamily ,
+    \ (a , c) →
+      (a , (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)
+
+#def has-retraction-total-have-inverse-family
+  ( A : U)
+  ( B C : A → U)
+  ( f : (a : A) → (B a) → (C a))
+  ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
+  : has-retraction (total-type A B) (total-type A C) (total-map A B C f)
+  :=
+    ( map-inverse-total-have-inverse-family A B C f invfamily ,
       \ (a , b) →
         (eq-eq-fiber-Σ A B a
           ( (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) (f a b)) b
           ( (first (second (invfamily a))) b)))
 
-#def invertible-family-total-section
+#def has-section-total-have-inverse-family
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
-  : has-section (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f)
+  : has-section (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( invertible-family-total-inverse A B C f invfamily ,
+    ( map-inverse-total-have-inverse-family A B C f invfamily ,
       \ (a , c) →
         ( eq-eq-fiber-Σ A C a
           ( f a ((map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)) c
           ( (second (second (invfamily a))) c)))
 
-#def invertible-family-total-invertible
+#def has-inverse-total-have-inverse-family
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
-  : has-inverse
-    ( Σ (x : A) , B x)
-    ( Σ (x : A) , C x)
-    ( total-map A B C f)
+  : has-inverse (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( invertible-family-total-inverse A B C f invfamily ,
-      ( second (invertible-family-total-retraction A B C f invfamily) ,
-        second (invertible-family-total-section A B C f invfamily)))
-
-#def family-of-equiv-total-equiv
-  ( A : U)
-  ( B C : A → U)
-  ( f : (a : A) → (B a) → (C a))
-  ( familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
-  : is-equiv
-    ( Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f)
-  :=
-    is-equiv-has-inverse
-    ( Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f)
-    ( invertible-family-total-invertible A B C f
-      ( \ a → has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a)))
-
-#def total-equiv-family-equiv
-  ( A : U)
-  ( B C : A → U)
-  ( familyeq : (a : A) → Equiv (B a) (C a))
-  : Equiv (Σ (x : A) , B x) (Σ (x : A) , C x)
-  :=
-    ( total-map A B C (\ a → first (familyeq a)) ,
-      family-of-equiv-total-equiv A B C
-        ( \ a → first (familyeq a))
-        ( \ a → second (familyeq a)))
+    ( map-inverse-total-have-inverse-family A B C f invfamily ,
+      ( second (has-retraction-total-have-inverse-family A B C f invfamily) ,
+        second (has-section-total-have-inverse-family A B C f invfamily)))
 ```
 
 The one-way result: that a family of equivalence gives an invertible map (and
 thus an equivalence) on total spaces.
 
 ```rzk
-#def total-has-inverse-family-equiv
+#def has-inverse-total-are-equiv-family
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
-  : has-inverse (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map A B C f)
+  : has-inverse (total-type A B) ( total-type A C) ( total-map A B C f)
   :=
-    invertible-family-total-invertible A B C f
+    has-inverse-total-have-inverse-family A B C f
     ( \ a → has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a))
+
+#def is-equiv-total-are-equiv-family
+  ( A : U)
+  ( B C : A → U)
+  ( f : (a : A) → (B a) → (C a))
+  ( familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
+  : is-equiv ( total-type A B) (total-type A C) (total-map A B C f)
+  :=
+    is-equiv-has-inverse
+    ( total-type A B) ( total-type A C) ( total-map A B C f)
+    ( has-inverse-total-are-equiv-family A B C f familyequiv)
+
+#def total-equiv-family-equiv
+  ( A : U)
+  ( B C : A → U)
+  ( familyeq : (a : A) → Equiv (B a) (C a))
+  : Equiv (total-type A B) (total-type A C)
+  :=
+    ( total-map A B C (\ a → first (familyeq a))
+    , is-equiv-total-are-equiv-family A B C
+      ( \ a → first (familyeq a))
+      ( \ a → second (familyeq a)))
 ```
 
 For the converse, we make use of our calculation on fibers. The first
 implication could be proven similarly.
 
 ```rzk
-#def total-contr-map-family-of-contr-maps
+#def is-contr-map-total-are-contr-map-family
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( totalcontrmap :
-    is-contr-map
-      ( Σ (x : A) , B x)
-      ( Σ (x : A) , C x)
-      ( total-map A B C f))
+  ( totalcontrmap
+    : is-contr-map (total-type A B) ( total-type A C) ( total-map A B C f))
   ( a : A)
   : is-contr-map (B a) (C a) (f a)
   :=
     \ c →
       is-contr-equiv-is-contr'
-        ( fib (B a) (C a) (f a) c)
-        ( fib (Σ (x : A) , B x) (Σ (x : A) , C x)
-          ( total-map A B C f) ((a , c)))
-        ( total-map-fiber-equiv A B C f ((a , c)))
-        ( totalcontrmap ((a , c)))
+      ( fib (B a) (C a) (f a) c)
+      ( fib ( total-type A B) ( total-type A C) ( total-map A B C f) (a , c))
+      ( equiv-total-map-fiber A B C f (a , c))
+      ( totalcontrmap (a , c))
 
 #def total-equiv-family-of-equiv
   ( A : U)
@@ -254,7 +235,7 @@ implication could be proven similarly.
   : is-equiv (B a) (C a) (f a)
   :=
     is-equiv-is-contr-map (B a) (C a) (f a)
-    ( total-contr-map-family-of-contr-maps A B C f
+    ( is-contr-map-total-are-contr-map-family A B C f
       ( is-contr-map-is-equiv
         ( Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map A B C f) totalequiv) a)
@@ -284,7 +265,7 @@ equivalence.
       ( (a : A) → is-equiv (B a) (C a) (f a))
       ( is-equiv (Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map A B C f))
-  := (family-of-equiv-total-equiv A B C f , total-equiv-family-of-equiv A B C f)
+  := (is-equiv-total-are-equiv-family A B C f , total-equiv-family-of-equiv A B C f)
 ```
 
 ## Path spaces
@@ -625,7 +606,7 @@ equivalence of total spaces.
         ( ( total-map A ( \ x → (a = x)) B f) ,
           ( is-equiv-has-inverse (Σ (x : A) , a = x) (Σ (x : A) , B x)
             ( total-map A ( \ x → (a = x)) B f)
-            ( total-has-inverse-family-equiv A
+            ( has-inverse-total-are-equiv-family A
               ( \ x → (a = x)) B f familyequiv)))
         ( is-contr-based-paths A a)))
 
@@ -737,7 +718,7 @@ types over a product type.
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
     ( \ (a , (b , c)) → (a , (b , h a b c)))
     ( \ (a , (b , c)) → (a , (g b , c)))
-    ( family-of-equiv-total-equiv A
+    ( is-equiv-total-are-equiv-family A
       ( \ a → (Σ (b : B) , C' (f a) (g b)))
       ( \ a → (Σ (b' : B') , C' (f a) b'))
       ( \ a (b , c) → (g b , c))

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -223,41 +223,38 @@ implication could be proven similarly.
       ( equiv-total-map-fiber A B C f (a , c))
       ( totalcontrmap (a , c))
 
-#def total-equiv-family-of-equiv
+#def are-equiv-family-is-equiv-total
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( totalequiv : is-equiv
-                ( Σ (x : A) , B x)
-                ( Σ (x : A) , C x)
-                ( total-map A B C f))
+  ( totalequiv
+    : is-equiv (total-type A B) (total-type A C) ( total-map A B C f))
   (a : A)
   : is-equiv (B a) (C a) (f a)
   :=
     is-equiv-is-contr-map (B a) (C a) (f a)
     ( is-contr-map-total-are-contr-map-family A B C f
       ( is-contr-map-is-equiv
-        ( Σ (x : A) , B x) (Σ (x : A) , C x)
-        ( total-map A B C f) totalequiv) a)
+        ( total-type A B) (total-type A C) (total-map A B C f)
+        ( totalequiv))
+      ( a))
 
-#def family-equiv-total-equiv
+#def family-of-equivs-is-equiv-total
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( totalequiv : is-equiv
-                ( Σ (x : A) , B x)
-                ( Σ (x : A) , C x)
-                ( total-map A B C f))
+  ( totalequiv
+    : is-equiv (total-type A B) (total-type A C) ( total-map A B C f))
   ( a : A)
   : Equiv (B a) (C a)
-  := ( f a , total-equiv-family-of-equiv A B C f totalequiv a)
+  := ( f a , are-equiv-family-is-equiv-total A B C f totalequiv a)
 ```
 
 In summary, a family of maps is an equivalence iff the map on total spaces is an
 equivalence.
 
 ```rzk
-#def total-equiv-iff-family-of-equiv
+#def is-equiv-total-iff-are-equiv-family
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -265,7 +262,9 @@ equivalence.
       ( (a : A) → is-equiv (B a) (C a) (f a))
       ( is-equiv (Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map A B C f))
-  := (is-equiv-total-are-equiv-family A B C f , total-equiv-family-of-equiv A B C f)
+  :=
+    ( is-equiv-total-are-equiv-family A B C f
+    , are-equiv-family-is-equiv-total A B C f)
 ```
 
 ## Path spaces
@@ -615,7 +614,7 @@ equivalence of total spaces.
     ( (x : A) → (is-equiv (a = x) (B x) (f x)))
   :=
     ( \ is-contr-Σ-A-B x →
-      total-equiv-family-of-equiv A
+      are-equiv-family-is-equiv-total A
         ( \ x' → (a = x'))
         ( B)
         ( f)
@@ -742,11 +741,11 @@ types over a product type.
   ( b0 : B)
   : is-equiv (C a0 b0) (C' (f a0) (g b0)) (h a0 b0)
   :=
-    total-equiv-family-of-equiv B
+    are-equiv-family-is-equiv-total B
       ( \ b → C a0 b)
       ( \ b → C' (f a0) (g b))
       ( \ b c → h a0 b c)
-      ( total-equiv-family-of-equiv
+      ( are-equiv-family-is-equiv-total
         ( A)
         ( \ a → (Σ (b : B) , C a b))
         ( \ a → (Σ (b : B) , C' (f a) (g b)))

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -19,7 +19,7 @@ maps.
   : ( total-type A B) → (total-type A C)
   := \ (a , b) → (a , f a b)
 
-#def total-map-to-fiber
+#def fib-total-map-fib-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -28,7 +28,7 @@ maps.
   → fib (total-type A B) (total-type A C) (total-map A B C f) (a , c)
   := \ (b , p) → ((a , b) , eq-eq-fiber-Σ A C a (f a b) c p)
 
-#def total-map-from-fiber
+#def fib-fiberwise-fib-total-map
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -40,9 +40,7 @@ maps.
     ( \ (a' , c') _ → fib (B a') (C a') (f a') c')
     ( \ (_ , b') → (b' , refl))
 
-
-
-#def total-map-to-fiber-retraction
+#def has-retraction-fib-total-map-fib-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -50,20 +48,20 @@ maps.
   : has-retraction
     ( fib (B a) (C a) (f a) (c))
     ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
-    ( total-map-to-fiber A B C f (a , c))
+    ( fib-total-map-fib-fiberwise A B C f (a , c))
   :=
-    ( ( total-map-from-fiber A B C f (a , c))
+    ( ( fib-fiberwise-fib-total-map A B C f (a , c))
     , ( \ (b , p) →
         ind-path ( C a) ( f a b)
         ( \ c' p' →
-          ( ( total-map-from-fiber A B C f ((a , c')))
-            ( (total-map-to-fiber A B C f (a , c')) (b , p'))
+          ( ( fib-fiberwise-fib-total-map A B C f ((a , c')))
+            ( (fib-total-map-fib-fiberwise A B C f (a , c')) (b , p'))
           = ( b , p')))
         ( refl)
         ( c)
         ( p)))
 
-#def total-map-to-fiber-section
+#def has-section-fib-total-map-fib-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -71,22 +69,22 @@ maps.
   : has-section
     ( fib (B a) (C a) (f a) c)
     ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
-    ( total-map-to-fiber A B C f (a , c))
+    ( fib-total-map-fib-fiberwise A B C f (a , c))
   :=
-    ( ( total-map-from-fiber A B C f (a , c))
+    ( ( fib-fiberwise-fib-total-map A B C f (a , c))
     , ( \ ((a', b') , p) →
         ind-path
           ( total-type A C)
           ( a' , f a' b')
           ( \ w' p' →
-            ( ( total-map-to-fiber A B C f w')
-              ( ( total-map-from-fiber A B C f w') ((a' , b') , p'))
+            ( ( fib-total-map-fib-fiberwise A B C f w')
+              ( ( fib-fiberwise-fib-total-map A B C f w') ((a' , b') , p'))
             = ( (a' , b') , p')))
           ( refl)
           ( a , c)
           ( p)))
 
-#def is-equiv-total-map-to-fiber
+#def is-equiv-fib-total-map-fib-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -94,12 +92,12 @@ maps.
   : is-equiv
     ( fib (B a) (C a) (f a) c)
     ( fib (total-type A B) (total-type A C) ( total-map A B C f) (a , c))
-    ( total-map-to-fiber A B C f (a , c))
+    ( fib-total-map-fib-fiberwise A B C f (a , c))
   :=
-    ( total-map-to-fiber-retraction A B C f (a , c)
-    , total-map-to-fiber-section A B C f (a , c))
+    ( has-retraction-fib-total-map-fib-fiberwise A B C f (a , c)
+    , has-section-fib-total-map-fib-fiberwise A B C f (a , c))
 
-#def equiv-total-map-fiber
+#def equiv-fib-total-map-fib-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -108,8 +106,8 @@ maps.
     ( fib (B a) (C a) (f a) c)
     ( fib (total-type A B) (total-type A C) ( total-map A B C f) (a , c))
   :=
-    ( total-map-to-fiber A B C f (a , c)
-    , is-equiv-total-map-to-fiber A B C f (a, c))
+    ( fib-total-map-fib-fiberwise A B C f (a , c)
+    , is-equiv-fib-total-map-fib-fiberwise A B C f (a, c))
 ```
 
 ## Families of equivalences
@@ -118,7 +116,7 @@ A family of equivalences induces an equivalence on total spaces and conversely.
 It will be easiest to work with the incoherent notion of two-sided-inverses.
 
 ```rzk
-#def map-inverse-total-have-inverse-family
+#def map-inverse-total-has-inverse-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -128,59 +126,59 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
     \ (a , c) →
       (a , (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)
 
-#def has-retraction-total-have-inverse-family
+#def has-retraction-total-has-inverse-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-retraction (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( map-inverse-total-have-inverse-family A B C f invfamily ,
+    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily ,
       \ (a , b) →
         (eq-eq-fiber-Σ A B a
           ( (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) (f a b)) b
           ( (first (second (invfamily a))) b)))
 
-#def has-section-total-have-inverse-family
+#def has-section-total-has-inverse-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-section (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( map-inverse-total-have-inverse-family A B C f invfamily ,
+    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily ,
       \ (a , c) →
         ( eq-eq-fiber-Σ A C a
           ( f a ((map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)) c
           ( (second (second (invfamily a))) c)))
 
-#def has-inverse-total-have-inverse-family
+#def has-inverse-total-has-inverse-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-inverse (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( map-inverse-total-have-inverse-family A B C f invfamily ,
-      ( second (has-retraction-total-have-inverse-family A B C f invfamily) ,
-        second (has-section-total-have-inverse-family A B C f invfamily)))
+    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily ,
+      ( second (has-retraction-total-has-inverse-fiberwise A B C f invfamily) ,
+        second (has-section-total-has-inverse-fiberwise A B C f invfamily)))
 ```
 
 The one-way result: that a family of equivalence gives an invertible map (and
 thus an equivalence) on total spaces.
 
 ```rzk
-#def has-inverse-total-are-equiv-family
+#def has-inverse-total-is-equiv-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
   : has-inverse (total-type A B) ( total-type A C) ( total-map A B C f)
   :=
-    has-inverse-total-have-inverse-family A B C f
+    has-inverse-total-has-inverse-fiberwise A B C f
     ( \ a → has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a))
 
-#def is-equiv-total-are-equiv-family
+#def is-equiv-total-is-equiv-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -189,16 +187,16 @@ thus an equivalence) on total spaces.
   :=
     is-equiv-has-inverse
     ( total-type A B) ( total-type A C) ( total-map A B C f)
-    ( has-inverse-total-are-equiv-family A B C f familyequiv)
+    ( has-inverse-total-is-equiv-fiberwise A B C f familyequiv)
 
-#def total-equiv-family-equiv
+#def total-equiv-family-of-equiv
   ( A : U)
   ( B C : A → U)
   ( familyeq : (a : A) → Equiv (B a) (C a))
   : Equiv (total-type A B) (total-type A C)
   :=
     ( total-map A B C (\ a → first (familyeq a))
-    , is-equiv-total-are-equiv-family A B C
+    , is-equiv-total-is-equiv-fiberwise A B C
       ( \ a → first (familyeq a))
       ( \ a → second (familyeq a)))
 ```
@@ -207,7 +205,7 @@ For the converse, we make use of our calculation on fibers. The first
 implication could be proven similarly.
 
 ```rzk
-#def is-contr-map-total-are-contr-map-family
+#def is-contr-map-total-is-contr-map-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -220,10 +218,10 @@ implication could be proven similarly.
       is-contr-equiv-is-contr'
       ( fib (B a) (C a) (f a) c)
       ( fib ( total-type A B) ( total-type A C) ( total-map A B C f) (a , c))
-      ( equiv-total-map-fiber A B C f (a , c))
+      ( equiv-fib-total-map-fib-fiberwise A B C f (a , c))
       ( totalcontrmap (a , c))
 
-#def are-equiv-family-is-equiv-total
+#def is-equiv-fiberwise-is-equiv-total
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -233,7 +231,7 @@ implication could be proven similarly.
   : is-equiv (B a) (C a) (f a)
   :=
     is-equiv-is-contr-map (B a) (C a) (f a)
-    ( is-contr-map-total-are-contr-map-family A B C f
+    ( is-contr-map-total-is-contr-map-fiberwise A B C f
       ( is-contr-map-is-equiv
         ( total-type A B) (total-type A C) (total-map A B C f)
         ( totalequiv))
@@ -247,14 +245,14 @@ implication could be proven similarly.
     : is-equiv (total-type A B) (total-type A C) ( total-map A B C f))
   ( a : A)
   : Equiv (B a) (C a)
-  := ( f a , are-equiv-family-is-equiv-total A B C f totalequiv a)
+  := ( f a , is-equiv-fiberwise-is-equiv-total A B C f totalequiv a)
 ```
 
 In summary, a family of maps is an equivalence iff the map on total spaces is an
 equivalence.
 
 ```rzk
-#def is-equiv-total-iff-are-equiv-family
+#def is-equiv-total-iff-is-equiv-fiberwise
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
@@ -263,8 +261,8 @@ equivalence.
       ( is-equiv (Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map A B C f))
   :=
-    ( is-equiv-total-are-equiv-family A B C f
-    , are-equiv-family-is-equiv-total A B C f)
+    ( is-equiv-total-is-equiv-fiberwise A B C f
+    , is-equiv-fiberwise-is-equiv-total A B C f)
 ```
 
 ## Path spaces
@@ -276,7 +274,7 @@ equivalence.
   ( A : U)
   ( a : A)
   : Equiv (Σ (x : A) , x = a) (Σ (x : A) , a = x)
-  := total-equiv-family-equiv A (\ x → x = a) (\ x → a = x) (\ x → equiv-rev A x a)
+  := total-equiv-family-of-equiv A (\ x → x = a) (\ x → a = x) (\ x → equiv-rev A x a)
 ```
 
 ```rzk title="Endpoint based path spaces are contractible"
@@ -309,7 +307,7 @@ The canonical map from a type to its the free path type is an equivalence.
 #def is-constant-free-path
   ( A : U)
   ( ((a , y) , p) : free-paths A)
-  : constant-free-path A a = ((a,y), p)
+  : constant-free-path A a = ((a , y), p)
   :=
     ind-path A a
     ( \ x p' →  constant-free-path A a = ((a , x) , p'))
@@ -368,8 +366,8 @@ The pullback of a family along homotopic maps is equivalent.
     ( pullback A B g C a)
     ( pullback-homotopy)
   :=
-    ( map-inverse-pullback-homotopy ,
-      \ c →
+    ( map-inverse-pullback-homotopy
+    , \ c →
         concat
         ( pullback A B f C a)
         ( transport B C (g a) (f a)
@@ -388,8 +386,8 @@ The pullback of a family along homotopic maps is equivalent.
   : has-section (pullback A B f C a) (pullback A B g C a)
     ( pullback-homotopy)
   :=
-    ( map-inverse-pullback-homotopy ,
-      \ c →
+    ( map-inverse-pullback-homotopy
+    , \ c →
       concat
         ( pullback A B g C a)
         ( transport B C (f a) (g a) (α a)
@@ -566,7 +564,7 @@ As a corollary, we show that pullback along an equivalence induces an
 equivalence of total spaces.
 
 ```rzk
-#def total-equiv-pullback-is-equiv
+#def equiv-total-pullback-is-equiv
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
@@ -596,25 +594,26 @@ equivalence of total spaces.
 #variable B : A → U
 #variable f : (x : A) → (a = x) → B x
 
-#def fund-id-fam-of-eqs-implies-sum-over-codomain-contr
-  : ((x : A) → (is-equiv (a = x) (B x) (f x))) → (is-contr (Σ (x : A) , B x))
+#def is-contr-total-are-equiv-from-paths
+  : ( (x : A) → (is-equiv (a = x) (B x) (f x)))
+  → ( is-contr (Σ (x : A) , B x))
   :=
     ( \ familyequiv →
       ( equiv-with-contractible-domain-implies-contractible-codomain
         ( Σ (x : A) , a = x) (Σ (x : A) , B x)
-        ( ( total-map A ( \ x → (a = x)) B f) ,
-          ( is-equiv-has-inverse (Σ (x : A) , a = x) (Σ (x : A) , B x)
+        ( ( total-map A ( \ x → (a = x)) B f)
+        , ( is-equiv-has-inverse (Σ (x : A) , a = x) (Σ (x : A) , B x)
             ( total-map A ( \ x → (a = x)) B f)
-            ( has-inverse-total-are-equiv-family A
+            ( has-inverse-total-is-equiv-fiberwise A
               ( \ x → (a = x)) B f familyequiv)))
         ( is-contr-based-paths A a)))
 
-#def fund-id-sum-over-codomain-contr-implies-fam-of-eqs
-  : ( is-contr (Σ (x : A) , B x)) →
-    ( (x : A) → (is-equiv (a = x) (B x) (f x)))
+#def are-equiv-from-paths-is-contr-total
+  : ( is-contr (Σ (x : A) , B x))
+  → ( (x : A) → (is-equiv (a = x) (B x) (f x)))
   :=
     ( \ is-contr-Σ-A-B x →
-      are-equiv-family-is-equiv-total A
+      is-equiv-fiberwise-is-equiv-total A
         ( \ x' → (a = x'))
         ( B)
         ( f)
@@ -646,12 +645,46 @@ fundamental theorem:
       ( \ (u' , p') → P u' p')
       ( contr-implies-singleton-induction-pointed
         ( Σ (z : A) , B z)
-        ( fund-id-fam-of-eqs-implies-sum-over-codomain-contr familyequiv)
+        ( is-contr-total-are-equiv-from-paths familyequiv)
         ( \ (x' , p') → P x' p'))
       ( p0)
       ( u , p)
 
 #end fundamental-thm-id-types
+```
+
+One can summarize the fundamental theorem of identity types as follows: A type
+family `B : A → U` is equivalent to the family of based paths at a point if and
+only if its total space is contractible.
+
+```rzk
+#def map-from-paths-inhabited-total
+  ( A : U)
+  ( B : A → U)
+  ( (a , b) : total-type A B)
+  ( x : A)
+  : (a = x) → B x
+  := ind-path A a ( \ y _ → B y) b x
+
+#def fundamental-theorem-of-identity-types
+  ( A : U)
+  ( B : A → U)
+  : iff
+    ( is-contr (total-type A B))
+    ( Σ (a : A) , ((x : A) → Equiv (a = x) (B x)))
+  :=
+  ( ( \ ((a , b) , h) →
+      ( a
+      , \ x →
+        ( map-from-paths-inhabited-total A B (a , b) x
+        , are-equiv-from-paths-is-contr-total A a B
+          ( map-from-paths-inhabited-total A B (a , b))
+          ( (a , b) , h)
+          ( x))))
+  , ( \ (a , familyequiv) →
+      is-contr-total-are-equiv-from-paths A a B
+      ( \ x → first (familyequiv x))
+      ( \ x → second (familyequiv x))))
 ```
 
 ## Maps over product types
@@ -667,23 +700,24 @@ types over a product type.
 #variable C' : A' → B' → U
 #variable f : A → A'
 #variable g : B → B'
-#variable h : (a : A) → (b : B) → (c : C a b) → C' (f a) (g b)
+#variable h : (a : A) → (b : B) → (C a b) → C' (f a) (g b)
 
 #def total-map-fibered-map-over-product
-  : (Σ (a : A) , (Σ (b : B) , C a b)) → (Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+  : ( Σ (a : A) , (Σ (b : B) , C a b))
+  → ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
   := \ (a , (b , c)) → (f a , (g b , h a b c))
 
 #def pullback-is-equiv-base-is-equiv-total-is-equiv
-  ( is-equiv-total :
-    is-equiv
+  ( is-equiv-total
+    : is-equiv
       ( Σ (a : A) , (Σ (b : B) , C a b))
       ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
       ( total-map-fibered-map-over-product))
   ( is-equiv-f : is-equiv A A' f)
   : is-equiv
-      ( Σ (a : A) , (Σ (b : B) , C a b))
-      ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
-      ( \ (a , (b , c)) → (a , (g b , h a b c)))
+    ( Σ (a : A) , (Σ (b : B) , C a b))
+    ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
+    ( \ (a , (b , c)) → (a , (g b , h a b c)))
   :=
     is-equiv-right-factor
     ( Σ (a : A) , (Σ (b : B) , C a b))
@@ -692,24 +726,24 @@ types over a product type.
     ( \ (a , (b , c)) → (a , (g b , h a b c)))
     ( \ (a , (b' , c')) → (f a , (b' , c')))
     ( second
-      ( total-equiv-pullback-is-equiv
+      ( equiv-total-pullback-is-equiv
         ( A) (A')
         ( f) (is-equiv-f)
         ( \ a' → (Σ (b' : B') , C' a' b'))))
     ( is-equiv-total)
 
 #def pullback-is-equiv-bases-are-equiv-total-is-equiv
-  ( is-equiv-total :
-      is-equiv
-        ( Σ (a : A) , (Σ (b : B) , C a b))
-        ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
-        ( total-map-fibered-map-over-product))
+  ( is-equiv-total
+    : is-equiv
+      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+      ( total-map-fibered-map-over-product))
   ( is-equiv-f : is-equiv A A' f)
   ( is-equiv-g : is-equiv B B' g)
   : is-equiv
-      ( Σ (a : A) , (Σ (b : B) , C a b))
-      ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
-      ( \ (a , (b , c)) → (a , (b , h a b c)))
+    ( Σ (a : A) , (Σ (b : B) , C a b))
+    ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
+    ( \ (a , (b , c)) → (a , (b , h a b c)))
   :=
     is-equiv-right-factor
     ( Σ (a : A) , (Σ (b : B) , C a b))
@@ -717,35 +751,35 @@ types over a product type.
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
     ( \ (a , (b , c)) → (a , (b , h a b c)))
     ( \ (a , (b , c)) → (a , (g b , c)))
-    ( is-equiv-total-are-equiv-family A
+    ( is-equiv-total-is-equiv-fiberwise A
       ( \ a → (Σ (b : B) , C' (f a) (g b)))
       ( \ a → (Σ (b' : B') , C' (f a) b'))
       ( \ a (b , c) → (g b , c))
       ( \ a →
         ( second
-          ( total-equiv-pullback-is-equiv
+          ( equiv-total-pullback-is-equiv
             ( B) (B')
             ( g) (is-equiv-g)
             ( \ b' → C' (f a) b')))))
     ( pullback-is-equiv-base-is-equiv-total-is-equiv is-equiv-total is-equiv-f)
 
 #def fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
-  ( is-equiv-total :
-      is-equiv
-        ( Σ (a : A) , (Σ (b : B) , C a b))
-        ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
-        ( total-map-fibered-map-over-product))
+  ( is-equiv-total
+    : is-equiv
+      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+      ( total-map-fibered-map-over-product))
   ( is-equiv-f : is-equiv A A' f)
   ( is-equiv-g : is-equiv B B' g)
   ( a0 : A)
   ( b0 : B)
   : is-equiv (C a0 b0) (C' (f a0) (g b0)) (h a0 b0)
   :=
-    are-equiv-family-is-equiv-total B
+    is-equiv-fiberwise-is-equiv-total B
       ( \ b → C a0 b)
       ( \ b → C' (f a0) (g b))
       ( \ b c → h a0 b c)
-      ( are-equiv-family-is-equiv-total
+      ( is-equiv-fiberwise-is-equiv-total
         ( A)
         ( \ a → (Σ (b : B) , C a b))
         ( \ a → (Σ (b : B) , C' (f a) (g b)))

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -237,7 +237,7 @@ implication could be proven similarly.
         ( totalequiv))
       ( a))
 
-#def family-of-equivs-is-equiv-total
+#def family-of-equiv-is-equiv-total
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -586,6 +586,13 @@ equivalence of total spaces.
 
 ## Fundamental theorem of identity types
 
+The fundamental theorem of identity types concerns the following question: Given
+a type family `B : A → U`, when is `B` equivalent to `\ x → a x` for some
+`a : A`?
+
+We start by fixing `a : A` and investigating when a map of families
+`x : A → (a = x) → B x` is a (fiberwise) equivalence.
+
 ```rzk
 #section fundamental-thm-id-types
 
@@ -653,9 +660,9 @@ fundamental theorem:
 #end fundamental-thm-id-types
 ```
 
-One can summarize the fundamental theorem of identity types as follows: A type
-family `B : A → U` is equivalent to the family of based paths at a point if and
-only if its total space is contractible.
+We can now answer the original question. A type family `B : A → U` is equivalent
+to the family of based paths at a point if and only if its total space is
+contractible.
 
 ```rzk
 #def map-from-paths-inhabited-total

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -108,7 +108,7 @@ square is homotopy-cartesian.
   )
   : is-homotopy-cartesian
   :=
-    total-equiv-family-of-equiv
+    are-equiv-family-is-equiv-total
         A' C' ( \ x → C (α x) ) γ    -- use x instead of a' to avoid shadowing
         ( is-equiv-right-factor
             ( total-type A' C')

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -81,7 +81,7 @@ cartesian square, then so is the upper one `Σαγ : Σ C' → Σ C`.
         ( Σ (a' : A'), C (α a'))
         ( total-type A C)
         ( total-map A' C' (\ a' → C (α a')) γ)
-        ( family-of-equiv-total-equiv
+        ( is-equiv-total-are-equiv-family
           ( A' )
           ( C' )
           ( \ a' → C (α a') )

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -81,18 +81,13 @@ cartesian square, then so is the upper one `Σαγ : Σ C' → Σ C`.
         ( Σ (a' : A'), C (α a'))
         ( total-type A C)
         ( total-map A' C' (\ a' → C (α a')) γ)
-        ( is-equiv-total-are-equiv-family
-          ( A' )
-          ( C' )
+        ( is-equiv-total-is-equiv-fiberwise A' C'
           ( \ a' → C (α a') )
           ( γ)
           ( \ a' → is-hc-α-γ a'))
         ( \ (a', c) → (α a', c) )
         ( second
-          ( total-equiv-pullback-is-equiv
-            ( A')
-            ( A )
-            ( α )
+          ( equiv-total-pullback-is-equiv A' A α
             ( is-equiv-α )
             ( C ))))
 ```
@@ -108,15 +103,15 @@ square is homotopy-cartesian.
   )
   : is-homotopy-cartesian
   :=
-    are-equiv-family-is-equiv-total
-        A' C' ( \ x → C (α x) ) γ    -- use x instead of a' to avoid shadowing
+    is-equiv-fiberwise-is-equiv-total
+        A' C' ( \ x → C (α x) ) γ
         ( is-equiv-right-factor
             ( total-type A' C')
             ( Σ (x : A'), C (α x))
             ( total-type A C)
             ( total-map A' C' (\ x → C (α x)) γ)
             ( \ (x, c) → (α x, c) )
-            ( second ( total-equiv-pullback-is-equiv A' A α is-equiv-α C))
+            ( second ( equiv-total-pullback-is-equiv A' A α is-equiv-α C))
             ( is-equiv-homotopy
                 ( total-type A' C')
                 ( total-type A C )

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -680,7 +680,7 @@ extensionality. The following is statement the as proved in RS17.
         ( f = g)
         ( (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
         ( ext-htpy-eq I ψ ϕ A a f g)
-  := are-equiv-family-is-equiv-total
+  := is-equiv-fiberwise-is-equiv-total
       ( (t : ψ ) → A t [ϕ t ↦ a t] )
       ( \ g → (f = g) )
       ( \ g → (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
@@ -1052,7 +1052,7 @@ pointwise.
     ( homotopy-extension-type I ψ ϕ A σ)
     ( pointwise-homotopy-extension-type σ)
   :=
-    total-equiv-family-equiv
+    total-equiv-family-of-equiv
     ( (t : ψ) → A t)
     ( \ τ → (\ t → τ t) =_{ (t : ϕ) → A t} σ)
     ( \ τ → (t : ϕ) → (τ t = σ t))
@@ -1111,7 +1111,7 @@ Given a map `α : A' → A`, there is also a notion of relative extension types.
     ( relative-extension-type')
     ( relative-extension-type)
   :=
-    total-equiv-family-equiv
+    total-equiv-family-of-equiv
     ( (t : ψ) → A' t [ϕ t ↦ σ' t])
     ( \ τ' → (\ t → α t (τ' t)) =_{ (t : ψ) → A t [ϕ t ↦ α t (σ' t)]} τ)
     ( \ τ' → (t : ψ) → (α t (τ' t) = τ t) [ϕ t ↦ refl])

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -680,7 +680,7 @@ extensionality. The following is statement the as proved in RS17.
         ( f = g)
         ( (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
         ( ext-htpy-eq I ψ ϕ A a f g)
-  := total-equiv-family-of-equiv
+  := are-equiv-family-is-equiv-total
       ( (t : ψ ) → A t [ϕ t ↦ a t] )
       ( \ g → (f = g) )
       ( \ g → (t : ψ ) → (f t = g t) [ϕ t ↦ refl])

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1233,7 +1233,7 @@ arrow.
   : Equiv (f = h) (hom2 A x x y (id-hom A x) f h)
   :=
     ( ( map-hom2-homotopy A x y f h) ,
-      ( total-equiv-family-of-equiv
+      ( are-equiv-family-is-equiv-total
         ( hom A x y)
         ( \ k → (f = k))
         ( \ k → (hom2 A x x y (id-hom A x) f k))
@@ -1295,7 +1295,7 @@ A dual notion of homotopy can be defined similarly.
   : Equiv (f = h) (hom2 A x y y f (id-hom A y) h)
   :=
     ( ( map-hom2-homotopy' A x y f h) ,
-      ( total-equiv-family-of-equiv
+      ( are-equiv-family-is-equiv-total
         ( hom A x y)
         ( \ k → (f = k))
         ( \ k → (hom2 A x y y f (id-hom A y) k))
@@ -1366,7 +1366,7 @@ the data provided by a commutative triangle with that boundary.
   : Equiv ((comp-is-segal A is-segal-A x y z f g) = k) (hom2 A x y z f g k)
   :=
     ( ( map-hom2-eq-is-segal A is-segal-A x y z f g k) ,
-      ( total-equiv-family-of-equiv
+      ( are-equiv-family-is-equiv-total
         ( hom A x z)
         ( \ m → (comp-is-segal A is-segal-A x y z f g) = m)
         ( hom2 A x y z f g)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1233,7 +1233,7 @@ arrow.
   : Equiv (f = h) (hom2 A x x y (id-hom A x) f h)
   :=
     ( ( map-hom2-homotopy A x y f h) ,
-      ( are-equiv-family-is-equiv-total
+      ( is-equiv-fiberwise-is-equiv-total
         ( hom A x y)
         ( \ k → (f = k))
         ( \ k → (hom2 A x x y (id-hom A x) f k))
@@ -1295,7 +1295,7 @@ A dual notion of homotopy can be defined similarly.
   : Equiv (f = h) (hom2 A x y y f (id-hom A y) h)
   :=
     ( ( map-hom2-homotopy' A x y f h) ,
-      ( are-equiv-family-is-equiv-total
+      ( is-equiv-fiberwise-is-equiv-total
         ( hom A x y)
         ( \ k → (f = k))
         ( \ k → (hom2 A x y y f (id-hom A y) k))
@@ -1366,7 +1366,7 @@ the data provided by a commutative triangle with that boundary.
   : Equiv ((comp-is-segal A is-segal-A x y z f g) = k) (hom2 A x y z f g k)
   :=
     ( ( map-hom2-eq-is-segal A is-segal-A x y z f g k) ,
-      ( are-equiv-family-is-equiv-total
+      ( is-equiv-fiberwise-is-equiv-total
         ( hom A x z)
         ( \ m → (comp-is-segal A is-segal-A x y z f g) = m)
         ( hom2 A x y z f g)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -159,7 +159,7 @@ equivalences of maps and when passing to/from total types.
       ( free-paths A) ( fibered-arr' A)
       ( \ ((a,b), p) → ((a,b), hom-eq A a b p))
     ( equiv-of-maps-total-map-hom-eq-const-Δ¹)
-    ( family-of-equiv-total-equiv
+    ( is-equiv-total-are-equiv-family
         ( product A A) ( \ (a,b) → a = b) ( \ (a,b) → hom A a b)
       ( \ (a,b) → hom-eq A a b)
       ( \ (a,b) → is-discrete-A a b))
@@ -753,7 +753,7 @@ The previous calculations allow us to establish a family of equivalences:
       ( fibered-map-square-sigma-over-product
           A x y x y f refl refl))
   :=
-    family-of-equiv-total-equiv
+    is-equiv-total-are-equiv-family
       ( hom A x y)
       ( \ g → f = g)
       ( \ g →

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -169,7 +169,7 @@ equivalences of maps and when passing to/from total types.
   : is-discrete A
   :=
   \ a b →
-    ( total-equiv-family-of-equiv ( product A A) ( \ (a,b) → a = b)
+    ( are-equiv-family-is-equiv-total ( product A A) ( \ (a,b) → a = b)
         ( \ (a,b) → hom A a b)
       ( \ (a,b) → hom-eq A a b)
       ( is-equiv-Equiv-is-equiv' ( A) ( Δ¹ → A) ( \ a _ → a)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -159,7 +159,7 @@ equivalences of maps and when passing to/from total types.
       ( free-paths A) ( fibered-arr' A)
       ( \ ((a,b), p) → ((a,b), hom-eq A a b p))
     ( equiv-of-maps-total-map-hom-eq-const-Δ¹)
-    ( is-equiv-total-are-equiv-family
+    ( is-equiv-total-is-equiv-fiberwise
         ( product A A) ( \ (a,b) → a = b) ( \ (a,b) → hom A a b)
       ( \ (a,b) → hom-eq A a b)
       ( \ (a,b) → is-discrete-A a b))
@@ -169,7 +169,7 @@ equivalences of maps and when passing to/from total types.
   : is-discrete A
   :=
   \ a b →
-    ( are-equiv-family-is-equiv-total ( product A A) ( \ (a,b) → a = b)
+    ( is-equiv-fiberwise-is-equiv-total ( product A A) ( \ (a,b) → a = b)
         ( \ (a,b) → hom A a b)
       ( \ (a,b) → hom-eq A a b)
       ( is-equiv-Equiv-is-equiv' ( A) ( Δ¹ → A) ( \ a _ → a)
@@ -753,7 +753,7 @@ The previous calculations allow us to establish a family of equivalences:
       ( fibered-map-square-sigma-over-product
           A x y x y f refl refl))
   :=
-    is-equiv-total-are-equiv-family
+    is-equiv-total-is-equiv-fiberwise
       ( hom A x y)
       ( \ g → f = g)
       ( \ g →

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -1326,7 +1326,7 @@ equivalence. This follows from the fact that the total types (summed over
       (covariant-uniqueness-curried A x y f C is-covariant-C u v)
   :=
 
-    total-equiv-family-of-equiv
+    are-equiv-family-is-equiv-total
       (C y)
       (dhom A x y f C u)
       (\ v' → covariant-transport A x y f C is-covariant-C u = v')
@@ -1500,7 +1500,7 @@ domain are equivalent:
     ( (t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i])
     ( (t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i])
   :=
-    family-equiv-total-equiv
+    family-of-equivs-is-equiv-total
     ( B x)
     ( \ ii → ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ ii]))
     ( \ ii → ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) ii]))
@@ -2179,7 +2179,7 @@ The fibers of a covariant fibration over a Segal type are discrete types.
   : is-discrete (C x)
   :=
     ( \ u v →
-    total-equiv-family-of-equiv
+    are-equiv-family-is-equiv-total
       ( C x)
       ( \ v' → (u = v'))
       ( hom (C x) u)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -680,7 +680,7 @@ By uncurrying (RS 4.2) we have an equivalence:
               (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
               (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
   :=
-    total-equiv-family-equiv
+    total-equiv-family-of-equiv
       ( hom A a y)
       ( \ v → dhom-representable A a x y f u v)
       ( \ v →
@@ -763,7 +763,7 @@ By uncurrying (RS 4.2) we have an equivalence:
         ( Σ ( d : hom A a y) ,
             ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
   :=
-    total-equiv-family-equiv
+    total-equiv-family-of-equiv
     ( hom A a y)
     ( \ v →
       ( ( (t , s) : Δ¹×Δ¹) →
@@ -828,7 +828,7 @@ By uncurrying (RS 4.2) we have an equivalence:
         ( Σ ( v : hom A a y) ,
             ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
     ( representable-dhom-from-hom2 A a x y f u)
-    ( total-equiv-family-equiv
+    ( total-equiv-family-of-equiv
       ( hom A a y)
       ( \ d →
         ( product
@@ -867,7 +867,7 @@ Now we introduce the hypothesis that A is Segal type.
           ( hom2 A a x y u f d)
           ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
     ( representable-dhom-from-hom2-dist A a x y f u)
-    ( total-equiv-family-equiv
+    ( total-equiv-family-of-equiv
       ( hom A a y)
       ( \ d → product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d)))
       ( \ d →
@@ -875,12 +875,12 @@ Now we introduce the hypothesis that A is Segal type.
           ( hom2 A a x y u f d)
           ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
       ( \ d →
-        ( total-equiv-family-equiv
+        ( total-equiv-family-of-equiv
           ( hom2 A a x y u f d)
           ( \ α → (Σ (v : hom A a y) , (v = d)))
           ( \ α → (Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d))
           ( \ α →
-            ( total-equiv-family-equiv
+            ( total-equiv-family-of-equiv
               ( hom A a y)
               ( \ v → (v = d))
               ( \ v → hom2 A a a y (id-hom A a) v d)
@@ -918,7 +918,7 @@ Now we introduce the hypothesis that A is Segal type.
       ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
     ( Σ (d : hom A a y) , (hom2 A a x y u f d))
     ( representable-dhom-from-path-space-is-segal A is-segal-A a x y f u)
-    ( total-equiv-family-equiv
+    ( total-equiv-family-of-equiv
       ( hom A a y)
       ( \ d → product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d)))
       ( \ d → hom2 A a x y u f d)
@@ -1083,7 +1083,7 @@ types as follows.
               (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
               (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
   :=
-    total-equiv-pullback-is-equiv
+    equiv-total-pullback-is-equiv
     ( ( (t , s) : ∂□) →
       A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
           (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
@@ -1326,7 +1326,7 @@ equivalence. This follows from the fact that the total types (summed over
       (covariant-uniqueness-curried A x y f C is-covariant-C u v)
   :=
 
-    are-equiv-family-is-equiv-total
+    is-equiv-fiberwise-is-equiv-total
       (C y)
       (dhom A x y f C u)
       (\ v' → covariant-transport A x y f C is-covariant-C u = v')
@@ -1464,7 +1464,7 @@ domain are equivalent:
     ( Σ (i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
     ( Σ (u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
   :=
-    total-equiv-pullback-is-equiv
+    equiv-total-pullback-is-equiv
       ( B x)
       ( C x)
       ( first (equiv-BC x))
@@ -1732,7 +1732,7 @@ By uncurrying (RS 4.2) we have an equivalence:
               (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
               (Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
   :=
-    total-equiv-family-equiv
+    total-equiv-family-of-equiv
     ( hom A x a)
     ( \ u → dhom-contra-representable A a x y f u v)
     ( \ u →
@@ -1759,7 +1759,7 @@ By uncurrying (RS 4.2) we have an equivalence:
       (Σ (d : hom A x a) ,
         product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
   :=
-    total-equiv-family-equiv (hom A x a)
+    total-equiv-family-of-equiv (hom A x a)
     ( \ u →
       ( ( (t , s) : Δ¹×Δ¹) →
         A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -1821,14 +1821,14 @@ By uncurrying (RS 4.2) we have an equivalence:
           ( Σ ( u : hom A x a) ,
               ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))))
       ( representable-dhom-to-hom2 A a x y f v)
-      ( total-equiv-family-equiv (hom A x a)
+      ( total-equiv-family-of-equiv (hom A x a)
         (\ d →
           Σ ( u : hom A x a) ,
             ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
         ( \ d →
           Σ ( u : hom A x a) ,
             ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d)))
-        ( \ d → total-equiv-family-equiv (hom A x a)
+        ( \ d → total-equiv-family-of-equiv (hom A x a)
           ( \ u → product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))
           ( \ u → product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))
           ( \ u →
@@ -1858,7 +1858,7 @@ By uncurrying (RS 4.2) we have an equivalence:
           ( hom2 A x y a f v d)
           ( hom2 A x a a u (id-hom A a) d)))
     ( representable-dhom-to-hom2-swap A a x y f v)
-    ( total-equiv-family-equiv (hom A x a)
+    ( total-equiv-family-of-equiv (hom A x a)
       ( \ d →
         ( product
           ( hom2 A x y a f v d)
@@ -1896,19 +1896,19 @@ Now we introduce the hypothesis that A is Segal type.
           ( hom2 A x y a f v d)
           ( Σ (u : hom A x a) , (hom2 A x a a u (id-hom A a) d))))
     ( representable-dhom-to-hom2-dist A a x y f v)
-    ( total-equiv-family-equiv (hom A x a)
+    ( total-equiv-family-of-equiv (hom A x a)
       ( \ d → product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d)))
       ( \ d →
         product
           ( hom2 A x y a f v d)
           ( Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d))
       ( \ d →
-        total-equiv-family-equiv
+        total-equiv-family-of-equiv
           ( hom2 A x y a f v d)
           ( \ α → (Σ (u : hom A x a) , (u = d)))
           ( \ α → (Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d))
           ( \ α →
-          ( total-equiv-family-equiv
+          ( total-equiv-family-of-equiv
             ( hom A x a)
             ( \ u → (u = d))
             ( \ u → hom2 A x a a u (id-hom A a) d)
@@ -1930,7 +1930,7 @@ Now we introduce the hypothesis that A is Segal type.
         ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
     ( Σ (d : hom A x a) , (hom2 A x y a f v d))
     ( representable-dhom-to-path-space-is-segal A is-segal-A a x y f v)
-    ( total-equiv-family-equiv
+    ( total-equiv-family-of-equiv
       ( hom A x a)
       ( \ d → product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d)))
       ( \ d → hom2 A x y a f v d)
@@ -2179,7 +2179,7 @@ The fibers of a covariant fibration over a Segal type are discrete types.
   : is-discrete (C x)
   :=
     ( \ u v →
-    are-equiv-family-is-equiv-total
+    is-equiv-fiberwise-is-equiv-total
       ( C x)
       ( \ v' → (u = v'))
       ( hom (C x) u)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -1500,7 +1500,7 @@ domain are equivalent:
     ( (t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i])
     ( (t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i])
   :=
-    family-of-equivs-is-equiv-total
+    family-of-equiv-is-equiv-total
     ( B x)
     ( \ ii → ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ ii]))
     ( \ ii → ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) ii]))

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -662,7 +662,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
       ( Σ ( α' : nat-trans-components X A f g) ,
         ( x : X) → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) (α' x))
       ( (x : X) → Iso (A x) (is-segal-A x) (f x) (g x))
-      ( total-equiv-family-equiv
+      ( total-equiv-family-of-equiv
         ( nat-trans X A f g)
         ( \ α →
           ( is-iso-arrow
@@ -674,7 +674,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
           ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
             ( ev-components-nat-trans X A f g α x)))
         ( \ α → equiv-is-iso-pointwise-is-iso X A is-segal-A f g α))
-      ( total-equiv-pullback-is-equiv
+      ( equiv-total-pullback-is-equiv
         ( nat-trans X A f g)
         ( nat-trans-components X A f g)
         ( ev-components-nat-trans X A f g)


### PR DESCRIPTION
This is a housekeeping PR for 08-family-of-maps:
- Update many names to our current naming scheme. This of course created many ripples in the whole codebase. This resolves #117.
- Some code formatting and clean up.
- Restructured and added some prose to the section on fundamental theorem of identity types.

While I feel mostly confident that I chose good names, it might still be a good idea if someone like @fredrik-bakke could give it a glance to make sure I didn't do anything silly.