### PR TITLE
Functoriality properties of extension types

### DIFF
--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -224,6 +224,10 @@ The type of equivalences between types uses `#!rzk is-equiv` rather than
 
 ## Induction with section
 
+We have two variants of induction with section that say that if `f : A → B`
+has a section, it suffices to prove statements about `b : B` by doing so terms
+of the form `f a`.
+
 ```rzk
 #def ind-has-section
   ( A B : U)
@@ -234,6 +238,16 @@ The type of equivalences between types uses `#!rzk is-equiv` rather than
   ( b : B)
   : C b
   := transport B C (f (sec-f b)) b (ε-f b) (s (sec-f b))
+
+#def ind-has-section'
+  ( A B : U)
+  ( f : A → B)
+  ( ( sec-f , ε-f) : has-section A B f)
+  ( C : B → U)
+  ( c' : (b : B) → C (f (sec-f b)))
+  ( b : B)
+  : C b
+  := transport B C (f (sec-f b)) b (ε-f b) (c' b)
 ```
 
 It is convenient to have available the special case where `f` is an equivalence.
@@ -595,6 +609,16 @@ equivalent, so we content ourselves in showing that there is a logical
 biimplication between them.
 
 ```rzk
+#def is-equiv-retraction-section
+  ( A B : U)
+  ( s : A → B)
+  ( r : B → A)
+  ( η : (a : A) → r (s a) = a)
+  : is-equiv A A (\ a → r (s a))
+  :=
+    is-equiv-homotopy A A (\ a → r (s (a))) (identity A)
+      ( η) ( is-equiv-identity A)
+
 #def has-retraction-externalize
   ( A B : U)
   ( s : A → B)
@@ -602,8 +626,7 @@ biimplication between them.
   : has-external-retraction A B s
   :=
     ( ( A , r)
-    , is-equiv-homotopy A A (\ a → r (s (a))) (identity A)
-      ( η) ( is-equiv-identity A))
+    , is-equiv-retraction-section A B s r η)
 
 #def has-section-externalize
   ( B A' : U)
@@ -612,8 +635,7 @@ biimplication between them.
   : has-external-section B A' r
   :=
     ( ( A' , s)
-    , is-equiv-homotopy A' A' (\ a' → r (s (a'))) (identity A')
-      ( ε) ( is-equiv-identity A'))
+    , is-equiv-retraction-section A' B s r ε)
 
 #def has-retraction-internalize
   ( A B : U)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -224,9 +224,9 @@ The type of equivalences between types uses `#!rzk is-equiv` rather than
 
 ## Induction with section
 
-We have two variants of induction with section that say that if `f : A → B`
-has a section, it suffices to prove statements about `b : B` by doing so terms
-of the form `f a`.
+We have two variants of induction with section that say that if `f : A → B` has
+a section, it suffices to prove statements about `b : B` by doing so terms of
+the form `f a`.
 
 ```rzk
 #def ind-has-section

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -448,6 +448,27 @@ In fact, it suffices to assume that the left square has horizontal sections.
       ( F' a'') ( has-sections-F' a'')
       ( F (f' a'')) ( ihc'' a''))
 
+#def is-homotopy-cartesian-left-cancel-with-section'
+  ( (sec-f' , ε-f') : has-section A'' A' f')
+  ( has-sections-F'
+    : (a' : A')
+    → has-section (C'' (sec-f' a')) (C' (f' (sec-f' a'))) (F' (sec-f' a')))
+  ( ihc''
+    : is-homotopy-cartesian A'' C'' A C
+      ( comp A'' A' A f f')
+      ( \ a'' →
+        comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
+        ( F (f' a'')) (F' a'')))
+  : is-homotopy-cartesian A' C' A C f F
+  :=
+    ind-has-section' A'' A' f' (sec-f', ε-f')
+    ( \ a' → is-equiv (C' a') (C (f a')) (F a'))
+    ( \ a' →
+      is-equiv-left-cancel
+      ( C'' (sec-f' a')) (C' (f' (sec-f' a'))) (C (f (f' (sec-f' a'))))
+      ( F' (sec-f' a')) ( has-sections-F' a')
+      ( F (f' (sec-f' a'))) ( ihc'' (sec-f' a')))
+
 #end homotopy-cartesian-horizontal-calculus
 ```
 

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -704,7 +704,6 @@ We now assume extension extensionality and derive a few consequences.
 
 ```rzk
 #assume extext : ExtExt
-#assume naiveextext : NaiveExtExt
 ```
 
 In particular, extension extensionality implies that homotopies give rise to
@@ -740,7 +739,6 @@ arguments below.
   ( f : (t : ψ) → A t [ϕ t ↦ a t])
   : (t : ψ ) → A t
   := f
-
 ```
 
 The homotopy extension property has the following signature. We state this
@@ -1510,7 +1508,7 @@ types.
 The following special case of extensions from `BOT` is also useful.
 
 ```rzk
-#def has-section-extensions-BOT-has-section uses (naiveextext)
+#def has-section-extensions-BOT-has-section uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
@@ -1520,7 +1518,7 @@ The following special case of extensions from `BOT` is also useful.
   :=
     ( ( \ b t → first (has-section-f t) (b t))
     , \ b →
-      ( naiveextext I ψ (\ _ → BOT) B (\ _ → recBOT)
+      ( naiveextext-extext extext I ψ (\ _ → BOT) B (\ _ → recBOT)
         ( \ t → f t (first (has-section-f t) (b t)))
         ( \ t → b t)
         ( \ t → second (has-section-f t) (b t))))

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1484,3 +1484,51 @@ First we treat the case of extensions from `BOT`.
         ( \ t → b t)
         ( \ t → second (has-section-f t) (b t))))
 ```
+
+There is also a version for general extensions, but it is a little less pleasant
+to state.
+
+```rzk
+#section has-section-extensions-has-section
+
+#variable I : CUBE
+#variable ψ : I → TOPE
+#variable ϕ : ψ → TOPE
+#variables B A : ψ → U
+#variable r : (t : ψ) → B t → A t
+
+#variable has-section-r : (t : ψ) → has-section (B t) (A t) (r t)
+
+#def s-uSdw uses (r)
+  : (t : ψ) → A t → B t
+  := \ t → first (has-section-r t)
+
+#def ε-uSdw uses (B)
+  ( t : ψ)
+  ( a : A t)
+  : r t (s-uSdw t a) = a
+  := second (has-section-r t) a
+
+#def has-section-extensions-has-section
+  uses (extext has-section-r)
+  ( a : (t : ϕ) → A t)
+  : has-section
+    ( (t : ψ) → B t [ϕ t ↦ s-uSdw t (a t)])
+    ( (t : ψ) → A t [ϕ t ↦ r t (s-uSdw t (a t))])
+    ( \ b t → r t (b t))
+  :=
+    has-section-internalize
+    ( (t : ψ) → B t [ϕ t ↦ s-uSdw t (a t)])
+    ( (t : ψ) → A t [ϕ t ↦ r t (s-uSdw t (a t))])
+    ( \ b t → r t (b t))
+    ( ( ( (t : ψ) → A t [ϕ t ↦ a t])
+      , \ a' t → s-uSdw t (a' t))
+    , ( is-equiv-extensions-is-equiv I ψ ϕ A A
+        ( \ t x → r t (s-uSdw t (x)))
+        ( \ t →
+           is-equiv-retraction-section (A t) (B t)
+           ( s-uSdw t) (r t) (ε-uSdw t))
+        ( a)))
+
+#end has-section-extensions-has-section
+```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1049,7 +1049,6 @@ We now assume extension extensionality and derive a few consequences.
 
 ```rzk
 #assume extext : ExtExt
-#assume naiveextext : NaiveExtExt
 ```
 
 ### Pointwise homotopy extension types

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1217,7 +1217,9 @@ The converse is of course trivial.
 
 ## Functoriality of extension types
 
-For simplicity, we only consider extesions of `#!rzk BOT`.
+We aim to show that special properties of a map of types `f : A → B`, such as
+being an equivalence or having a retraction carry over to the induced map on
+extension types.
 
 For each map `f : A → B` and each shape inclusion `ϕ ⊂ ψ`, we have a commutative
 square.
@@ -1262,11 +1264,15 @@ We can view it as a map of maps either vertically or horizontally.
     , \ _ → refl)
 ```
 
+### Equivalences induce equivalences of extension types
+
+We start by treating the case of extensions from the empty shape `BOT`.
+
 It follows from extension extensionality that if `f : A → B` is an equivalence,
 then so is the map of maps `map-of-restriction-maps`.
 
 ```rzk
-#def is-equiv-extension-is-equiv-family uses (extext)
+#def is-equiv-extensions-BOT-is-equiv-family uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
@@ -1290,7 +1296,7 @@ then so is the map of maps `map-of-restriction-maps`.
               ( b)
               ( \ t → second (second (is-equiv-f t)) (b t)))))
 
