### PR TITLE
Total fibers are iterated fibers

### DIFF
--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -251,10 +251,9 @@ For any map `#!rzk f : A → B` the domain `#!rzk A` is equivalent to the sum of
 the fibers.
 
 ```rzk
-
-#def equiv-domain-sum-of-fibers
-  (A B : U)
-  (f : A → B)
+#def equiv-sum-of-fibers-domain
+  ( A B : U)
+  ( f : A → B)
   : Equiv A (Σ (b : B), fib A B f b)
   :=
     equiv-left-cancel
@@ -266,6 +265,19 @@ the fibers.
       ( \ a → Σ (b : B), f a = b)
       ( \ a → is-contr-based-paths B (f a)))
     ( fubini-Σ A B (\ a b → f a = b))
+```
+
+The inverse map is just the canonical projection to `A`.
+
+```rzk
+#def is-equiv-domain-sum-of-fibers
+  ( A B : U)
+  ( f : A → B)
+  : is-equiv (Σ (b : B), fib A B f b) A ( \ (_ , (a , _)) → a)
+  :=
+    second
+    ( inv-equiv A (Σ (b : B) , fib A B f b)
+      ( equiv-sum-of-fibers-domain A B f))
 ```
 
 ## Equivalence between fibers in equivalent domains

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -142,7 +142,7 @@ always do this (whether the square is homotopy-cartesian or not).
   :=
     (first ĉ', first-path-Σ A C (temp-uBDx-Σαγ ĉ') ĉ q̂)
 
-#def temp-uBDx-helper-IkCK-type uses (γ C')
+#def temp-uBDx-helper-type uses (γ C')
   ( ((s', s) , η) : has-section-family-over-map)
   ( a : A )
   ( (a', p) : fib A' A α a )
@@ -151,14 +151,14 @@ always do this (whether the square is homotopy-cartesian or not).
     Σ ( q̂ : temp-uBDx-Σαγ (a', s' a') = (a, s a)),
         ( induced-map-on-fibers-Σ (a, s a) ((a', s' a'), q̂) = (a', p))
 
-#def temp-uBDx-helper-IkCK uses (γ C')
+#def temp-uBDx-helper uses (γ C')
   ( ((s', s) , η) : has-section-family-over-map)
   : ( a : A) →
     ( (a', p) : fib A' A α a ) →
-    temp-uBDx-helper-IkCK-type ((s',s), η) a (a', p)
+    temp-uBDx-helper-type ((s',s), η) a (a', p)
   :=
     ind-fib A' A α
-    ( temp-uBDx-helper-IkCK-type ((s',s), η))
+    ( temp-uBDx-helper-type ((s',s), η))
     ( \ a' →
       ( eq-pair A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ) ,
         eq-pair
@@ -185,9 +185,9 @@ always do this (whether the square is homotopy-cartesian or not).
         ( \ (a', c') → (α a', γ a' c'))
         ( a, s a)))
   :=
-    ( \ (a', p) → ( (a', s' a'), first (temp-uBDx-helper-IkCK ((s',s),η) a (a',p))),
+    ( \ (a', p) → ( (a', s' a'), first (temp-uBDx-helper ((s',s),η) a (a',p))),
       ( induced-map-on-fibers-Σ (a, s a) ,
-        \ (a', p) → second (temp-uBDx-helper-IkCK ((s',s),η) a (a',p))))
+        \ (a', p) → second (temp-uBDx-helper ((s',s),η) a (a',p))))
 
 #def push-down-equiv-with-section uses (γ)
   ( ((s',s),η) : has-section-family-over-map)

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -900,10 +900,10 @@ that an equivalence of maps induces an equivalence of fibers at each base point.
   ( sums-of-fibers-to-domains-map-of-maps)
   ( second
     ( ( inv-equiv A' (Σ (a : A), fib A' A α a))
-      ( equiv-domain-sum-of-fibers A' A α)))
+      ( equiv-sum-of-fibers-domain A' A α)))
   ( second
     ( ( inv-equiv B' (Σ (b : B), fib B' B β b))
-      ( equiv-domain-sum-of-fibers B' B β)))
+      ( equiv-sum-of-fibers-domain B' B β)))
   ( is-equiv-s')
 
 #variable is-equiv-s : is-equiv A B s-c4XT

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -725,11 +725,10 @@ the fiber fibers.
   : fib-vertical-fibs-comm-square c (b,p)
   := ((t , q) , e)
 
-
 #def fib-vertical-fibs-tot-fib-comm-square uses (η β' γ')
-  : ( ((b,c),p) : relative-product A B β C γ)
-  → ( (t , h) : tot-fib-comm-square ((b,c),p))
-  → fib-vertical-fibs-comm-square c (b,p)
+  ( ((b,c),p) : relative-product A B β C γ)
+  ( (t , h) : tot-fib-comm-square ((b,c),p))
+  : fib-vertical-fibs-comm-square c (b,p)
   :=
     ( fib-vertical-fibs-helper-IkCK ((b,c),p) t)
     ( ind-fib T (relative-product A B β C γ)
@@ -740,25 +739,23 @@ the fiber fibers.
       ( t , h))
 ```
 
-Note that we could have defined this comparison map without the helper by a
-direct fiber induction, but this would leave it with worse definitional
-computation properties on which the rest of our construction relies.
+We could have defined this comparison map without the helper by a direct fiber
+induction, but in this case it would not commute definitionally with the
+canonical projection to `T`.
 
 ```rzk
-#def fib-vertical-fibs-tot-fib-comm-square' uses (η β' γ')
--- worse computation than fib-vertical-fibs-tot-fib-comm-square
-  : ( ((b,c),p) : relative-product A B β C γ)
-  → ( (t , h) : tot-fib-comm-square ((b,c),p))
-  → fib-vertical-fibs-comm-square c (b,p)
-  :=
-  ind-fib T (relative-product A B β C γ) (gap-map-comm-square)
-  ( \ ((b,c),p) _ → fib-vertical-fibs-comm-square c (b,p))
-  ( \ t → ((t , refl) , refl))
+#def compute-fib-vertical-fibs-tot-fib-comm-square uses (η β' γ')
+  ( bcp : relative-product A B β C γ)
+  ( (t , h) : tot-fib-comm-square bcp)
+  :
+  ( first (first (fib-vertical-fibs-tot-fib-comm-square bcp (t , h)))
+  = t)
+  := refl
 ```
 
 Finally, we show that these comparison maps are equivalences by summing over all
 of them. Indeed, by applications of `is-equiv-domain-sum-of-fibers`, the total
-sum of each is just equivalent to `T`.
+type on each side is just equivalent to `T`.
 
 ```rzk
 #def is-equiv-projection-fib-vertical-fibs-comm-square uses (η β')


### PR DESCRIPTION
- In a commutative square
```
T → B
↓   ↓
C → A
```
the total fibers (=fibers of the gap map) can be computed as iterated fibers between fibers.

- I have renamed the term `equiv-domain-sum-of-fibers` which according to our naming scheme should be called `equiv-sum-of-fibers-domain`. I have added a formula `is-equiv-domain-sum-of-fibers` for its inverse.