### PR TITLE
More functoriality of fibers

### DIFF
--- a/src/hott/00-common.rzk.md
+++ b/src/hott/00-common.rzk.md
@@ -84,3 +84,26 @@ The following demonstrates the syntax for constructing terms in Sigma types:
   : B → U
   := \ b → C (f b)
 ```
+
+## Maps
+
+```rzk
+#def Map
+  : U
+  := Σ ((A',A) : product U U) , (A' → A)
+
+#def the-map-Map
+  ( ((A',A),α) : Map)
+  : A' → A
+  := α
+
+#def the-domain-Map
+  ( ((A',_),_) : Map)
+  : U
+  := A'
+
+#def the-codomain-Map
+  ( ((_,A),_) : Map)
+  : U
+  := A
+```

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -941,6 +941,12 @@ dependent function types.
     Σ ( ( s',s) : product ( A' → B' ) ( A → B))
     , ( ( a' : A') → β ( s' a') = s ( α a'))
 
+#def map-Map
+  ( ((A',A),α) : Map)
+  ( ((B',B),β) : Map)
+  : U
+  := map-of-maps A' A α B' B β
+
 #def Equiv-of-maps
   ( A' A : U)
   ( α : A' → A)

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -81,7 +81,7 @@ of the form `#!rzk (a, refl : f a = f a) : fib A B f`.
   :=
     ind-path-end B (f a) (\ b p → C b (a, p)) (s a) b q
 
-#def ind-fib-computation
+#def compute-ind-fib
   ( A B : U)
   ( f : A → B)
   ( C : (b : B) → fib A B f b → U)

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -621,8 +621,8 @@ The relative product of `f : B → A` with a map `Unit → A` corresponding to
 ## Functoriality of fibers
 
 We have an assignment that to each `α : A' → A` and each `a : A` assigns the
-fiber `fib A' A α a`.
-We now investigate the functoriality properties of this assignment.
+fiber `fib A' A α a`. We now investigate the functoriality properties of this
+assignment.
 
 Every map of maps induces a map of fibers.
 

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -618,12 +618,13 @@ The relative product of `f : B → A` with a map `Unit → A` corresponding to
 
 ```
 
-## Applications
+## Functoriality of fibers
 
-### Maps induced on fibers
+We have an assignment that to each `α : A' → A` and each `a : A` assigns the
+fiber `fib A' A α a`.
+We now investigate the functoriality properties of this assignment.
 
-As an application of `#!rzk is-homotopy-cartesian-is-horizontal-equiv`, we show
-that an equivalence of maps induces an equivalence of fibers at each base point.
+Every map of maps induces a map of fibers.
 
 ```rzk
 #section is-equiv-map-of-fibers-is-equiv-map-of-maps
@@ -647,7 +648,14 @@ that an equivalence of maps induces an equivalence of fibers at each base point.
   , ( concat B (β (s'-c4XT a')) (s-c4XT (α a')) (s-c4XT a))
     ( second  map-of-maps-α-β a')
     ( ap A B (α a') a s-c4XT p))
+```
 
+### Equivalences induce equivalences on fibers
+
+As an application of `#!rzk is-homotopy-cartesian-is-horizontal-equiv`, we show
+that an equivalence of maps induces an equivalence of fibers at each base point.
+
+```rzk
 #def map-of-sums-of-fibers-map-of-maps uses (map-of-maps-α-β)
   ( (a, u) : Σ (a : A), fib A' A α a)
   : Σ (b : B), fib B' B β b
@@ -727,8 +735,9 @@ that an equivalence of maps induces an equivalence of fibers at each base point.
     ( a))
 ```
 
-We also show that the map induced on fibers is respects composition up to
-homotopy.
+### Composition induces composition on fibers
+
+The map induced on fibers respects composition up to homotopy.
 
 ```rzk
 #def comp-map-of-maps
@@ -781,10 +790,9 @@ homotopy.
     ( \ a' → refl)
 ```
 
-### Retracts of equivalences are equivalences
+### Retracts induce retracts on fibers
 
-We show that if a map `α` is a retract of an equivalence `β`,
-then `α` is itself an equivalence.
+Every retract of types induces a retract on fibers.
 
 ```rzk
 #def is-section-retraction-pair-Map
@@ -814,20 +822,16 @@ then `α` is itself an equivalence.
     Σ (S : map-Map α β)
     , has-external-retract-Map α β S
 
-#def is-equiv-is-retract-of-is-equiv
+#def is-retract-of-fibers-is-external-retract-of-Map
   ( A' A : U)
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
   ( ( ((s',s),ηs) , ( ( ((C',C),γ) , ((r',r),ηr)) , ( is-s-r' , is-s-r)))
     : is-external-retract-of-Map ((A',A),α) ((B',B),β))
-  ( is-equiv-β : is-equiv B' B β)
-  : is-equiv A' A α
+  ( a : A)
+  : is-retract-of (fib A' A α a) (fib B' B β (s a))
   :=
-  is-equiv-is-contr-map A' A α
-  ( \ a →
-    is-contr-is-retract-of-is-contr
-    ( fib A' A α a) (fib B' B β (s a))
     ( ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) a)
     , ( has-retraction-internalize
         ( fib A' A α a) (fib B' B β (s a))
@@ -850,5 +854,29 @@ then `α` is itself an equivalence.
               ( is-s-r')
               ( is-s-r)
               ( a))))))
+```
+
+### Equivalences are closed under retracts
+
+As an immediate corollary we obtain that equivalences are closed under retracts.
+
+```rzk
+#def is-equiv-is-retract-of-is-equiv
+  ( A' A : U)
+  ( α : A' → A)
+  ( B' B : U)
+  ( β : B' → B)
+  ( (((s',s),ηs) , has-ext-retr-S)
+    : is-external-retract-of-Map ((A',A),α) ((B',B),β))
+  ( is-equiv-β : is-equiv B' B β)
+  : is-equiv A' A α
+  :=
+  is-equiv-is-contr-map A' A α
+  ( \ a →
+    is-contr-is-retract-of-is-contr
+    ( fib A' A α a) (fib B' B β (s a))
+    ( is-retract-of-fibers-is-external-retract-of-Map A' A α B' B β
+      ( ((s',s),ηs) , has-ext-retr-S)
+      ( a))
     ( is-contr-map-is-equiv B' B β is-equiv-β (s a)))
 ```

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -726,3 +726,129 @@ that an equivalence of maps induces an equivalence of fibers at each base point.
     ( is-equiv-s')
     ( a))
 ```
+
+We also show that the map induced on fibers is respects composition up to
+homotopy.
+
+```rzk
+#def comp-map-of-maps
+  ( A' A : U)
+  ( α : A' → A)
+  ( B' B : U)
+  ( β : B' → B)
+  ( C' C : U)
+  ( γ : C' → C)
+  ( ((t',t),ηt) : map-of-maps B' B β C' C γ)
+  ( ((s',s),ηs) : map-of-maps A' A α B' B β)
+  : map-of-maps A' A α C' C γ
+  :=
+  ( ( comp A' B' C' t' s'
+    , comp A B C t s)
+  , ( \ a' →
+      concat C (γ (t' (s' a'))) (t (β (s' a'))) (t (s (α a')))
+      ( ηt (s' a'))
+      ( ap B C (β (s' a')) (s (α a')) t (ηs a'))))
+
+#def comp-map-of-fibers-comp-map-of-maps
+  ( A' A : U)
+  ( α : A' → A)
+  ( B' B : U)
+  ( β : B' → B)
+  ( C' C : U)
+  ( γ : C' → C)
+  ( ((t',t),ηt) : map-of-maps B' B β C' C γ)
+  ( ((s',s),ηs) : map-of-maps A' A α B' B β)
+  : ( a : A)
+  → homotopy (fib A' A α a) (fib C' C γ (t (s a)))
+    ( comp ( fib A' A α a) (fib B' B β (s a)) (fib C' C γ (t (s a)))
+      ( map-of-fibers-map-of-maps B' B β C' C γ ((t',t),ηt) ( s a))
+      ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) ( a)))
+    ( map-of-fibers-map-of-maps A' A α C' C γ
+      ( comp-map-of-maps A' A α B' B β C' C γ
+        ((t',t),ηt) ((s',s),ηs))
+      (a))
+  :=
+    ind-fib A' A α
+    ( \ a a'p →
+      ( ( map-of-fibers-map-of-maps B' B β C' C γ ((t',t),ηt) (s a))
+        ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) a
+          ( a'p))
+      =_{ fib C' C γ (t (s a))}
+        ( map-of-fibers-map-of-maps A' A α C' C γ
+          ( comp-map-of-maps A' A α B' B β C' C γ
+            ((t',t),ηt) ((s',s),ηs))
+          ( a) (a'p))))
+    ( \ a' → refl)
+```
+
+### Retracts of equivalences are equivalences
+
+We show that if a map `α` is a retract of an equivalence `β`,
+then `α` is itself an equivalence.
+
+```rzk
+#def is-section-retraction-pair-Map
+  ( ((A',A),α) : Map)
+  ( ((B',B),β) : Map)
+  ( ((C',C),γ) : Map)
+  ( ((s',s),_) : map-Map ((A',A),α) ((B',B),β))
+  ( ((t',t),_) : map-Map ((B',B),β) ((C',C),γ))
+  : U
+  :=
+    product
+    ( is-section-retraction-pair A' B' C' s' t')
+    ( is-section-retraction-pair A B C s t)
+
+#def has-external-retract-Map
+  ( α β : Map)
+  ( S : map-Map α β)
+  : U
+  :=
+    Σ ((γ , T) : ( Σ (γ : Map) , (map-Map β γ)))
+    , ( is-section-retraction-pair-Map α β γ S T)
+
+#def is-external-retract-of-Map
+  ( α β : Map)
+  : U
+  :=
+    Σ (S : map-Map α β)
+    , has-external-retract-Map α β S
+
+#def is-equiv-is-retract-of-is-equiv
+  ( A' A : U)
+  ( α : A' → A)
+  ( B' B : U)
+  ( β : B' → B)
+  ( ( ((s',s),ηs) , ( ( ((C',C),γ) , ((r',r),ηr)) , ( is-s-r' , is-s-r)))
+    : is-external-retract-of-Map ((A',A),α) ((B',B),β))
+  ( is-equiv-β : is-equiv B' B β)
+  : is-equiv A' A α
+  :=
+  is-equiv-is-contr-map A' A α
+  ( \ a →
+    is-contr-is-retract-of-is-contr
+    ( fib A' A α a) (fib B' B β (s a))
+    ( ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) a)
+    , ( has-retraction-internalize
+        ( fib A' A α a) (fib B' B β (s a))
+        ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) a)
+        ( ( fib C' C γ (r (s a))
+          , map-of-fibers-map-of-maps B' B β C' C γ ((r',r),ηr) (s a))
+        , ( is-equiv-homotopy (fib A' A α a) (fib C' C γ (r (s a)))
+                ( comp ( fib A' A α a) (fib B' B β (s a)) (fib C' C γ (r (s a)))
+                  ( map-of-fibers-map-of-maps B' B β C' C γ ((r',r),ηr) ( s a))
+                  ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) ( a)))
+                ( map-of-fibers-map-of-maps A' A α C' C γ
+                  ( comp-map-of-maps A' A α B' B β C' C γ
+                    ( (r',r),ηr) ((s',s),ηs))
+                  (a))
+            ( comp-map-of-fibers-comp-map-of-maps A' A α B' B β C' C γ
+              ( (r',r),ηr) ((s',s),ηs)
+              ( a))
+            ( is-equiv-map-of-fibers-is-equiv-map-of-maps A' A α C' C γ
+              ( comp-map-of-maps A' A α B' B β C' C γ ((r',r),ηr) ((s',s),ηs))
+              ( is-s-r')
+              ( is-s-r)
+              ( a))))))
+    ( is-contr-map-is-equiv B' B β is-equiv-β (s a)))
+```

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -762,7 +762,7 @@ Then we can deduce that right orthogonal maps are preserved under pullback:
 #end right-orthogonal-calculus
 ```
 
-### Right orthogonal maps are closed under equivalence
+### Stability under equivalence
 
 If two maps `α : A' → A` and `β : B' → B` are equivalent, then if one is right
 orthogonal to `ϕ ⊂ ψ`, then so is the other.


### PR DESCRIPTION
- Composition of maps of maps induce composition on fibers.
- Retracts of maps induce retracts on fibers.

Deduce that retracts of equivalences are equivalences.

I have introduced the universe of maps (called `Map`) in `00-common`. Please let me know if this is supposed to be elsewhere.