-#def equiv-extension-equiv-family uses (extext)
+#def equiv-extensions-BOT-equiv-family uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
@@ -1298,7 +1304,7 @@ then so is the map of maps `map-of-restriction-maps`.
   : Equiv ((t : ψ) → A t) ((t : ψ) → B t)
   :=
     ( ( \ a t → first ( famequiv t) (a t))
-    , is-equiv-extension-is-equiv-family I ψ A B
+    , is-equiv-extensions-BOT-is-equiv-family I ψ A B
       ( \ t → first (famequiv t))
       ( \ t → second (famequiv t)))
 
@@ -1313,21 +1319,160 @@ then so is the map of maps `map-of-restriction-maps`.
     ( (t : ψ) → B t) ( (t : ϕ) → B t)  (\ b t → b t)
   :=
     ( map-of-restriction-maps I ψ ϕ A B (\ t → first (famequiv t))
-    , ( second (equiv-extension-equiv-family I ψ A B famequiv)
-      , second ( equiv-extension-equiv-family I
+    , ( second (equiv-extensions-BOT-equiv-family I ψ A B famequiv)
+      , second ( equiv-extensions-BOT-equiv-family I
                  (\ t → ϕ t) (\ t → A t) (\ t → B t) (\ t → famequiv t))))
+```
+
+Now we use the result for extensions of `BOT` to bootstrap to arbitrary
+extensions. We show that an equivalence `f : A → B` induces an equivalence of
+all extension types, not just those extended from `BOT`.
+
+```rzk
+#def is-equiv-extensions-are-equiv uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A B : ψ → U)
+  ( f : (t : ψ) → A t → B t)
+  ( are-equiv-f : (t : ψ) → is-equiv (A t) (B t) (f t))
+  : ( a : (t : ϕ) → A t)
+  → is-equiv
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ψ) → B t [ϕ t ↦ f t (a t)])
+    ( \ a' t → f t (a' t))
+  :=
+    is-homotopy-cartesian-is-horizontal-equiv
+    ( (t : ϕ) → A t)
+    ( \ a → (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ϕ) → B t)
+    ( \ b → (t : ψ) → B t [ϕ t ↦ b t])
+    ( \ a t → f t (a t))
+    ( \ _ a' t → f t (a' t))
+    ( is-equiv-extensions-BOT-is-equiv-family
+      ( I) (\ t → ϕ t) (\ t → A t) (\ t → B t) ( \ t → f t)
+      ( \ (t : ϕ) → are-equiv-f t))
+    ( is-equiv-Equiv-is-equiv'
+        ( (t : ψ) → A t) ((t : ψ) → B t) (\ a' t → f t (a' t))
+        ( Σ (a : (t : ϕ) → A t) , ((t : ψ) → A t [ϕ t ↦ a t]))
+        ( Σ (b : (t : ϕ) → B t) , ((t : ψ) → B t [ϕ t ↦ b t]))
+        ( \ (a , a') → ( \ t → f t (a t) , \ t → f t (a' t)))
+      ( cofibration-composition-functorial
+        I ψ ϕ (\ _ → BOT) A B f (\ _ → recBOT))
+      ( is-equiv-extensions-BOT-is-equiv-family I ψ A B f are-equiv-f))
+
+#def equiv-extensions-equiv-family uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A B : ψ → U)
+  ( equivs-A-B : (t : ψ) → Equiv (A t) (B t))
+  ( a : (t : ϕ) → A t)
+  : Equiv
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ψ) → B t [ϕ t ↦ first (equivs-A-B t) (a t)])
+  :=
+  ( ( \ a' t → first (equivs-A-B t) (a' t))
+  , ( is-equiv-extensions-are-equiv I ψ ϕ A B
+      ( \ t → first (equivs-A-B t))
+      ( \ t → second (equivs-A-B t))
+      ( a)))
+```
+
+### Retracts induce retracts of extension types
+
+We show that if `f : A → B` has a retraction, then the same is true for the
+induced map on extension types. We reduce this to the case of equivalences by
+working with external retractions.
+
+```rzk
+#section has-retraction-extensions-have-retraction
+
+#variable I : CUBE
+#variable ψ : I → TOPE
+#variable ϕ : ψ → TOPE
+#variables A B : ψ → U
+#variable s : (t : ψ) → A t → B t
+
+#variable have-retraction-s : (t : ψ) → has-retraction (A t) (B t) (s t)
+
+#def A'-uSdw
+  : ψ → U
+  :=
+  \ t →
+    first
+    ( first
+      ( has-retraction-externalize (A t) (B t) (s t) (have-retraction-s t)))
+
+#def r-uSdw
+  (t : ψ)
+  : B t → A t
+  :=
+    second
+    ( first
+      ( has-retraction-externalize (A t) (B t) (s t) (have-retraction-s t)))
+
+#def is-sec-rec-f-uSdw
+  (t : ψ)
+  : is-section-retraction-pair (A t) (B t) (A'-uSdw t) (s t) (r-uSdw t)
+  :=
+    second
+    ( has-retraction-externalize (A t) (B t) (s t) (have-retraction-s t))
+
+#def has-retraction-extensions-have-retraction
+  uses (extext have-retraction-s)
+  ( a : (t : ϕ) → A t)
+  : has-retraction
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( \ a' t → s t (a' t))
+  :=
+    has-retraction-internalize
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( \ a' t → s t (a' t))
+    ( ( (t : ψ) → A'-uSdw t [ϕ t ↦ r-uSdw t (s t (a t))]
+      , \ b' t → r-uSdw t (b' t))
+    , ( is-equiv-extensions-are-equiv I ψ ϕ A A'-uSdw
+        ( \ t a₀ → r-uSdw t (s t (a₀)))
+        ( \ t → is-sec-rec-f-uSdw t)
+        ( a)))
+
+#end has-retraction-extensions-have-retraction
+```
+
+We summarize by saying that retracts of types induce retracts of extension
+types.
+
+```rzk
+#def is-retract-of-extensions-are-retract-of uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A B : ψ → U)
+  ( are-retract-A-of-B : (t : ψ) → is-retract-of (A t) (B t))
+  ( a : (t : ϕ) → A t)
+  : is-retract-of
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ψ) → B t [ϕ t ↦ first (are-retract-A-of-B t) (a t)])
+  :=
+  ( ( \ a' t → first (are-retract-A-of-B t) (a' t))
+  , ( has-retraction-extensions-have-retraction I ψ ϕ A B
+      ( \ t → first (are-retract-A-of-B t))
+      ( \ t → second (are-retract-A-of-B t))
+      ( a)))
 ```
 
 Similarly, a fiberwise section of a map `(t : ψ) → A t → B t` induces a section
 on extension types.
 
 ```rzk
