### PR TITLE
More on orthogonal calculus

### DIFF
--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -42,7 +42,7 @@ We define equivalences to be bi-invertible maps.
   ( A : U)
   : is-equiv A A (\ a → a)
   :=
-    ( (\ a → a, \ _ → refl), (\ a → a, \ _ → refl))
+    ( (\ a → a , \ _ → refl) , (\ a → a , \ _ → refl))
 ```
 
 ## Equivalence data

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -948,6 +948,14 @@ dependent function types.
   := ind-path A x
        ( \ y p → is-equiv (C x) (C y) (transport A C x y p))
        ( is-equiv-identity (C x) )
+
+#def equiv-transport
+  ( A : U)
+  ( C : A → U)
+  ( x y : A)
+  ( p : x = y)
+  : Equiv (C x) (C y)
+  := (transport A C x y p , is-equiv-transport A C x y p)
 ```
 
 ## Equivalence is equivalence invariant

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -174,7 +174,6 @@ always do this (whether the square is homotopy-cartesian or not).
           first-path-Σ-eq-pair
             A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ))))
 
-
 #def induced-retraction-on-fibers-with-section uses (γ)
   ( ((s',s),η) : has-section-family-over-map)
   ( a : A )
@@ -203,9 +202,9 @@ always do this (whether the square is homotopy-cartesian or not).
       ( induced-retraction-on-fibers-with-section ((s',s),η) a)
       ( is-contr-map-is-equiv
         ( total-type A' C') (total-type A C)
-        (temp-uBDx-Σαγ)
+        ( temp-uBDx-Σαγ)
         ( is-equiv-Σαγ )
-        (a, s a)))
+        ( a , s a)))
 
 #end homotopy-cartesian
 ```

--- a/src/simplicial-hott/02-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/02-simplicial-type-theory.rzk.md
@@ -530,9 +530,7 @@ For example the pair `{00} ⊂ Δ²` is a retract of `{0} × Δ¹ ⊂ Δ¹ × Δ
 
 ```
 
-For completeness we verify that the intesection `Δ² ∧ {0}×Δ¹`
-is indeed `{00}`.
-
+For completeness we verify that the intesection `Δ² ∧ {0}×Δ¹` is indeed `{00}`.
 
 ```rzk
 #def verify-functorial-retract-0-Δ²-0Δ¹-Δ¹×Δ¹

--- a/src/simplicial-hott/02-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/02-simplicial-type-theory.rzk.md
@@ -370,12 +370,12 @@ describe this isomorphism on representables.
   :=
   Σ ( (f , F) : isomorphism-shape-inclusions I ψ ϕ J χ ζ)
   , ( Σ ( e
-          : ( A' : U)
-          → ( A : U)
-          → ( α : A' → A)
-          → ( σ' : ζ → A')
-          → ( ( \ (t : I | ϕ t) → α (first (f A') σ' t))
-            = ( first (f A) (\ t → α (σ' t)))))
+        : ( A' : U)
+        → ( A : U)
+        → ( α : A' → A)
+        → ( σ' : ζ → A')
+        → ( ( \ (t : I | ϕ t) → α (first (f A') σ' t))
+          = ( first (f A) (\ t → α (σ' t)))))
       , ( ( A' : U)
         → ( A : U)
         → ( α : A' → A)
@@ -439,4 +439,105 @@ ugly boilerplate code.
   :=
     ( isomorphism-0-Δ¹-1-right-leg-of-Λ
     , ( \ _ _ _ _ → refl , \ _ _ _ _ _ → refl))
+```
+
+### Functorial retracts of shape inclusions
+
+We want to express what it means for a shape inclusion `ζ ⊂ χ` to be a retract
+of another shape inclusion `ϕ ⊂ ψ`.
+
+If these shapes were types, we would require a commutative diagram
+
+```
+ζ ⊂ χ
+↓   ↓
+ϕ ⊂ ψ
+↓   ↓
+ζ ⊂ χ
+```
+
+such that the vertical composites are the identity. As before, we cannot say
+this directly; instead we express this property on representables. Since the
+upper vertical maps are necessarily monomorphisms, we may we may assume up to
+isomorphism (which we already dealt with) that `ζ ⊂ χ` are actual subshapes of
+`ϕ ⊂ ψ`.
+
+We observe that we must have `ζ = χ ∧ ϕ`. Thus we have the following setting:
+
+```rzk
+#section retracts-shape-inclusions
+
+#variable I : CUBE
+#variable ψ : I → TOPE
+#variables ϕ χ : ψ → TOPE
+-- ζ := χ ∧ ϕ
+
+#def retract-shape-inclusion
+  : U
+  :=
+  Σ ( s
+    : ( A : U)
+    → ( σ : (t : I | χ t ∧ ϕ t) → A)
+    → ( t : ϕ)
+    → A [ χ t ∧ ϕ t ↦ σ t])
+  , ( ( A : U)
+    → ( σ : (t : I | χ t ∧ ϕ t) → A)
+    → ( τ : (t : χ) → A [χ t ∧ ϕ t ↦ σ t])
+    → ( t : ψ)
+    → A [χ t ↦ τ t , ϕ t ↦ s A σ t])
+
+#def functorial-retract-shape-inclusion
+  : U
+  :=
+  Σ ( (s, S) : retract-shape-inclusion)
+  , Σ ( h
+      : ( A' : U)
+      → ( A : U)
+      → ( α : A' → A)
+      → ( σ' : (t : I | χ t ∧ ϕ t) → A')
+      → ( ( \ (t : I | ϕ t) → α (s A' σ' t))
+        =_{ ϕ → A}
+          ( s A ( \ t → α (σ' t)))))
+    , ( ( A' : U)
+      → ( A : U)
+      → ( α : A' → A)
+      → ( σ' : (t : I | χ t ∧ ϕ t) → A')
+      → ( τ' : (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
+      → ( ( transport
+            ( (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+            (\ σ → (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ σ t])
+            ( \ t → α (s A' σ' t))
+            ( \ t → s A ( \ t' → α (σ' t')) t)
+            ( h A' A α σ')
+            ( \ t → α ( S A' σ' τ' t)))
+        =_{ (t : ψ) → A [ϕ t ↦ s A (\ t' → α (τ' t')) t]}
+          ( S A (\ t → α (σ' t)) ( \ t → α (τ' t)))))
+
+#end retracts-shape-inclusions
+```
+
+For example the pair `{00} ⊂ Δ²` is a retract of `{0} × Δ¹ ⊂ Δ¹ × Δ¹`.
+
+```rzk
+#def functorial-retract-00-Δ²-0Δ¹-Δ¹×Δ¹
+  : functorial-retract-shape-inclusion (2 × 2)
+    ( Δ¹×Δ¹) ( \ (t , _) → t ≡ 0₂)
+    ( \ ts → Δ² ts)
+  :=
+  ( ( (\ _ f (t , s) → recOR ( t ≤ s ↦ f (t , t) , s ≤ t ↦ f (t , s)))
+    , (\ _ _ f (t , s) → recOR ( t ≤ s ↦ f (t , t) , s ≤ t ↦ f (t , s))))
+  , ( \ _ _ _ _ → refl , \ _ _ _ _ _ → refl))
+
+```
+
+For completeness we verify that the intesection `Δ² ∧ {0}×Δ¹`
+is indeed `{00}`.
+
+
+```rzk
+#def verify-functorial-retract-0-Δ²-0Δ¹-Δ¹×Δ¹
+  ( A : U)
+  : ( ( shape-intersection (2 × 2) (\ ts → Δ² ts) (\ (t , _) → t ≡ 0₂) → A)
+    = ( ( (t, s) : 2 × 2 | t ≡ 0₂ ∧ s ≡ 0₂) → A))
+  := refl
 ```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -351,8 +351,8 @@ The original form.
         ( (t : χ) → X t [ψ t ↦ f t]))
   :=
     ( ( \ h → (\ t → h t , \ t → h t))
-    , ( ( \ (_f , g) t → g t , \ h → refl)
-      , ( ( \ (_f , g) t → g t , \ h → refl))))
+    , ( ( \ (_ , g) t → g t , \ _ → refl)
+      , ( ( \ (_ , g) t → g t , \ _ → refl))))
 
 #def cofibration-composition-functorial
   ( I : CUBE)
@@ -395,8 +395,52 @@ A reformulated version via tope disjunction instead of inclusion (see
         , ( (t : χ) → X t [χ t ∧ ψ t ↦ f t]))
   :=
     ( ( \ h → (\ t → h t , \ t → h t))
-    , ( ( \ (_f , g) t → g t , \ h → refl)
-      , ( \ (_f , g) t → g t , \ h → refl)))
+    , ( ( \ (_ , g) t → g t , \ _ → refl)
+      , ( \ (_ , g) t → g t , \ _ → refl)))
+```
+
+Another variant is the following:
+
+```rzk
+#def cofibration-composition''
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ χ : ψ → TOPE)
+  ( A : ψ → U)
+  ( a : (t : I | ϕ t) → A t)
+  : Equiv
+    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( Σ ( b : (t : I | χ t) → A t [χ t ∧ ϕ t ↦ a t])
+      , (t : ψ) → A t [χ t ↦ b t , ϕ t ↦ a t])
+  :=
+  ( \ c → (\ t → c t , \ t → c t)
+  , ( ( \ (_ , c) t → c t
+      , \ _ → refl)
+    , ( \ (_ , c) t → c t
+      , \ _ → refl)))
+
+#def cofibration-composition-functorial''
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ χ : ψ → TOPE)
+  ( A' A : (t : I | ϕ t ∨ ψ t) → U)
+  ( α : (t : I | ϕ t ∨ ψ t) → A' t → A t)
+  ( a' : (t : I | ϕ t) → A' t)
+  : Equiv-of-maps
+    ( (t : ψ) → A' t [ϕ t ↦ a' t])
+    ( (t : ψ) → A t [ϕ t ↦ α t (a' t)])
+    ( \ c t → α t (c t))
+    ( Σ ( b' : (t : I | χ t) → A' t [χ t ∧ ϕ t ↦ a' t])
+      , (t : ψ) → A' t [χ t ↦ b' t , ϕ t ↦ a' t])
+    ( Σ ( b : (t : I | χ t) → A t [χ t ∧ ϕ t ↦ α t (a' t)])
+      , (t : ψ) → A t [χ t ↦ b t , ϕ t ↦ α t (a' t)])
+    ( \ (b , c) → (\ t → α t (b t) , \ t → α t (c t)))
+  :=
+  ( ( ( first (cofibration-composition'' I ψ ϕ χ A' a')
+      , first (cofibration-composition'' I ψ ϕ χ A (\ t → α t (a' t))))
+    , \ _ → refl)
+  , ( second (cofibration-composition'' I ψ ϕ χ A' a')
+    , second (cofibration-composition'' I ψ ϕ χ A (\ t → α t (a' t)))))
 ```
 
 ```rzk title="RS17, Theorem 4.5"

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -219,9 +219,34 @@ This equivalence is functorial in the following sense:
       ( uncurry-opcurry I J ψ ϕ ζ χ X f)
 ```
 
+### Functorial instances
+
 For each of these we provide a corresponding functorial instance
 
 ```rzk
+#def flip-ext-fun-functorial
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( X : U)
+  ( A' A : ψ → X → U)
+  ( α : (t : ψ) → (x : X) → A' t x → A t x)
+  ( σ' : (t : ϕ) → (x : X) → A' t x)
+  : Equiv-of-maps
+    ( (t : ψ) → ((x : X) → A' t x) [ϕ t ↦ σ' t])
+    ( (t : ψ) → ((x : X) → A t x) [ϕ t ↦ \ x → α t x (σ' t x)])
+    ( \ τ t x → α t x (τ t x))
+    ( (x : X) → (t : ψ) → A' t x [ϕ t ↦ σ' t x])
+    ( (x : X) → (t : ψ) → A t x [ϕ t ↦ α t x (σ' t x)])
+    ( \ τ x t → α t x (τ x t))
+  :=
+    ( ( ( first (flip-ext-fun I ψ ϕ X A' σ')
+        , first (flip-ext-fun I ψ ϕ X A (\ t x → α t x (σ' t x))))
+      , ( \ _ → refl))
+    , ( second (flip-ext-fun I ψ ϕ X A' σ')
+      , second (flip-ext-fun I ψ ϕ X A (\ t x → α t x (σ' t x)))))
+
+
 #def curry-uncurry-functorial
   ( I J : CUBE)
   ( ψ : I → TOPE)
@@ -353,31 +378,6 @@ The original form.
     ( ( \ h → (\ t → h t , \ t → h t))
     , ( ( \ (_ , g) t → g t , \ _ → refl)
       , ( ( \ (_ , g) t → g t , \ _ → refl))))
-
-#def cofibration-composition-functorial
-  ( I : CUBE)
-  ( χ : I → TOPE)
-  ( ψ : χ → TOPE)
-  ( ϕ : ψ → TOPE)
-  ( A' A : χ → U)
-  ( α : (t : χ) → A' t → A t)
-  ( σ' : (t : ϕ) → A' t)
-  : Equiv-of-maps
-    ( (t : χ) → A' t [ϕ t ↦ σ' t])
-    ( (t : χ) → A t [ϕ t ↦ α t (σ' t)])
-    ( \ τ' t → α t (τ' t))
-    ( Σ ( τ' : (t : ψ) → A' t [ϕ t ↦ σ' t])
-      , ( (t : χ) → A' t [ψ t ↦ τ' t]))
-    ( Σ ( τ : (t : ψ) → A t [ϕ t ↦ α t (σ' t)])
-      , ( (t : χ) → A t [ψ t ↦ τ t]))
-    ( \ (τ', υ') → ( \ t → α t (τ' t), \t → α t (υ' t)))
-  :=
-    ( ( ( \ h → (\ t → h t , \ t → h t) , \ h → (\ t → h t , \ t → h t))
-      , ( \ _ → refl))
-    , ( ( ( \ (_f , g) t → g t , \ h → refl)
-        , ( ( \ (_f , g) t → g t , \ h → refl)))
-      , ( ( \ (_f , g) t → g t , \ h → refl)
-        , ( ( \ (_f , g) t → g t , \ h → refl)))))
 ```
 
 A reformulated version via tope disjunction instead of inclusion (see
@@ -418,6 +418,50 @@ Another variant is the following:
       , \ _ → refl)
     , ( \ (_ , c) t → c t
       , \ _ → refl)))
+```
+
+```rzk title="RS17, Theorem 4.5"
+#def cofibration-union
+  ( I : CUBE)
+  ( ϕ ψ : I → TOPE)
+  ( X : (t : I | ϕ t ∨ ψ t) → U)
+  ( a : (t : ψ) → X t)
+  : Equiv
+      ( (t : I | ϕ t ∨ ψ t) → X t [ψ t ↦ a t])
+      ( (t : ϕ) → X t [ϕ t ∧ ψ t ↦ a t])
+  :=
+    ( \ h t → h t
+    , ( ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)
+      , ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)))
+```
+
+### Functorial instances
+
+```rzk
+#def cofibration-composition-functorial
+  ( I : CUBE)
+  ( χ : I → TOPE)
+  ( ψ : χ → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A' A : χ → U)
+  ( α : (t : χ) → A' t → A t)
+  ( σ' : (t : ϕ) → A' t)
+  : Equiv-of-maps
+    ( (t : χ) → A' t [ϕ t ↦ σ' t])
+    ( (t : χ) → A t [ϕ t ↦ α t (σ' t)])
+    ( \ τ' t → α t (τ' t))
+    ( Σ ( τ' : (t : ψ) → A' t [ϕ t ↦ σ' t])
+      , ( (t : χ) → A' t [ψ t ↦ τ' t]))
+    ( Σ ( τ : (t : ψ) → A t [ϕ t ↦ α t (σ' t)])
+      , ( (t : χ) → A t [ψ t ↦ τ t]))
+    ( \ (τ', υ') → ( \ t → α t (τ' t), \t → α t (υ' t)))
+  :=
+    ( ( ( \ h → (\ t → h t , \ t → h t) , \ h → (\ t → h t , \ t → h t))
+      , ( \ _ → refl))
+    , ( ( ( \ (_f , g) t → g t , \ h → refl)
+        , ( ( \ (_f , g) t → g t , \ h → refl)))
+      , ( ( \ (_f , g) t → g t , \ h → refl)
+        , ( ( \ (_f , g) t → g t , \ h → refl)))))
 
 #def cofibration-composition-functorial''
   ( I : CUBE)
@@ -441,21 +485,6 @@ Another variant is the following:
     , \ _ → refl)
   , ( second (cofibration-composition'' I ψ ϕ χ A' a')
     , second (cofibration-composition'' I ψ ϕ χ A (\ t → α t (a' t)))))
-```
-
-```rzk title="RS17, Theorem 4.5"
-#def cofibration-union
-  ( I : CUBE)
-  ( ϕ ψ : I → TOPE)
-  ( X : (t : I | ϕ t ∨ ψ t) → U)
-  ( a : (t : ψ) → X t)
-  : Equiv
-      ( (t : I | ϕ t ∨ ψ t) → X t [ψ t ↦ a t])
-      ( (t : ϕ) → X t [ϕ t ∧ ψ t ↦ a t])
-  :=
-    ( \ h t → h t
-    , ( ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)
-      , ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)))
 
 #def cofibration-union-functorial
   ( I : CUBE)

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -171,9 +171,13 @@ occasionally go back or forth along the functorial equivalence
 #def is-homotopy-cartesian-Σ-is-right-orthogonal-to-shape uses (is-orth-ψ-ϕ)
   : is-homotopy-cartesian
     ( ϕ → A')
-    ( \ σ' → Σ ( τ' : (t : χ) → A' [ϕ t ↦ σ' t]), ( t : ψ) → A' [χ t ↦ τ' t])
+    ( \ σ' →
+      Σ ( τ' : (t : χ) → A' [ϕ t ↦ σ' t])
+      , ( t : ψ) → A' [χ t ↦ τ' t])
     ( ϕ → A)
-    ( \ σ → Σ ( τ : (t : χ) → A [ϕ t ↦ σ t]), ( t : ψ) → A [χ t ↦ τ t])
+    ( \ σ →
+      Σ ( τ : (t : χ) → A [ϕ t ↦ σ t])
+      , ( t : ψ) → A [χ t ↦ τ t])
     ( \ σ' t → α (σ' t))
     ( \ _ (τ', υ') → ( \ t → α (τ' t), \ t → α (υ' t) ))
   :=
@@ -572,20 +576,47 @@ retract of it, then `ζ ⊂ χ` is also left orthogonal.
     ( \ τ' υ →
       ( transport
         ( (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
-        (\ σ → (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ σ t])
+        ( \ σ → (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ σ t])
         ( \ t → α (s A' σ' t))
-        ( \ t → s A ( \ t' → α (σ' t')) t)
+        ( s A ( \ t → α (σ' t)))
         ( h A' A α σ')
         ( \ t → α ( υ t))))
-    ( ( S A' σ'
-      , S A (\ t → α (σ' t)))
+    ( ( S A' σ' , S A (\ t → α (σ' t)))
     , H A' A α σ')
-    ( undefined)
-
-
-
-
-
+    ( second
+      ( equiv-comp
+      ( Σ ( τ' : (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
+      , (t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
+      ( Σ ( τ : (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+          , (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
+        ( Σ ( τ : (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+          , (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ s A (\ t' → α (σ' t')) t])
+        ( ( \ (τ' , υ') →
+            ( (\ t → α (τ' t))
+            , (\ t → α (υ' t))))
+        , ( is-equiv-Equiv-is-equiv'
+            ( (t : ψ) → A' [ϕ t ↦ s A' σ' t])
+            ( (t : ψ) → A [ϕ t ↦ α (s A' σ' t)])
+            ( \ υ' t → α (υ' t))
+            ( Σ ( τ' : (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
+              , (t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
+            ( Σ ( τ : (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+              , (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
+              ( \ (τ' , υ') → ( (\ t → α (τ' t)) , (\ t → α (υ' t))))
+              ( cofibration-composition-functorial'' I ψ ϕ χ
+                (\ _ → A') (\ _ → A) (\ _ → α) (s A' σ'))
+            ( is-orth-ψ-ϕ (s A' σ'))))
+        ( total-equiv-family-of-equiv
+          ( (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+          ( \ τ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
+          ( \ τ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ s A (\ t' → α (σ' t')) t])
+          ( \ τ →
+            equiv-transport
+            ( (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+            ( \ σ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ σ t])
+            ( \ t → α (s A' σ' t))
+            ( s A (\ t → α (σ' t)))
+            ( h A' A α σ')))))
 ```
 
 ## Stability properties of right orthogonal maps

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -163,7 +163,7 @@ left orthogonality of shape inclusion with respect to `α : A' → A`.
 The only fact that stops some of these laws from being a direct corollary is
 that the `Σ`-types appearing in the vertical pasting of the relevant squares
 (such as `Σ (\ σ : ϕ → A), ( (t : χ) → A [ϕ t ↦ σ t])`) are not literally equal
-to the corresponding extension types (such as `τ → A `). Therefore we have to
+to the corresponding extension types (such as `χ → A `). Therefore we have to
 occasionally go back or forth along the functorial equivalence
 `cofibration-composition-functorial`.
 
@@ -318,7 +318,7 @@ affecting left orthogonality.
     ( is-orth-ψ-ϕ (\ (s , t) → σ' (t , s)))
 ```
 
-### Exponentiation
+### Tensoring
 
 If `ϕ ⊂ ψ` is left orthogonal to `α : A' → A` then so is `χ × ϕ ⊂ χ × ψ` for
 every other shape `χ`.
@@ -481,10 +481,10 @@ stability under pushout products.
       ( is-orth-ψ-ϕ))
 ```
 
-### Functorial isomorphisms of shape inclusion
+### Functorial isomorphisms
 
-If two pairs of shape inclusions `ϕ ⊂ ψ` and `ζ ⊂ χ` are isomorphic, then
-`ϕ ⊂ ψ` is left orthogonal if and only if `ζ ⊂ χ` is left orthogonal.
+If two pairs of shape inclusions `ϕ ⊂ ψ` and `ζ ⊂ χ` are (functorially)
+isomorphic, then `ϕ ⊂ ψ` is left orthogonal if and only if `ζ ⊂ χ` is left orthogonal.
 
 ```rzk
 #def is-right-orthogonal-to-shape-isomorphism'
@@ -543,6 +543,49 @@ If two pairs of shape inclusions `ϕ ⊂ ψ` and `ζ ⊂ χ` are isomorphic, the
   ( E A' A α)
   ( \ σ' → second (F A' σ')) (\ σ → second (F A σ))
   ( second (second (f A')))
+```
+
+### Functorial retracts
+
+If `ϕ ⊂ ψ` is a left orthogonal shape inclusion and `ζ ⊂ χ` is a (functorial)
+retract of it, then `ζ ⊂ χ` is also left orthogonal.
+
+```rzk
+#def is-right-orthogonal-to-shape-retract
+  ( A' A : U)
+  ( α : A' → A)
+  ( I : CUBE)
+  ( ψ : I → TOPE )
+  ( ϕ χ : ψ → TOPE)
+  -- ζ := χ ∧ ϕ
+  ( ((s , S) , (h , H)) : functorial-retract-shape-inclusion I ψ ϕ χ)
+  : is-right-orthogonal-to-shape I ψ ϕ A' A α
+  → is-right-orthogonal-to-shape I (\ t → χ t) (\ t → χ t ∧ ϕ t) A' A α
+  :=
+  \ is-orth-ψ-ϕ (σ' : (t : I | χ t ∧ ϕ t) → A') →
+    push-down-equiv-with-section
+    ( (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
+    ( \ τ' → (t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
+    ( (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+    ( \ τ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ s A (\ t' → α (σ' t')) t])
+    ( \ τ' t → α (τ' t))
+    ( \ τ' υ →
+      ( transport
+        ( (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+        (\ σ → (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ σ t])
+        ( \ t → α (s A' σ' t))
+        ( \ t → s A ( \ t' → α (σ' t')) t)
+        ( h A' A α σ')
+        ( \ t → α ( υ t))))
+    ( ( S A' σ'
+      , S A (\ t → α (σ' t)))
+    , H A' A α σ')
+    ( undefined)
+
+
+
+
+
 ```
 
 ## Stability properties of right orthogonal maps

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -488,7 +488,8 @@ stability under pushout products.
 ### Functorial isomorphisms
 
 If two pairs of shape inclusions `ϕ ⊂ ψ` and `ζ ⊂ χ` are (functorially)
-isomorphic, then `ϕ ⊂ ψ` is left orthogonal if and only if `ζ ⊂ χ` is left orthogonal.
+isomorphic, then `ϕ ⊂ ψ` is left orthogonal if and only if `ζ ⊂ χ` is left
+orthogonal.
 
 ```rzk
 #def is-right-orthogonal-to-shape-isomorphism'

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -937,6 +937,57 @@ orthogonal to `ϕ ⊂ ψ`, then so is the other.
 #end is-right-orthogonal-equiv-to-shape
 ```
 
+### Exponentiation / product types
+
+Let `α : A' → A` be right orthogonal to `ϕ ⊂ ψ`. Then the same is true for the
+induced map `(X → A') → (X → A)` for any type `X`. More generally, if
+`α x : A' x → A x` is a right orthogonal map for each `x : X`, then so is the
+map on dependent products `Π α : Π A' → Π A`.
+
+```rzk
+#def is-right-orthogonal-Π-to-shape uses (funext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( X : U)
+  ( A' A : X → U)
+  ( α : (x : X) → (A' x) → (A x))
+  ( are-right-orth-ψ-ϕ-α
+    : (x : X) → is-right-orthogonal-to-shape I ψ ϕ (A' x) (A x) (α x))
+  : is-right-orthogonal-to-shape I ψ ϕ
+    ( (x : X) → A' x)
+    ( (x : X) → A x)
+    ( \ a' x → α x (a' x))
+  :=
+  \ σ' →
+    is-equiv-Equiv-is-equiv
+    ( (t : ψ) → ((x : X) → A' x) [ϕ t ↦ σ' t])
+    ( (t : ψ) → ((x : X) → A x) [ϕ t ↦ \ x → α x (σ' t x)])
+    ( \ τ' t x → α x (τ' t x))
+    ( (x : X) → (t : ψ) → A' x [ϕ t ↦ σ' t x])
+    ( (x : X) → (t : ψ) → A x [ϕ t ↦ α x (σ' t x)])
+    ( \ τ' x t → α x (τ' x t))
+    ( flip-ext-fun-functorial I ψ ϕ X
+      (\ _ → A') (\ _ → A) (\ _ → α)
+      ( σ'))
+    ( is-equiv-function-is-equiv-family funext X
+      ( \ x → (t : ψ) → A' x [ϕ t ↦ σ' t x])
+      ( \ x → (t : ψ) → A x [ϕ t ↦ α x (σ' t x)])
+      ( \ x τ' t → α x (τ' t))
+      ( \ x → are-right-orth-ψ-ϕ-α x ( \ t → σ' t x)))
+```
+
+### Sigma types
+
+Warning: It is _not_ true that right orthogonal maps are preserved under
+dependent sums.
+
+Indeed, every map `f: A → B` can be written as
+`Σ (b : B) , fib f b → Σ (b : B) , Unit`; and it is not true that `f` is right
+orthogonal if and only if each `fib f b → Unit` is right orthogonal. For
+example, the map `{0} → Δ¹` is not a left fibration even though its fibers are
+all left fibrant (i.e. discrete).
+
 ## Types with unique extension
 
 We say that an type `A` has unique extensions for a shape inclusion `ϕ ⊂ ψ`, if

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -18,9 +18,8 @@ This is a literate `rzk` file:
   lifts.
 - `05-segal-types.rzk.md` - We make use of the notion of Segal types and their
   structures.
-- `06-contractible.rzk.md` - We make use of weak function extensionality.
-
-Some of the definitions in this file rely on extension extensionality:
+- `06-contractible.rzk.md` - We make use of weak function extensionality. ! Some
+  of the definitions in this file rely on extension extensionality:
 
 ```rzk
 #assume extext : ExtExt


### PR DESCRIPTION
- Formulate what it means for a shape inclusion to be a retract of another.
- Left orthogonal shape inclusions are closed under retracts.

- Right orthogonal maps are closed under exponentiation / product types