-#def has-section-extension-has-section-family uses (naiveextext)
+#def has-section-extensions-BOT-has-section-family uses (naiveextext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
   ( f : ( t : ψ) → A t → B t)
-  ( has-fiberwise-section-f : (t : ψ) → has-section (A t ) (B t) (f t))
+  ( has-fiberwise-section-f : (t : ψ) → has-section (A t) (B t) (f t))
   : has-section ((t : ψ) → A t) ((t : ψ) → B t) ( \ a t → f t (a t))
   :=
     ( ( \ b t → first (has-fiberwise-section-f t) (b t))

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1386,41 +1386,32 @@ induced map on extension types. We reduce this to the case of equivalences by
 working with external retractions.
 
 ```rzk
-#section has-retraction-extensions-has-retraction
+#section section-retraction-extensions
 
 #variable I : CUBE
 #variable ψ : I → TOPE
 #variable ϕ : ψ → TOPE
 #variables A B : ψ → U
+
 #variable s : (t : ψ) → A t → B t
+#variable r : (t : ψ) → B t → A t
+#variable η : (t : ψ) → (a : A t) → r t (s t a) = a
 
-#variable has-retraction-s : (t : ψ) → has-retraction (A t) (B t) (s t)
-
-#def A'-uSdw
-  : ψ → U
+#def is-sec-rec-extensions-sec-rec uses (extext)
+  ( a : (t : ϕ) → A t)
+  : is-section-retraction-pair
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( (t : ψ) → A t [ϕ t ↦ r t(s t(a t))])
+    ( \ a' t → s t (a' t))
+    ( \ b' t → r t (b' t))
   :=
-  \ t →
-    first
-    ( first
-      ( has-retraction-externalize (A t) (B t) (s t) (has-retraction-s t)))
+    is-equiv-extensions-is-equiv I ψ ϕ A A
+    ( \ t a₀ → r t (s t (a₀)))
+    ( \ t → is-equiv-retraction-section (A t) (B t) (s t) (r t) (η t))
+    ( a)
 
-#def r-uSdw
-  (t : ψ)
-  : B t → A'-uSdw t
-  :=
-    second
-    ( first
-      ( has-retraction-externalize (A t) (B t) (s t) (has-retraction-s t)))
-
-#def is-sec-rec-s-r-uSdw
-  (t : ψ)
-  : is-section-retraction-pair (A t) (B t) (A'-uSdw t) (s t) (r-uSdw t)
-  :=
-    second
-    ( has-retraction-externalize (A t) (B t) (s t) (has-retraction-s t))
-
-#def has-retraction-extensions-has-retraction
-  uses (extext has-retraction-s)
+#def has-retraction-extensions-has-retraction' uses (extext η)
   ( a : (t : ϕ) → A t)
   : has-retraction
     ( (t : ψ) → A t [ϕ t ↦ a t])
@@ -1431,14 +1422,67 @@ working with external retractions.
     ( (t : ψ) → A t [ϕ t ↦ a t])
     ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
     ( \ a' t → s t (a' t))
-    ( ( (t : ψ) → A'-uSdw t [ϕ t ↦ r-uSdw t (s t (a t))]
-      , \ b' t → r-uSdw t (b' t))
-    , ( is-equiv-extensions-is-equiv I ψ ϕ A A'-uSdw
-        ( \ t a₀ → r-uSdw t (s t (a₀)))
-        ( \ t → is-sec-rec-s-r-uSdw t)
-        ( a)))
+    ( ( (t : ψ) → A t [ϕ t ↦ r t (s t (a t))]
+      , \ b' t → r t (b' t))
+    , is-sec-rec-extensions-sec-rec a)
 
-#end has-retraction-extensions-has-retraction
+#def has-section-extensions-has-section' uses (extext η)
+  ( a : (t : ϕ) → A t)
+  : has-section
+    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( (t : ψ) → A t [ϕ t ↦ r t (s t (a t))])
+    ( \ b t → r t (b t))
+  :=
+    has-section-internalize
+    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( (t : ψ) → A t [ϕ t ↦ r t (s t (a t))])
+    ( \ b' t → r t (b' t))
+    ( ( ( (t : ψ) → A t [ϕ t ↦ a t])
+      , ( \ a' t → s t (a' t)))
+    , is-sec-rec-extensions-sec-rec a)
+
+#end section-retraction-extensions
+```
+
+It is convenient to have uncurried versions.
+
+```rzk
+#def has-retraction-extensions-has-retraction uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A B : ψ → U)
+  ( s : (t : ψ) → A t → B t)
+  ( has-retraction-s : (t : ψ) → has-retraction (A t) (B t) (s t))
+  ( a : (t : ϕ) → A t)
+  : has-retraction
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( \ a' t → s t (a' t))
+  :=
+    has-retraction-extensions-has-retraction' I ψ ϕ A B s
+    ( \ t → first (has-retraction-s t))
+    ( \ t → second (has-retraction-s t))
+    ( a)
+
+#def has-section-extensions-has-section uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( B A : ψ → U)
+  ( r : (t : ψ) → B t → A t)
+  ( has-section-r : (t : ψ) → has-section (B t) (A t) (r t))
+  ( a : (t : ϕ) → A t)
+  : has-section
+    ( (t : ψ) → B t [ϕ t ↦ (first (has-section-r t)) (a t)])
+    ( (t : ψ) → A t [ϕ t ↦ r t (first (has-section-r t) (a t))])
+    ( \ b t → r t (b t))
+  :=
+    has-section-extensions-has-section' I ψ ϕ A B
+    ( \ t → first (has-section-r t))
+    ( r)
+    ( \ t → second (has-section-r t))
+    ( a)
 ```
 
 We summarize by saying that retracts of types induce retracts of extension
@@ -1463,10 +1507,7 @@ types.
       ( a)))
 ```
 
-Similarly, a fiberwise section of a map `(t : ψ) → A t → B t` induces a section
-on extension types.
-
-First we treat the case of extensions from `BOT`.
+The following special case of extensions from `BOT` is also useful.
 
 ```rzk
 #def has-section-extensions-BOT-has-section uses (naiveextext)
@@ -1483,52 +1524,4 @@ First we treat the case of extensions from `BOT`.
         ( \ t → f t (first (has-section-f t) (b t)))
         ( \ t → b t)
         ( \ t → second (has-section-f t) (b t))))
-```
-
-There is also a version for general extensions, but it is a little less pleasant
-to state.
-
-```rzk
-#section has-section-extensions-has-section
-
-#variable I : CUBE
-#variable ψ : I → TOPE
-#variable ϕ : ψ → TOPE
-#variables B A : ψ → U
-#variable r : (t : ψ) → B t → A t
-
-#variable has-section-r : (t : ψ) → has-section (B t) (A t) (r t)
-
-#def s-uSdw uses (r)
-  : (t : ψ) → A t → B t
-  := \ t → first (has-section-r t)
-
-#def ε-uSdw uses (B)
-  ( t : ψ)
-  ( a : A t)
-  : r t (s-uSdw t a) = a
-  := second (has-section-r t) a
-
-#def has-section-extensions-has-section
-  uses (extext has-section-r)
-  ( a : (t : ϕ) → A t)
-  : has-section
-    ( (t : ψ) → B t [ϕ t ↦ s-uSdw t (a t)])
-    ( (t : ψ) → A t [ϕ t ↦ r t (s-uSdw t (a t))])
-    ( \ b t → r t (b t))
-  :=
-    has-section-internalize
-    ( (t : ψ) → B t [ϕ t ↦ s-uSdw t (a t)])
-    ( (t : ψ) → A t [ϕ t ↦ r t (s-uSdw t (a t))])
-    ( \ b t → r t (b t))
-    ( ( ( (t : ψ) → A t [ϕ t ↦ a t])
-      , \ a' t → s-uSdw t (a' t))
-    , ( is-equiv-extensions-is-equiv I ψ ϕ A A
-        ( \ t x → r t (s-uSdw t (x)))
-        ( \ t →
-           is-equiv-retraction-section (A t) (B t)
-           ( s-uSdw t) (r t) (ε-uSdw t))
-        ( a)))
-
-#end has-section-extensions-has-section
 ```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1272,7 +1272,7 @@ It follows from extension extensionality that if `f : A → B` is an equivalence
 then so is the map of maps `map-of-restriction-maps`.
 
 ```rzk
-#def is-equiv-extensions-BOT-is-equiv-family uses (extext)
+#def is-equiv-extensions-BOT-is-equiv uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
@@ -1296,7 +1296,7 @@ then so is the map of maps `map-of-restriction-maps`.
               ( b)
               ( \ t → second (second (is-equiv-f t)) (b t)))))
 
-#def equiv-extensions-BOT-equiv-family uses (extext)
+#def equiv-extensions-BOT-equiv uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
@@ -1304,11 +1304,11 @@ then so is the map of maps `map-of-restriction-maps`.
   : Equiv ((t : ψ) → A t) ((t : ψ) → B t)
   :=
     ( ( \ a t → first ( famequiv t) (a t))
-    , is-equiv-extensions-BOT-is-equiv-family I ψ A B
+    , is-equiv-extensions-BOT-is-equiv I ψ A B
       ( \ t → first (famequiv t))
       ( \ t → second (famequiv t)))
 
-#def equiv-of-restriction-maps-equiv-family uses (extext)
+#def equiv-of-restriction-maps-equiv uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
@@ -1319,8 +1319,8 @@ then so is the map of maps `map-of-restriction-maps`.
     ( (t : ψ) → B t) ( (t : ϕ) → B t)  (\ b t → b t)
   :=
     ( map-of-restriction-maps I ψ ϕ A B (\ t → first (famequiv t))
-    , ( second (equiv-extensions-BOT-equiv-family I ψ A B famequiv)
-      , second ( equiv-extensions-BOT-equiv-family I
+    , ( second (equiv-extensions-BOT-equiv I ψ A B famequiv)
+      , second ( equiv-extensions-BOT-equiv I
                  (\ t → ϕ t) (\ t → A t) (\ t → B t) (\ t → famequiv t))))
 ```
 
@@ -1329,13 +1329,13 @@ extensions. We show that an equivalence `f : A → B` induces an equivalence of
 all extension types, not just those extended from `BOT`.
 
 ```rzk
-#def is-equiv-extensions-are-equiv uses (extext)
+#def is-equiv-extensions-is-equiv uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A B : ψ → U)
   ( f : (t : ψ) → A t → B t)
-  ( are-equiv-f : (t : ψ) → is-equiv (A t) (B t) (f t))
+  ( is-equiv-f : (t : ψ) → is-equiv (A t) (B t) (f t))
   : ( a : (t : ϕ) → A t)
   → is-equiv
     ( (t : ψ) → A t [ϕ t ↦ a t])
@@ -1349,9 +1349,9 @@ all extension types, not just those extended from `BOT`.
     ( \ b → (t : ψ) → B t [ϕ t ↦ b t])
     ( \ a t → f t (a t))
     ( \ _ a' t → f t (a' t))
-    ( is-equiv-extensions-BOT-is-equiv-family
+    ( is-equiv-extensions-BOT-is-equiv
       ( I) (\ t → ϕ t) (\ t → A t) (\ t → B t) ( \ t → f t)
-      ( \ (t : ϕ) → are-equiv-f t))
+      ( \ (t : ϕ) → is-equiv-f t))
     ( is-equiv-Equiv-is-equiv'
         ( (t : ψ) → A t) ((t : ψ) → B t) (\ a' t → f t (a' t))
         ( Σ (a : (t : ϕ) → A t) , ((t : ψ) → A t [ϕ t ↦ a t]))
@@ -1359,9 +1359,9 @@ all extension types, not just those extended from `BOT`.
         ( \ (a , a') → ( \ t → f t (a t) , \ t → f t (a' t)))
       ( cofibration-composition-functorial
         I ψ ϕ (\ _ → BOT) A B f (\ _ → recBOT))
-      ( is-equiv-extensions-BOT-is-equiv-family I ψ A B f are-equiv-f))
+      ( is-equiv-extensions-BOT-is-equiv I ψ A B f is-equiv-f))
 
-#def equiv-extensions-equiv-family uses (extext)
+#def equiv-extensions-equiv uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
@@ -1373,7 +1373,7 @@ all extension types, not just those extended from `BOT`.
     ( (t : ψ) → B t [ϕ t ↦ first (equivs-A-B t) (a t)])
   :=
   ( ( \ a' t → first (equivs-A-B t) (a' t))
-  , ( is-equiv-extensions-are-equiv I ψ ϕ A B
+  , ( is-equiv-extensions-is-equiv I ψ ϕ A B
       ( \ t → first (equivs-A-B t))
       ( \ t → second (equivs-A-B t))
       ( a)))
@@ -1386,7 +1386,7 @@ induced map on extension types. We reduce this to the case of equivalences by
 working with external retractions.
 
 ```rzk
-#section has-retraction-extensions-have-retraction
+#section has-retraction-extensions-has-retraction
 
 #variable I : CUBE
 #variable ψ : I → TOPE
@@ -1394,7 +1394,7 @@ working with external retractions.
 #variables A B : ψ → U
 #variable s : (t : ψ) → A t → B t
 
-#variable have-retraction-s : (t : ψ) → has-retraction (A t) (B t) (s t)
+#variable has-retraction-s : (t : ψ) → has-retraction (A t) (B t) (s t)
 
 #def A'-uSdw
   : ψ → U
@@ -1402,25 +1402,25 @@ working with external retractions.
   \ t →
     first
     ( first
-      ( has-retraction-externalize (A t) (B t) (s t) (have-retraction-s t)))
+      ( has-retraction-externalize (A t) (B t) (s t) (has-retraction-s t)))
 
 #def r-uSdw
   (t : ψ)
-  : B t → A t
+  : B t → A'-uSdw t
   :=
     second
     ( first
-      ( has-retraction-externalize (A t) (B t) (s t) (have-retraction-s t)))
+      ( has-retraction-externalize (A t) (B t) (s t) (has-retraction-s t)))
 
-#def is-sec-rec-f-uSdw
+#def is-sec-rec-s-r-uSdw
   (t : ψ)
   : is-section-retraction-pair (A t) (B t) (A'-uSdw t) (s t) (r-uSdw t)
   :=
     second
-    ( has-retraction-externalize (A t) (B t) (s t) (have-retraction-s t))
+    ( has-retraction-externalize (A t) (B t) (s t) (has-retraction-s t))
 
-#def has-retraction-extensions-have-retraction
-  uses (extext have-retraction-s)
+#def has-retraction-extensions-has-retraction
+  uses (extext has-retraction-s)
   ( a : (t : ϕ) → A t)
   : has-retraction
     ( (t : ψ) → A t [ϕ t ↦ a t])
@@ -1433,12 +1433,12 @@ working with external retractions.
     ( \ a' t → s t (a' t))
     ( ( (t : ψ) → A'-uSdw t [ϕ t ↦ r-uSdw t (s t (a t))]
       , \ b' t → r-uSdw t (b' t))
-    , ( is-equiv-extensions-are-equiv I ψ ϕ A A'-uSdw
+    , ( is-equiv-extensions-is-equiv I ψ ϕ A A'-uSdw
         ( \ t a₀ → r-uSdw t (s t (a₀)))
-        ( \ t → is-sec-rec-f-uSdw t)
+        ( \ t → is-sec-rec-s-r-uSdw t)
         ( a)))
 
-#end has-retraction-extensions-have-retraction
+#end has-retraction-extensions-has-retraction
 ```
 
 We summarize by saying that retracts of types induce retracts of extension
@@ -1457,7 +1457,7 @@ types.
     ( (t : ψ) → B t [ϕ t ↦ first (are-retract-A-of-B t) (a t)])
   :=
   ( ( \ a' t → first (are-retract-A-of-B t) (a' t))
-  , ( has-retraction-extensions-have-retraction I ψ ϕ A B
+  , ( has-retraction-extensions-has-retraction I ψ ϕ A B
       ( \ t → first (are-retract-A-of-B t))
       ( \ t → second (are-retract-A-of-B t))
       ( a)))
@@ -1466,19 +1466,21 @@ types.
 Similarly, a fiberwise section of a map `(t : ψ) → A t → B t` induces a section
 on extension types.
 
+First we treat the case of extensions from `BOT`.
+
 ```rzk
-#def has-section-extensions-BOT-has-section-family uses (naiveextext)
+#def has-section-extensions-BOT-has-section uses (naiveextext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
   ( f : ( t : ψ) → A t → B t)
-  ( has-fiberwise-section-f : (t : ψ) → has-section (A t) (B t) (f t))
+  ( has-section-f : (t : ψ) → has-section (A t) (B t) (f t))
   : has-section ((t : ψ) → A t) ((t : ψ) → B t) ( \ a t → f t (a t))
   :=
-    ( ( \ b t → first (has-fiberwise-section-f t) (b t))
+    ( ( \ b t → first (has-section-f t) (b t))
     , \ b →
       ( naiveextext I ψ (\ _ → BOT) B (\ _ → recBOT)
-        ( \ t → f t (first (has-fiberwise-section-f t) (b t)))
+        ( \ t → f t (first (has-section-f t) (b t)))
         ( \ t → b t)
-        ( \ t → second (has-fiberwise-section-f t) (b t))))
+        ( \ t → second (has-section-f t) (b t))))
 ```

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -505,24 +505,8 @@ Every equivalence `α : A' → A` is right orthogonal to `ϕ ⊂ ψ`.
   ( is-equiv-α : is-equiv A' A α)
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=
-    is-homotopy-cartesian-is-horizontal-equiv
-      ( ϕ → A') (\ σ' → (t : ψ) → A' [ϕ t ↦ σ' t])
-      ( ϕ → A) (\ σ → (t : ψ) → A [ϕ t ↦ σ t])
-      ( \ σ' t → α (σ' t))
-      ( \ _ τ' t → α (τ' t))
-      ( second
-        ( equiv-extensions-BOT-equiv extext I ( \ t → ϕ t)
-          ( \ _ → A') ( \ _ → A) ( \ _ → (α , is-equiv-α))))
-     ( is-equiv-Equiv-is-equiv'
-         ( ψ → A') ( ψ → A) ( \ τ' t → α (τ' t))
-         ( Σ (σ' : ϕ → A') , (t : ψ) → A' [ϕ t ↦ σ' t])
-         ( Σ (σ : ϕ → A) , (t : ψ) → A [ϕ t ↦ σ t])
-         ( \ (σ' , τ') → ( \ t → α (σ' t) , \ t → α (τ' t)))
-       ( cofibration-composition-functorial I ψ ϕ ( \ _ → BOT)
-           ( \ _ → A') ( \ _ → A) ( \ _ → α) ( \ _ → recBOT))
-       ( second
-         ( equiv-extensions-BOT-equiv extext I ( \ t → ψ t)
-           ( \ _ → A') ( \ _ → A) ( \ _ → (α , is-equiv-α)))))
+    is-equiv-extensions-is-equiv extext I ψ ϕ
+    ( \ _ → A') ( \  _ → A) ( \ _ → α) ( \ _ → is-equiv-α)
 ```
 
 Right orthogonality is closed under homotopy.
@@ -586,14 +570,14 @@ One can always cancel right orthogonal maps from the right.
      ( is-orth-ψ-ϕ-αα' σ'')
 ```
 
-### Left cancellation with section (weak version)
+### Left cancellation with section
 
 If the map `α' : A'' → A'` has a section, then we can also cancel it from the
 right (whether it is right orthogonal or not.)
 
 ```rzk
 #def is-right-orthogonal-left-cancel-with-section-to-shape
-      uses (extext is-orth-ψ-ϕ-αα')
+  uses (extext is-orth-ψ-ϕ-αα')
   ( has-section-α' : has-section A'' A' α')
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -399,7 +399,7 @@ Every equivalence `α : A' → A` is right orthogonal to `ϕ ⊂ ψ`.
       ( \ σ' t → α (σ' t))
       ( \ _ τ' t → α (τ' t))
       ( second
-        ( equiv-extension-equiv-family extext I ( \ t → ϕ t)
+        ( equiv-extensions-BOT-equiv-family extext I ( \ t → ϕ t)
           ( \ _ → A') ( \ _ → A) ( \ _ → (α , is-equiv-α))))
      ( is-equiv-Equiv-is-equiv'
          ( ψ → A') ( ψ → A) ( \ τ' t → α (τ' t))
@@ -409,7 +409,7 @@ Every equivalence `α : A' → A` is right orthogonal to `ϕ ⊂ ψ`.
        ( cofibration-composition-functorial I ψ ϕ ( \ _ → BOT)
            ( \ _ → A') ( \ _ → A) ( \ _ → α) ( \ _ → recBOT))
        ( second
-         ( equiv-extension-equiv-family extext I ( \ t → ψ t)
+         ( equiv-extensions-BOT-equiv-family extext I ( \ t → ψ t)
            ( \ _ → A') ( \ _ → A) ( \ _ → (α , is-equiv-α)))))
 ```
 
@@ -488,12 +488,15 @@ This should hold even without assuming `is-orth-ψ-ϕ-α'`.
         ( ϕ → A ) ( \ σ → (t : ψ) → A [ϕ t ↦ σ t])
         ( \ σ'' t → α' (σ'' t)) ( \ _ τ'' x → α' (τ'' x) )
         ( \ σ' t → α (σ' t)) ( \ _ τ' x → α (τ' x) )
-    ( has-section-extension-has-section-family naiveextext I (\ t → ϕ t)
+    ( has-section-extensions-BOT-has-section-family naiveextext I (\ t → ϕ t)
           ( \ _ → A'') (\ _ → A') (\ _ → α')
       ( \ _ → has-section-α'))
     ( is-orth-ψ-ϕ-α')
     ( is-orth-ψ-ϕ-αα')
 ```
+
+
+
 
 ### Stability under pullback
 

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -456,6 +456,8 @@ Right orthogonality is closed under homotopy.
 
 ### Right cancellation
 
+One can always cancel right orthogonal maps from the right.
+
 ```rzk
 #def is-right-orthogonal-right-cancel-to-shape
   uses (is-orth-ψ-ϕ-α is-orth-ψ-ϕ-αα')
@@ -474,24 +476,27 @@ Right orthogonality is closed under homotopy.
 
 ### Left cancellation with section (weak version)
 
-This should hold even without assuming `is-orth-ψ-ϕ-α'`.
+If the map `α' : A'' → A'` has a section, then we can also cancel it from the
+right (whether it is right orthogonal or not.)
 
 ```rzk
-#def is-right-orthogonal-weak-left-cancel-with-section-to-shape
-      uses (naiveextext is-orth-ψ-ϕ-α' is-orth-ψ-ϕ-αα')
+#def is-right-orthogonal-left-cancel-with-section-to-shape
+      uses (extext is-orth-ψ-ϕ-αα')
   ( has-section-α' : has-section A'' A' α')
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=
-    is-homotopy-cartesian-left-cancel-with-lower-section
+    is-homotopy-cartesian-left-cancel-with-section'
         ( ϕ → A'' ) ( \ σ'' → (t : ψ) → A'' [ϕ t ↦ σ'' t])
         ( ϕ → A' ) ( \ σ' → (t : ψ) → A' [ϕ t ↦ σ' t])
         ( ϕ → A ) ( \ σ → (t : ψ) → A [ϕ t ↦ σ t])
         ( \ σ'' t → α' (σ'' t)) ( \ _ τ'' x → α' (τ'' x) )
         ( \ σ' t → α (σ' t)) ( \ _ τ' x → α (τ' x) )
-    ( has-section-extensions-BOT-has-section naiveextext I (\ t → ϕ t)
+    ( has-section-extensions-BOT-has-section extext I (\ t → ϕ t)
           ( \ _ → A'') (\ _ → A') (\ _ → α')
       ( \ _ → has-section-α'))
-    ( is-orth-ψ-ϕ-α')
+    ( has-section-extensions-has-section extext I ψ ϕ
+          ( \ _ → A'') (\ _ → A') (\ _ → α')
+      ( \ _ → has-section-α'))
     ( is-orth-ψ-ϕ-αα')
 ```
 
@@ -680,14 +685,13 @@ orthogonal to `ϕ ⊂ ψ`, then so is the other.
         ( is-orth-ψ-ϕ-β)))
 
 #def is-right-orthogonal-equiv-to-shape'
-  uses (funext extext naiveextext)
+  uses (funext extext)
   ( (((s', s), η), (is-equiv-s', is-equiv-s)) : Equiv-of-maps A' A α B' B β)
   ( is-orth-ψ-ϕ-α : is-right-orthogonal-to-shape I ψ ϕ A' A α)
   : is-right-orthogonal-to-shape I ψ ϕ B' B β
   :=
-    is-right-orthogonal-weak-left-cancel-with-section-to-shape
+    is-right-orthogonal-left-cancel-with-section-to-shape
           I ψ ϕ A' B' B s' β
-    ( is-right-orthogonal-is-equiv-to-shape I ψ ϕ A' B' s' is-equiv-s')
     ( is-right-orthogonal-homotopy-to-shape I ψ ϕ A' B
       ( \ a' → s (α a')) ( \ a' → β (s' a'))
       ( rev-homotopy A' B ( \ a' → β (s' a')) ( \ a' → s (α a')) ( η))

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -728,8 +728,7 @@ equivalence.
 ```rzk
 #def is-local-type
   : U
-  :=
-    is-equiv (ψ → A) (ϕ → A) ( \ τ t → τ t)
+  := is-equiv (ψ → A) (ϕ → A) ( \ τ t → τ t)
 ```
 
 We can ask that the terminal map `A → Unit` is right orthogonal to `ϕ ⊂ ψ`.
@@ -737,8 +736,7 @@ We can ask that the terminal map `A → Unit` is right orthogonal to `ϕ ⊂ ψ`
 ```rzk
 #def is-right-orthogonal-terminal-map
   : U
-  :=
-    is-right-orthogonal-to-shape I ψ ϕ A Unit (terminal-map A)
+  := is-right-orthogonal-to-shape I ψ ϕ A Unit (terminal-map A)
 ```
 
 ### Unique extensions types are local types

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -399,7 +399,7 @@ Every equivalence `α : A' → A` is right orthogonal to `ϕ ⊂ ψ`.
       ( \ σ' t → α (σ' t))
       ( \ _ τ' t → α (τ' t))
       ( second
-        ( equiv-extensions-BOT-equiv-family extext I ( \ t → ϕ t)
+        ( equiv-extensions-BOT-equiv extext I ( \ t → ϕ t)
           ( \ _ → A') ( \ _ → A) ( \ _ → (α , is-equiv-α))))
      ( is-equiv-Equiv-is-equiv'
          ( ψ → A') ( ψ → A) ( \ τ' t → α (τ' t))
@@ -409,7 +409,7 @@ Every equivalence `α : A' → A` is right orthogonal to `ϕ ⊂ ψ`.
        ( cofibration-composition-functorial I ψ ϕ ( \ _ → BOT)
            ( \ _ → A') ( \ _ → A) ( \ _ → α) ( \ _ → recBOT))
        ( second
-         ( equiv-extensions-BOT-equiv-family extext I ( \ t → ψ t)
+         ( equiv-extensions-BOT-equiv extext I ( \ t → ψ t)
            ( \ _ → A') ( \ _ → A) ( \ _ → (α , is-equiv-α)))))
 ```
 
@@ -488,15 +488,12 @@ This should hold even without assuming `is-orth-ψ-ϕ-α'`.
         ( ϕ → A ) ( \ σ → (t : ψ) → A [ϕ t ↦ σ t])
         ( \ σ'' t → α' (σ'' t)) ( \ _ τ'' x → α' (τ'' x) )
         ( \ σ' t → α (σ' t)) ( \ _ τ' x → α (τ' x) )
-    ( has-section-extensions-BOT-has-section-family naiveextext I (\ t → ϕ t)
+    ( has-section-extensions-BOT-has-section naiveextext I (\ t → ϕ t)
           ( \ _ → A'') (\ _ → A') (\ _ → α')
       ( \ _ → has-section-α'))
     ( is-orth-ψ-ϕ-α')
     ( is-orth-ψ-ϕ-αα')
 ```
-
-
-
 
 ### Stability under pullback
 
@@ -878,7 +875,7 @@ Unique extension types are closed under equivalence.
     is-equiv-Equiv-is-equiv
       ( ψ → A') ( ϕ → A') ( \ τ' t → τ' t)
       ( ψ → A)  ( ϕ → A)  ( \ τ t → τ t)
-      ( equiv-of-restriction-maps-equiv-family extext I ψ ϕ
+      ( equiv-of-restriction-maps-equiv extext I ψ ϕ
         ( \ _ → A') ( \ _ → A) ( \ _ → A'≃A))
 
 #def has-unique-extensions-equiv-has-unique-extensions uses (extext)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -654,7 +654,7 @@ then $(x : X) → A x$ is a Segal type.
           ( \ t s → A s)
           ( \ u → recBOT)))
       ( \ h s t → h s t) -- second equivalence
-      ( second (equiv-extension-equiv-family extext I ψ
+      ( second (equiv-extensions-BOT-equiv-family extext I ψ
         ( \ s → Δ² → A s)
         ( \ s → Λ → A s)
         ( \ s → (horn-restriction (A s) , fiberwise-is-segal-A s))))

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -654,7 +654,7 @@ then $(x : X) → A x$ is a Segal type.
           ( \ t s → A s)
           ( \ u → recBOT)))
       ( \ h s t → h s t) -- second equivalence
-      ( second (equiv-extensions-BOT-equiv-family extext I ψ
+      ( second (equiv-extensions-BOT-equiv extext I ψ
         ( \ s → Δ² → A s)
         ( \ s → Λ → A s)
         ( \ s → (horn-restriction (A s) , fiberwise-is-segal-A s))))

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -251,7 +251,7 @@ of discrete types is discrete.
 ```
 
 By extension extensionality, an extension type into a family of discrete types
-is discrete. Since `#!rzk equiv-extensions-BOT-equiv-family` considers total
+is discrete. Since `#!rzk equiv-extensions-BOT-equiv` considers total
 extension types only, extending from `#!rzk BOT`, that's all we prove here for
 now.
 
@@ -270,7 +270,7 @@ now.
       ( (t : ψ) → hom (A t) (f t) (g t))
       ( hom ((t : ψ) → A t) f g)
       ( equiv-ExtExt extext I ψ (\ _ → BOT) A (\ _ → recBOT) f g)
-      ( equiv-extensions-BOT-equiv-family
+      ( equiv-extensions-BOT-equiv
         ( extext)
         ( I)
         ( ψ)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -251,7 +251,7 @@ of discrete types is discrete.
 ```
 
 By extension extensionality, an extension type into a family of discrete types
-is discrete. Since `#!rzk equiv-extension-equiv-family` considers total
+is discrete. Since `#!rzk equiv-extensions-BOT-equiv-family` considers total
 extension types only, extending from `#!rzk BOT`, that's all we prove here for
 now.
 
@@ -270,7 +270,7 @@ now.
       ( (t : ψ) → hom (A t) (f t) (g t))
       ( hom ((t : ψ) → A t) f g)
       ( equiv-ExtExt extext I ψ (\ _ → BOT) A (\ _ → recBOT) f g)
-      ( equiv-extension-equiv-family
+      ( equiv-extensions-BOT-equiv-family
         ( extext)
         ( I)
         ( ψ)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -251,9 +251,8 @@ of discrete types is discrete.
 ```
 
 By extension extensionality, an extension type into a family of discrete types
-is discrete. Since `#!rzk equiv-extensions-BOT-equiv` considers total
-extension types only, extending from `#!rzk BOT`, that's all we prove here for
-now.
+is discrete. Since `#!rzk equiv-extensions-BOT-equiv` considers total extension
+types only, extending from `#!rzk BOT`, that's all we prove here for now.
 
 ```rzk
 #def equiv-hom-eq-extension-type-is-discrete uses (extext)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -1434,7 +1434,7 @@ domain are equivalent:
 #def equiv-total-dhom-equiv uses (A x y)
   : Equiv ( (t : Δ¹) → B (f t)) ((t : Δ¹) → C (f t))
   :=
-    equiv-extensions-BOT-equiv-family
+    equiv-extensions-BOT-equiv
       ( extext)
       ( 2)
       ( Δ¹)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -1434,7 +1434,7 @@ domain are equivalent:
 #def equiv-total-dhom-equiv uses (A x y)
   : Equiv ( (t : Δ¹) → B (f t)) ((t : Δ¹) → C (f t))
   :=
-    equiv-extension-equiv-family
+    equiv-extensions-BOT-equiv-family
       ( extext)
       ( 2)
       ( Δ¹)


### PR DESCRIPTION
- Every equivalence of types induces an equivalence on extension types. This was previously only proved for extensions from `BOT`
- Every retract of types induces a retract on extension types.
- I have renamed the previous term that only work for extensions from `BOT` by putting `BOT` in the name.
- Deduce full `left-cancel-with-section` for right orthogonal calculus (previously only a weak version)