### PR TITLE
Auto-format all files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,3 +20,10 @@ jobs:
         with:
           dry: true
           prettier_options: --check **/*.{md,json,yaml,yml}
+
+      - name: Rzk formatter
+        uses: rzk-lang/rzk-action@v1.2.0
+        with:
+          rzk-version: v0.7.2
+          typecheck: false
+          check-formatting: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   "editor.inlineSuggest.enabled": true,
   "editor.acceptSuggestionOnEnter": "off",
   "editor.snippetSuggestions": "top",
-  "editor.wordBasedSuggestions": false,
+  "editor.wordBasedSuggestions": "off",
   "javascript.suggest.names": false,
 
   // Autoformatting and file type specific settings
@@ -61,5 +61,6 @@
     "editor.autoClosingBrackets": "never",
     "editor.detectIndentation": false,
     "editor.insertSpaces": true
-  }
+  },
+  "rzk.format.enable": true
 }

--- a/src/hott/00-common.rzk.md
+++ b/src/hott/00-common.rzk.md
@@ -90,20 +90,20 @@ The following demonstrates the syntax for constructing terms in Sigma types:
 ```rzk
 #def Map
   : U
-  := Σ ((A',A) : product U U) , (A' → A)
+  := Σ ((A' , A) : product U U) , (A' → A)
 
 #def the-map-Map
-  ( ((A',A),α) : Map)
+  ( ( ( A' , A) , α) : Map)
   : A' → A
   := α
 
 #def the-domain-Map
-  ( ((A',_),_) : Map)
+  ( ( ( A' , _) , _) : Map)
   : U
   := A'
 
 #def the-codomain-Map
-  ( ((_,A),_) : Map)
+  ( ( ( _ , A) , _) : Map)
   : U
   := A
 ```

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -15,7 +15,7 @@ it like any other function.
 #define ind-path
   ( A : U)
   ( a : A)
-  ( C : (x : A) -> (a = x) -> U)
+  ( C : (x : A) → (a = x) → U)
   ( d : C a refl)
   ( x : A)
   ( p : a = x)
@@ -32,7 +32,7 @@ with fixed end point.
 #define ind-path-start
   ( A : U)
   ( a : A)
-  ( C : (x : A) -> (a = x) -> U)
+  ( C : (x : A) → (a = x) → U)
   ( d : C a refl)
   ( x : A)
   ( p : a = x)
@@ -68,7 +68,7 @@ our main definition.
 #def concat
   ( p : x = y)
   ( q : y = z)
-  : (x = z)
+  : ( x = z)
   := ind-path (A) (y) (\ z' q' → (x = z')) (p) (z) (q)
 ```
 
@@ -78,7 +78,7 @@ situations where it is easier to induct on the first path.
 ```rzk
 #def concat'
   ( p : x = y)
-  : (y = z) → (x = z)
+  : ( y = z) → (x = z)
   := ind-path (A) (x) (\ y' p' → (y' = z) → (x = z)) (\ q' → q') (y) (p)
 
 #end path-algebra
@@ -94,7 +94,7 @@ situations where it is easier to induct on the first path.
 
 #def rev-rev
   ( p : x = y)
-  : (rev A y x (rev A x y p)) = p
+  : ( rev A y x (rev A x y p)) = p
   :=
     ind-path
     ( A) (x) (\ y' p' → (rev A y' x (rev A x y' p')) = p') (refl) (y) (p)
@@ -108,7 +108,7 @@ choice of definition.
 ```rzk
 #def left-unit-concat
   ( p : x = y)
-  : (concat A x x y refl p) = p
+  : ( concat A x x y refl p) = p
   := ind-path (A) (x) (\ y' p' → (concat A x x y' refl p') = p') (refl) (y) (p)
 ```
 
@@ -119,15 +119,15 @@ choice of definition.
   ( p : w = x)
   ( q : x = y)
   ( r : y = z)
-  : ( concat A w y z (concat A w x y p q) r) =
-    ( concat A w x z p (concat A x y z q r))
+  : ( concat A w y z (concat A w x y p q) r)
+  = ( concat A w x z p (concat A x y z q r))
   :=
     ind-path
       ( A)
       ( y)
       ( \ z' r' →
-        concat A w y z' (concat A w x y p q) r' =
-        concat A w x z' p (concat A x y z' q r'))
+        concat A w y z' (concat A w x y p q) r'
+      = concat A w x z' p (concat A x y z' q r'))
       ( refl)
       ( z)
       ( r)
@@ -136,22 +136,22 @@ choice of definition.
   ( p : w = x)
   ( q : x = y)
   ( r : y = z)
-  : ( concat A w x z p (concat A x y z q r)) =
-    ( concat A w y z (concat A w x y p q) r)
+  : ( concat A w x z p (concat A x y z q r))
+  = ( concat A w y z (concat A w x y p q) r)
   :=
     ind-path
       ( A)
       ( y)
       ( \ z' r' →
-          concat A w x z' p (concat A x y z' q r') =
-          concat A w y z' (concat A w x y p q) r')
+          concat A w x z' p (concat A x y z' q r')
+        = concat A w y z' (concat A w x y p q) r')
       ( refl)
       ( z)
       ( r)
 
 #def right-inverse-concat
   ( p : x = y)
-  : (concat A x y x p (rev A x y p)) = refl
+  : ( concat A x y x p (rev A x y p)) = refl
   :=
     ind-path
       ( A)
@@ -163,7 +163,7 @@ choice of definition.
 
 #def left-inverse-concat
   ( p : x = y)
-  : (concat A y x y (rev A x y p) p) = refl
+  : ( concat A y x y (rev A x y p) p) = refl
   :=
     ind-path
       ( A)
@@ -183,7 +183,7 @@ and `#!rzk rev`.
 #def zig-zag-concat
   ( p : x = y)
   ( q : z = y)
-  : (x = z)
+  : ( x = z)
   := concat A x y z p (rev A z y q)
 ```
 
@@ -194,15 +194,15 @@ Concatenation of two paths with common domain; defined using `#!rzk concat` and
 
 ```rzk
 #def zag-zig-concat
-  (p : y = x)
-  (q : y = z)
-  : (x = z)
+  ( p : y = x)
+  ( q : y = z)
+  : ( x = z)
   := concat A x y z (rev A y x p) q
 
 #def right-cancel-concat
   ( p q : x = y)
   ( r : y = z)
-  : ((concat A x y z p r) = (concat A x y z q r)) → (p = q)
+  : ( ( concat A x y z p r) = (concat A x y z q r)) → (p = q)
   :=
     ind-path
       ( A)
@@ -228,15 +228,15 @@ of the path algebra coherences defined above.
 #def rev-concat
   ( p : x = y)
   ( q : y = z)
-  : ( rev A x z (concat A x y z p q)) =
-    ( concat A z y x (rev A y z q) (rev A x y p))
+  : ( rev A x z (concat A x y z p q))
+  = ( concat A z y x (rev A y z q) (rev A x y p))
   :=
     ind-path
       ( A)
       ( y)
       ( \ z' q' →
-          (rev A x z' (concat A x y z' p q')) =
-          (concat A z' y x (rev A y z' q') (rev A x y p)))
+          ( rev A x z' (concat A x y z' p q'))
+        = ( concat A z' y x (rev A y z' q') (rev A x y p)))
       ( rev
           ( y = x)
           ( concat A y y x refl (rev A x y p))
@@ -253,7 +253,7 @@ of the path algebra coherences defined above.
   ( p q : x = y)
   ( H : p = q)
   ( r : y = z)
-  : (concat A x y z p r) = (concat A x y z q r)
+  : ( concat A x y z p r) = (concat A x y z q r)
   :=
     ind-path
       ( A)
@@ -271,19 +271,19 @@ Prewhiskering paths of paths is much harder.
 ```rzk
 #def concat-eq-right
   ( p : x = y)
-  : ( q : y = z) →
-    ( r : y = z) →
-    ( H : q = r) →
-    ( concat A x y z p q) = (concat A x y z p r)
+  : ( q : y = z)
+  → ( r : y = z)
+  → ( H : q = r)
+  → ( concat A x y z p q) = (concat A x y z p r)
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' p' →
-        ( q : y' = z) →
-        ( r : y' = z) →
-        ( H : q = r) →
-        ( concat A x y' z p' q) = (concat A x y' z p' r))
+        ( q : y' = z)
+      → ( r : y' = z)
+      → ( H : q = r)
+      → ( concat A x y' z p' q) = (concat A x y' z p' r))
       ( \ q r H →
         concat
           ( x = z)
@@ -301,15 +301,15 @@ Prewhiskering paths of paths is much harder.
 ```rzk
 #def concat-concat'
   ( p : x = y)
-  : ( q : y = z) →
-    ( concat A x y z p q) = (concat' A x y z p q)
+  : ( q : y = z)
+  → ( concat A x y z p q) = (concat' A x y z p q)
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' p' →
-          (q' : y' =_{A} z) →
-          (concat A x y' z p' q') =_{x =_{A} z} concat' A x y' z p' q')
+          ( q' : y' =_{A} z)
+        → ( concat A x y' z p' q') =_{x =_{A} z} concat' A x y' z p' q')
       ( \ q' → left-unit-concat A x z q')
       ( y)
       ( p)
@@ -332,17 +332,17 @@ This is easier to prove for `#!rzk concat'` than for `#!rzk concat`.
 #def alt-triangle-rotation
   ( p : x = z)
   ( q : x = y)
-  : ( r : y = z) →
-    ( H : p = concat' A x y z q r) →
-    ( concat' A y x z (rev A x y q) p) = r
+  : ( r : y = z)
+  → ( H : p = concat' A x y z q r)
+  → ( concat' A y x z (rev A x y q) p) = r
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' q' →
-        ( r' : y' =_{A} z) →
-        ( H' : p = concat' A x y' z q' r') →
-        ( concat' A y' x z (rev A x y' q') p) = r')
+        ( r' : y' =_{A} z)
+      → ( H' : p = concat' A x y' z q' r')
+      → ( concat' A y' x z (rev A x y' q') p) = r')
       ( \ r' H' → H')
       ( y)
       ( q)
@@ -361,7 +361,7 @@ The following needs to be outside the previous section because of the usage of
   ( q : x = y)
   ( r : y = z)
   ( H : p = concat A x y z q r)
-  : (concat A y x z (rev A x y q) p) = r
+  : ( concat A y x z (rev A x y q) p) = r
   :=
     concat
       ( y = z)
@@ -384,10 +384,10 @@ A special case of this is sometimes useful
 
 ```rzk
 #def cancel-left-path
-  (A : U)
-  (x y : A)
-  (p q : x = y)
-  : (p = q) → ( concat A y x y (rev A x y q) p) = refl
+  ( A : U)
+  ( x y : A)
+  ( p q : x = y)
+  : ( p = q) → (concat A y x y (rev A x y q) p) = refl
   := triangle-rotation A x y y p q refl
 ```
 
@@ -452,7 +452,7 @@ A special case of this is sometimes useful
   ( x y : A)
   ( f : A → B)
   ( p : x = y)
-  : (f x = f y)
+  : ( f x = f y)
   := ind-path (A) (x) (\ y' p' → (f x = f y')) (refl) (y) (p)
 
 #def ap-rev
@@ -460,7 +460,7 @@ A special case of this is sometimes useful
   ( x y : A)
   ( f : A → B)
   ( p : x = y)
-  : (ap A B y x f (rev A x y p)) = (rev B (f x) (f y) (ap A B x y f p))
+  : ( ap A B y x f (rev A x y p)) = (rev B (f x) (f y) (ap A B x y f p))
   :=
     ind-path
       ( A)
@@ -477,15 +477,15 @@ A special case of this is sometimes useful
   ( f : A → B)
   ( p : x = y)
   ( q : y = z)
-  : ( ap A B x z f (concat A x y z p q)) =
-    ( concat B (f x) (f y) (f z) (ap A B x y f p) (ap A B y z f q))
+  : ( ap A B x z f (concat A x y z p q))
+  = ( concat B (f x) (f y) (f z) (ap A B x y f p) (ap A B y z f q))
   :=
     ind-path
       ( A)
       ( y)
       ( \ z' q' →
-        ( ap A B x z' f (concat A x y z' p q')) =
-        ( concat B (f x) (f y) (f z') (ap A B x y f p) (ap A B y z' f q')))
+        ( ap A B x z' f (concat A x y z' p q'))
+      = ( concat B (f x) (f y) (f z') (ap A B x y f p) (ap A B y z' f q')))
       ( refl)
       ( z)
       ( q)
@@ -495,14 +495,14 @@ A special case of this is sometimes useful
   ( x y : A)
   ( f : A → B)
   ( p : x = y)
-  : (rev B (f y) (f x) (ap A B y x f (rev A x y p))) = (ap A B x y f p)
+  : ( rev B (f y) (f x) (ap A B y x f (rev A x y p))) = (ap A B x y f p)
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' p' →
-        (rev B (f y') (f x) (ap A B y' x f (rev A x y' p'))) =
-        (ap A B x y' f p'))
+        ( rev B (f y') (f x) (ap A B y' x f (rev A x y' p')))
+      = ( ap A B x y' f p'))
       ( refl)
       ( y)
       ( p)
@@ -519,8 +519,8 @@ The following is for a specific use.
   : ( concat
       ( B) (f y) (f x) (f y)
       ( ap A B y x f (rev A x y p))
-      ( ap A B x y f p)) =
-    ( refl)
+      ( ap A B x y f p))
+  = ( refl)
   :=
     ind-path
       ( A)
@@ -528,8 +528,8 @@ The following is for a specific use.
       ( \ y' p' →
         ( concat
           ( B) (f y') (f x) (f y')
-          ( ap A B y' x f (rev A x y' p')) (ap A B x y' f p')) =
-        ( refl))
+          ( ap A B y' x f (rev A x y' p')) (ap A B x y' f p'))
+      = ( refl))
       ( refl)
       ( y)
       ( p)
@@ -538,7 +538,7 @@ The following is for a specific use.
   ( A : U)
   ( x y : A)
   ( p : x = y)
-  : (ap A A x y (identity A) p) = p
+  : ( ap A A x y (identity A) p) = p
   := ind-path (A) (x) (\ y' p' → (ap A A x y' (\ z → z) p') = p') (refl) (y) (p)
 ```
 
@@ -551,7 +551,7 @@ Application of a function to homotopic paths yields homotopic paths.
   ( f : A → B)
   ( p q : x = y)
   ( H : p = q)
-  : (ap A B x y f p) = (ap A B x y f q)
+  : ( ap A B x y f p) = (ap A B x y f q)
   :=
     ind-path
       ( x = y)
@@ -567,15 +567,15 @@ Application of a function to homotopic paths yields homotopic paths.
   ( f : A → B)
   ( g : B → C)
   ( p : x = y)
-  : ( ap A C x y (comp A B C g f) p) =
-    ( ap B C (f x) (f y) g (ap A B x y f p))
+  : ( ap A C x y (comp A B C g f) p)
+  = ( ap B C (f x) (f y) g (ap A B x y f p))
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' p' →
-        ( ap A C x y' (\ z → g (f z)) p') =
-        ( ap B C (f x) (f y') g (ap A B x y' f p')))
+        ( ap A C x y' (\ z → g (f z)) p')
+      = ( ap B C (f x) (f y') g (ap A B x y' f p')))
       ( refl)
       ( y)
       ( p)
@@ -586,8 +586,8 @@ Application of a function to homotopic paths yields homotopic paths.
   ( f : A → B)
   ( g : B → C)
   ( p : x = y)
-  : ( ap B C (f x) (f y) g (ap A B x y f p)) =
-    ( ap A C x y (comp A B C g f) p)
+  : ( ap B C (f x) (f y) g (ap A B x y f p))
+  = ( ap A C x y (comp A B C g f) p)
   :=
     rev
       ( g (f x) = g (f y))
@@ -623,7 +623,7 @@ Application of a function to homotopic paths yields homotopic paths.
   ( x y : A)
   ( p : x = y)
   ( u : B x)
-  : (x , u) =_{Σ (z : A) , B z} (y , transport x y p u)
+  : ( x , u) =_{Σ (z : A) , B z} (y , transport x y p u)
   :=
     ind-path
       ( A)
@@ -642,15 +642,15 @@ Application of a function to homotopic paths yields homotopic paths.
   ( p : x = y)
   ( q : y = z)
   ( u : B x)
-  : ( transport x z (concat A x y z p q) u) =
-    ( transport y z q (transport x y p u))
+  : ( transport x z (concat A x y z p q) u)
+  = ( transport y z q (transport x y p u))
   :=
     ind-path
       ( A)
       ( y)
       ( \ z' q' →
-        ( transport x z' (concat A x y z' p q') u) =
-        ( transport y z' q' (transport x y p u)))
+        ( transport x z' (concat A x y z' p q') u)
+      = ( transport y z' q' (transport x y p u)))
       ( refl)
       ( z)
       ( q)
@@ -660,15 +660,15 @@ Application of a function to homotopic paths yields homotopic paths.
   ( p : x = y)
   ( q : y = z)
   ( u : B x)
-  : ( transport y z q (transport x y p u)) =
-    ( transport x z (concat A x y z p q) u)
+  : ( transport y z q (transport x y p u))
+  = ( transport x z (concat A x y z p q) u)
   :=
     ind-path
       ( A)
       ( y)
       ( \ z' q' →
-        ( transport y z' q' (transport x y p u)) =
-        ( transport x z' (concat A x y z' p q') u))
+        ( transport y z' q' (transport x y p u))
+      = ( transport x z' (concat A x y z' p q') u))
       ( refl)
       ( z)
       ( q)
@@ -682,7 +682,7 @@ Application of a function to homotopic paths yields homotopic paths.
   ( p q : x = y)
   ( H : p = q)
   ( u : B x)
-  : (transport x y p u) = (transport x y q u)
+  : ( transport x y p u) = (transport x y q u)
   :=
     ind-path
       ( x = y)
@@ -699,7 +699,7 @@ Application of a function to homotopic paths yields homotopic paths.
 #def transport-loop
   ( a : A)
   ( b : B a)
-  : (a = a) → B a
+  : ( a = a) → B a
   := \ p → (transport a a p b)
 ```
 
@@ -717,15 +717,15 @@ Application of a function to homotopic paths yields homotopic paths.
   ( x y : A')
   ( p : x = y)
   ( u : B (f x))
-  : transport A' (\ x → B (f x)) x y p u =
-    transport A B (f x) (f y) (ap A' A x y f p) u
+  : transport A' (\ x → B (f x)) x y p u
+  = transport A B (f x) (f y) (ap A' A x y f p) u
   :=
     ind-path
       ( A')
       ( x)
       ( \ y' p' →
-        transport A' (\ x → B (f x)) x y' p' u =
-        transport A B (f x) (f y') (ap A' A x y' f p') u)
+        transport A' (\ x → B (f x)) x y' p' u
+      = transport A B (f x) (f y') (ap A' A x y' f p') u)
       ( refl)
       ( y)
       ( p)
@@ -739,15 +739,15 @@ Using `rev` we can deduce a path induction principle with fixed end point.
 #def ind-path-end
   ( A : U)
   ( a : A)
-  ( C : (x : A) → (x = a) -> U)
+  ( C : (x : A) → (x = a) → U)
   ( d : C a refl)
   ( x : A)
   ( p : x = a)
   : C x p
   :=
     transport (x = a) (\ q → C x q) (rev A a x (rev A x a p)) p
-      (rev-rev A x a p)
-      (ind-path A a (\ y q → C y (rev A a y q)) d x (rev A x a p))
+      ( rev-rev A x a p)
+      ( ind-path A a (\ y q → C y (rev A a y q)) d x (rev A x a p))
 ```
 
 ## Dependent application
@@ -759,12 +759,12 @@ Using `rev` we can deduce a path induction principle with fixed end point.
   ( x y : A)
   ( f : (z : A) → B z)
   ( p : x = y)
-  : (transport A B x y p (f x)) = f y
+  : ( transport A B x y p (f x)) = f y
   :=
     ind-path
       ( A)
       ( x)
-      ( (\ y' p' → (transport A B x y' p' (f x)) = f y'))
+      ( ( \ y' p' → (transport A B x y' p' (f x)) = f y'))
       ( refl)
       ( y)
       ( p)
@@ -890,14 +890,14 @@ The following is the same as above but with alternating arguments.
   ( x y : A)
   ( f : A → B)
   ( p : x = y)
-  : (ap A B y y f (triple-concat A y x x y (rev A x y p) refl p)) = refl
+  : ( ap A B y y f (triple-concat A y x x y (rev A x y p) refl p)) = refl
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' p' →
-        ( ap A B y' y' f (triple-concat A y' x x y' (rev A x y' p') refl p')) =
-        ( refl))
+        ( ap A B y' y' f (triple-concat A y' x x y' (rev A x y' p') refl p'))
+      = ( refl))
       ( refl)
       ( y)
       ( p)
@@ -909,8 +909,8 @@ The following is the same as above but with alternating arguments.
   ( p : w = x)
   ( q : x = y)
   ( r : y = z)
-  : ( ap A B w z f (triple-concat A w x y z p q r)) =
-    ( triple-concat
+  : ( ap A B w z f (triple-concat A w x y z p q r))
+  = ( triple-concat
       ( B)
       ( f w)
       ( f x)
@@ -924,8 +924,8 @@ The following is the same as above but with alternating arguments.
       ( A)
       ( y)
       ( \ z' r' →
-        ( ap A B w z' f (triple-concat A w x y z' p q r')) =
-        ( triple-concat
+        ( ap A B w z' f (triple-concat A w x y z' p q r'))
+      = ( triple-concat
           ( B)
           ( f w) (f x) (f y) (f z')
           ( ap A B w x f p)
@@ -942,7 +942,7 @@ The following is the same as above but with alternating arguments.
   ( r : x = y)
   ( s : y = z)
   ( H : p = q)
-  : (triple-concat A w x y z p r s) = (triple-concat A w x y z q r s)
+  : ( triple-concat A w x y z p r s) = (triple-concat A w x y z q r s)
   := concat-eq-left A w x z p q H (concat A x y z r s)
 
 #def triple-concat-eq-second
@@ -952,7 +952,7 @@ The following is the same as above but with alternating arguments.
   ( q r : x = y)
   ( s : y = z)
   ( H : q = r)
-  : (triple-concat A w x y z p q s) = (triple-concat A w x y z p r s)
+  : ( triple-concat A w x y z p q s) = (triple-concat A w x y z p r s)
   :=
     ind-path
       ( x = y)
@@ -1057,45 +1057,45 @@ triple compostion for ease of use in a later proof.
 
 ```rzk
 #def eq-top-cancel-commutative-square
-  (A : U)
-  (v w y z : A)
-  (p : v = w)
-  (q : w = v)
-  (s : w = y)
-  (r : v = z)
-  (t : y = z)
-  (H : (concat A w v z q r) = (concat A w y z s t))
-  (H' : (concat A v w v p q) = refl)
+  ( A : U)
+  ( v w y z : A)
+  ( p : v = w)
+  ( q : w = v)
+  ( s : w = y)
+  ( r : v = z)
+  ( t : y = z)
+  ( H : (concat A w v z q r) = (concat A w y z s t))
+  ( H' : (concat A v w v p q) = refl)
   : r = (concat A v w z p (concat A w y z s t))
   :=
-  (concat
-    (v = z)
+  ( concat
+    ( v = z)
     ( r)
     ( concat A v v z refl r)
     ( concat A v w z p (concat A w y z s t))
-    (rev
-      (v = z)
-      (concat  A v v z refl r)
-      ( r )
-      (left-unit-concat A v z r))
-    (concat
+    ( rev
+      ( v = z)
+      ( concat  A v v z refl r)
+      ( r)
+      ( left-unit-concat A v z r))
+    ( concat
       ( v = z)
       ( concat A v v z refl r)
       ( concat A v v z (concat A v w v p q) r)
-      ( concat A v w z p (concat A w y z s t ))
-      (rev
-        ( v = z )
-        (concat A v v z  (concat A v w v p q) r)
-        (concat A v v z refl r)
+      ( concat A v w z p (concat A w y z s t))
+      ( rev
+        ( v = z)
+        ( concat A v v z  (concat A v w v p q) r)
+        ( concat A v v z refl r)
         ( concat-eq-left
           ( A)
           ( v)
           ( v)
           ( z)
           ( concat A v w v p q)
-          ( refl )
+          ( refl)
           ( H')
-          ( r) ))
+          ( r)))
       ( concat
         ( v = z)
         ( concat A v v z (concat A v w v p q) r)
@@ -1126,7 +1126,7 @@ It is also convenient to have a a version with the opposite associativity.
   ( t : y = z)
   ( H : (concat A w v z q r) = (concat A w y z s t))
   ( H' : (concat A v w v p q) = refl)
-  : r = ( concat A v y z (concat A v w y p s) t)
+  : r = (concat A v y z (concat A v w y p s) t)
   :=
   concat
   ( v = z)
@@ -1232,20 +1232,20 @@ get a homotopy between `#!rzk concat (rev p) q` and `#! refl`.
 ```rzk
 
 #def htpy-id-cancel-left-concat-left-eq
-  (A : U)
-  (a b : A)
-  (p : a = b)
-  (q : a = b)
-  (H : p = q)
-  (r : b = a)
-  (H' : (concat A a b a q r) = refl)
-  : (concat A a b a p r) = refl
+  ( A : U)
+  ( a b : A)
+  ( p : a = b)
+  ( q : a = b)
+  ( H : p = q)
+  ( r : b = a)
+  ( H' : (concat A a b a q r) = refl)
+  : ( concat A a b a p r) = refl
   :=
   concat
   ( a = a)
-  ( concat A a b a p r )
-  ( concat A a b a q r )
-  ( refl )
+  ( concat A a b a p r)
+  ( concat A a b a q r)
+  ( refl)
   ( concat-eq-left A a b a p q H r)
-  ( H' )
+  ( H')
 ```

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -18,7 +18,7 @@ This is a literate `rzk` file:
 #def homotopy
   ( f g : A → B)
   : U
-  := ( a : A) → (f a = g a)
+  := (a : A) → (f a = g a)
 ```
 
 ```rzk title="The reversal of a homotopy"
@@ -45,7 +45,7 @@ The following is the unit for compositions of homotopies.
 
 ```rzk
 #def refl-htpy
-  (f : A → B)
+  ( f : A → B)
   : homotopy f f
   := \ x → refl
 ```
@@ -60,7 +60,7 @@ There is also a dependent version of homotopy.
 #def dhomotopy
   ( A : U)
   ( B : A → U)
-  (f g : (a : A) → B a)
+  ( f g : (a : A) → B a)
   : U
   := (a : A) → (f a = g a)
 ```
@@ -74,15 +74,15 @@ $K^{-1} \cdot H  \sim \text{refl-htpy}_{g}$
 
 ```rzk
 #def htpy-cancel-left
-  (A B : U)
-  (f g : A → B)
-  (H K : homotopy A B f g)
-  (C : dhomotopy A (\ a → f a = g a) H K)
+  ( A B : U)
+  ( f g : A → B)
+  ( H K : homotopy A B f g)
+  ( C : dhomotopy A (\ a → f a = g a) H K)
   : dhomotopy
     A
-    (\ b → g b = g b)
-    (\ x → concat B (g x) (f x) (g x) (rev B (f x) (g x) (K x)) (H x))
-    (refl-htpy A B g)
+    ( \ b → g b = g b)
+    ( \ x → concat B (g x) (f x) (g x) (rev B (f x) (g x) (K x)) (H x))
+    ( refl-htpy A B g)
   := \ x →
       cancel-left-path B (f x) (g x) (H x) (K x) (C x)
 ```
@@ -119,8 +119,8 @@ $K^{-1} \cdot H  \sim \text{refl-htpy}_{g}$
   : homotopy
       A
       D
-      (triple-comp A B C D g h f)
-      (triple-comp A B C D g k f)
+      ( triple-comp A B C D g h f)
+      ( triple-comp A B C D g k f)
   :=
     postwhisker-homotopy
       A
@@ -162,15 +162,15 @@ $K^{-1} \cdot H  \sim \text{refl-htpy}_{g}$
   ( H : homotopy A B f g)
   ( x y : A)
   ( p : x = y)
-  : ( concat B (f x) (f y) (g y) (ap A B x y f p) (H y)) =
-    ( concat B (f x) (g x) (g y) (H x) (ap A B x y g p))
+  : ( concat B (f x) (f y) (g y) (ap A B x y f p) (H y))
+  = ( concat B (f x) (g x) (g y) (H x) (ap A B x y g p))
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' p' →
-        ( concat B (f x) (f y') (g y') (ap A B x y' f p') (H y')) =
-        ( concat B (f x) (g x) (g y') (H x) (ap A B x y' g p')))
+        ( concat B (f x) (f y') (g y') (ap A B x y' f p') (H y'))
+      = ( concat B (f x) (g x) (g y') (H x) (ap A B x y' g p')))
       ( left-unit-concat B (f x) (g x) (H x))
       ( y)
       ( p)
@@ -185,8 +185,8 @@ It is sometimes useful to have this in inverse form.
   ( H : homotopy A B f g)
   ( x y : A)
   ( p : x = y)
-  : ( concat B (f x) (g x) (g y) (H x) (ap A B x y g p)) =
-    ( concat B (f x) (f y) (g y) (ap A B x y f p) (H y))
+  : ( concat B (f x) (g x) (g y) (H x) (ap A B x y g p))
+  = ( concat B (f x) (f y) (g y) (ap A B x y f p) (H y))
   :=
   rev
   ( f x = g y)
@@ -204,8 +204,8 @@ It is sometimes useful to have this in inverse form.
   ( p : x = y)
   : triple-concat
       ( B) (g x) (f x) (f y) (g y)
-      ( rev B (f x) (g x) (H x)) (ap A B x y f p) (H y) =
-    ap A B x y g p
+      ( rev B (f x) (g x) (H x)) (ap A B x y f p) (H y)
+  = ap A B x y g p
   :=
     ind-path
       ( A)
@@ -219,8 +219,8 @@ It is sometimes useful to have this in inverse form.
             ( g y')
             ( rev B (f x) (g x) (H x))
             ( ap A B x y' f p')
-            ( H y') =
-          ap A B x y' g p')
+            ( H y')
+        = ap A B x y' g p')
       ( rev-refl-id-triple-concat B (f x) (g x) (H x))
       ( y)
       ( p)
@@ -243,8 +243,8 @@ square.
 
 ```rzk
 #def cocone-naturality
-  : ( concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
-    ( concat A (f (f a)) (f a) (a) (H (f a)) (ap A A (f a) a (identity A) (H a)))
+  : ( concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a))
+  = ( concat A (f (f a)) (f a) (a) (H (f a)) (ap A A (f a) a (identity A) (H a)))
   := nat-htpy A A f (identity A) H (f a) a (H a)
 ```
 
@@ -253,11 +253,11 @@ following:
 
 ```rzk
 #def reduced-cocone-naturality
-  : ( concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
-    ( concat A (f (f a)) (f a) (a) (H (f a)) (H a))
+  : ( concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a))
+  = ( concat A (f (f a)) (f a) (a) (H (f a)) (H a))
   :=
     concat
-      ( (f (f a)) = a)
+      ( ( f (f a)) = a)
       ( concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a))
       ( concat
         ( A)
@@ -284,7 +284,7 @@ need:
 
 ```rzk
 #def cocone-naturality-coherence
-  : (H (f a)) = (ap A A (f a) a f (H a))
+  : ( H (f a)) = (ap A A (f a) a f (H a))
   :=
     rev
       ( f (f a) = f a)
@@ -312,8 +312,8 @@ need:
   ( α : (a : A) → H a = K a)
   ( x y : A)
   ( p : f x = f y)
-  : triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (H x)) p (H y) =
-    triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (K x)) p (K y)
+  : triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (H x)) p (H y)
+  = triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (K x)) p (K y)
   :=
     ind-path
       ( f y = g y)
@@ -321,8 +321,8 @@ need:
       ( \ Ky α' →
         ( triple-concat
           ( B) (g x) (f x) (f y) (g y)
-          ( rev B (f x) (g x) (H x)) (p) (H y)) =
-        ( triple-concat
+          ( rev B (f x) (g x) (H x)) (p) (H y))
+      = ( triple-concat
           ( B) (g x) (f x) (f y) (g y)
           ( rev B (f x) (g x) (K x)) (p) (Ky)))
       ( triple-concat-eq-first
@@ -339,5 +339,5 @@ need:
           ( rev B (f x) (g x))
           ( α x)))
       ( K y)
-      (α y)
+      ( α y)
 ```

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -42,7 +42,7 @@ We define equivalences to be bi-invertible maps.
   ( A : U)
   : is-equiv A A (\ a → a)
   :=
-    ( (\ a → a , \ _ → refl) , (\ a → a , \ _ → refl))
+    ( ( \ a → a , \ _ → refl) , (\ a → a , \ _ → refl))
 ```
 
 ## Equivalence data
@@ -106,8 +106,8 @@ The following type of more coherent equivalences is not a proposition.
   ( f : A → B)
   : U
   :=
-    Σ ( g : B → A) ,
-      ( product
+    Σ ( g : B → A)
+    , ( product
         ( homotopy A A (comp A B A g f) (identity A))
         ( homotopy B B (comp B A B f g) (identity B)))
 ```
@@ -121,8 +121,8 @@ The following type of more coherent equivalences is not a proposition.
   ( has-inverse-f : has-inverse A B f)
   : is-equiv A B f
   :=
-    ( ( first has-inverse-f , first (second has-inverse-f)) ,
-      ( first has-inverse-f , second (second has-inverse-f)))
+    ( ( first has-inverse-f , first (second has-inverse-f))
+    , ( first has-inverse-f , second (second has-inverse-f)))
 ```
 
 ```rzk title="Equivalences are invertible"
@@ -132,8 +132,8 @@ The following type of more coherent equivalences is not a proposition.
   ( is-equiv-f : is-equiv A B f)
   : has-inverse A B f
   :=
-    ( section-is-equiv A B f is-equiv-f ,
-      ( concat-homotopy A A
+    ( section-is-equiv A B f is-equiv-f
+    , ( concat-homotopy A A
         ( comp A B A (section-is-equiv A B f is-equiv-f) f)
         ( comp A B A (retraction-is-equiv A B f is-equiv-f) f)
         ( identity A)
@@ -142,8 +142,8 @@ The following type of more coherent equivalences is not a proposition.
           ( retraction-is-equiv A B f is-equiv-f)
           ( homotopy-section-retraction-is-equiv A B f is-equiv-f)
           ( f))
-        ( second (first is-equiv-f)) ,
-      ( second (second is-equiv-f))))
+        ( second (first is-equiv-f))
+    , ( second (second is-equiv-f))))
 ```
 
 ## Invertible map data
@@ -203,11 +203,11 @@ The inverse of an invertible map has an inverse.
   ( A B : U)
   ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
-  : has-inverse B A ( map-inverse-has-inverse A B f has-inverse-f)
+  : has-inverse B A (map-inverse-has-inverse A B f has-inverse-f)
   :=
-    ( f,
-      ( second ( second has-inverse-f) ,
-        first ( second has-inverse-f)))
+    ( f
+    , ( second (second has-inverse-f)
+      , first (second has-inverse-f)))
 ```
 
 ## The type of equivalences
@@ -255,7 +255,7 @@ It is convenient to have available the special case where `f` is an equivalence.
 ```rzk
 #def ind-has-section-equiv
   ( A B : U)
-  ( (f, is-equiv-f) : Equiv A B)
+  ( ( f , is-equiv-f) : Equiv A B)
   : ( C : B → U) → ((a : A) → C (f a)) → (b : B) → C b
   := ind-has-section A B f (second is-equiv-f)
 ```
@@ -271,11 +271,11 @@ invertible map to prove symmetry:
   ( e : Equiv A B)
   : Equiv B A
   :=
-    ( first (has-inverse-is-equiv A B (first e) (second e)) ,
-      ( ( first e ,
-          second (second (has-inverse-is-equiv A B (first e) (second e)))) ,
-        ( first e ,
-        first (second (has-inverse-is-equiv A B (first e) (second e))))))
+    ( first (has-inverse-is-equiv A B (first e) (second e))
+    , ( ( first e
+        , second (second (has-inverse-is-equiv A B (first e) (second e))))
+      , ( first e
+      , first (second (has-inverse-is-equiv A B (first e) (second e))))))
 ```
 
 ```rzk title="Composition of equivalences in diagrammatic order"
@@ -285,9 +285,9 @@ invertible map to prove symmetry:
   ( B≃C : Equiv B C)
   : Equiv A C
   :=
-    ( ( \ a → first B≃C (first A≃B a)) ,
-      ( ( ( \ c → first (first (second A≃B)) (first (first (second (B≃C))) c)) ,
-          ( \ a →
+    ( ( \ a → first B≃C (first A≃B a))
+    , ( ( ( \ c → first (first (second A≃B)) (first (first (second (B≃C))) c))
+        , ( \ a →
             concat A
               ( first
                 ( first (second A≃B))
@@ -301,12 +301,12 @@ invertible map to prove symmetry:
                 ( first A≃B a)
                 ( first (first (second A≃B)))
                 ( second (first (second B≃C)) (first A≃B a)))
-              ( second (first (second A≃B)) a))) ,
-        ( ( \ c →
+              ( second (first (second A≃B)) a)))
+      , ( ( \ c →
           first
             ( second (second A≃B))
-            ( first (second (second (B≃C))) c)) ,
-          ( \ c →
+            ( first (second (second (B≃C))) c))
+        , ( \ c →
             concat C
               ( first B≃C
                 ( first A≃B
@@ -341,8 +341,8 @@ Now we compose the functions that are equivalences.
   :=
     ( ( comp C B A
         ( retraction-is-equiv A B f is-equiv-f)
-        ( retraction-is-equiv B C g is-equiv-g) ,
-        ( \ a →
+        ( retraction-is-equiv B C g is-equiv-g)
+      , ( \ a →
           concat A
             ( retraction-is-equiv A B f is-equiv-f
               ( retraction-is-equiv B C g is-equiv-g (g (f a))))
@@ -353,11 +353,11 @@ Now we compose the functions that are equivalences.
               ( f a)
               ( retraction-is-equiv A B f is-equiv-f)
               ( second (first is-equiv-g) (f a)))
-            ( second (first is-equiv-f) a))) ,
-      ( comp C B A
+            ( second (first is-equiv-f) a)))
+    , ( comp C B A
         ( section-is-equiv A B f is-equiv-f)
-        ( section-is-equiv B C g is-equiv-g) ,
-        ( \ c →
+        ( section-is-equiv B C g is-equiv-g)
+      , ( \ c →
           concat C
             ( g (f (first (second is-equiv-f) (first (second is-equiv-g) c))))
             ( g (first (second is-equiv-g) c))
@@ -397,16 +397,16 @@ retraction the first map is an equivalence, and dually.
 #def ap-cancel-has-retraction
   ( B C : U)
   ( g : B → C)
-  ( (retr-g, η-g) : has-retraction B C g)
+  ( ( retr-g , η-g) : has-retraction B C g)
   ( b b' : B)
-  : (g b = g b') → (b = b')
+  : ( g b = g b') → (b = b')
   :=
     \ gp →
       triple-concat B b (retr-g (g b)) (retr-g (g b')) b'
-        (rev B (retr-g (g b)) b
-          (η-g b))
-        (ap C B (g b) (g b') retr-g gp)
-        (η-g b')
+        ( rev B (retr-g (g b)) b
+          ( η-g b))
+        ( ap C B (g b) (g b') retr-g gp)
+        ( η-g b')
 ```
 
 ```rzk title="Right cancellation of equivalence property in diagrammatic order"
@@ -415,10 +415,10 @@ retraction the first map is an equivalence, and dually.
   ( f : A → B)
   ( g : B → C)
   ( has-retraction-g : has-retraction B C g)
-  ( ( (retr-gf, η-gf), (sec-gf, ε-gf)) : is-equiv A C (comp A B C g f))
+  ( ( ( retr-gf , η-gf) , (sec-gf , ε-gf)) : is-equiv A C (comp A B C g f))
   : is-equiv A B f
   :=
-    ( ( comp B C A retr-gf g, η-gf)
+    ( ( comp B C A retr-gf g , η-gf)
     , ( comp B C A sec-gf g
       , \ b →
             ap-cancel-has-retraction B C g
@@ -432,14 +432,14 @@ retraction the first map is an equivalence, and dually.
   ( f : A → B)
   ( has-section-f : has-section A B f)
   ( g : B → C)
-  ( ( ( retr-gf, η-gf), (sec-gf, ε-gf)) : is-equiv A C (comp A B C g f))
+  ( ( ( retr-gf , η-gf) , (sec-gf , ε-gf)) : is-equiv A C (comp A B C g f))
   : is-equiv B C g
   :=
     ( ( comp C A B f retr-gf
       , ind-has-section A B f has-section-f
           ( \ b → f (retr-gf (g b)) = b)
           ( \ a → ap A B (retr-gf (g (f a))) a f (η-gf a)))
-    , ( comp C A B f sec-gf, ε-gf))
+    , ( comp C A B f sec-gf , ε-gf))
 ```
 
 We typically apply the cancelation property in a setting where the composite and
@@ -541,7 +541,7 @@ The section associated with an equivalence is an equivalence.
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
-  : is-equiv B A ( section-is-equiv A B f is-equiv-f)
+  : is-equiv B A (section-is-equiv A B f is-equiv-f)
   :=
     is-equiv-has-inverse B A
       ( section-is-equiv A B f is-equiv-f)
@@ -556,7 +556,7 @@ The retraction associated with an equivalence is an equivalence.
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
-  : is-equiv B A ( retraction-is-equiv A B f is-equiv-f)
+  : is-equiv B A (retraction-is-equiv A B f is-equiv-f)
   :=
     is-equiv-rev-homotopy B A
       ( section-is-equiv A B f is-equiv-f)
@@ -588,7 +588,7 @@ When we have such a section-retraction pair `(s, r)`, we say that `r` is an
   ( s : A → B)
   : U
   :=
-    Σ ((A', r) : ( Σ (A' : U) , B → A'))
+    Σ ( ( A' , r) : (Σ (A' : U) , B → A'))
     , ( is-section-retraction-pair A B A' s r)
 
 #def has-external-section
@@ -596,7 +596,7 @@ When we have such a section-retraction pair `(s, r)`, we say that `r` is an
   ( r : B → A')
   : U
   :=
-    Σ ((A, s) : ( Σ (A : U) , A → B))
+    Σ ( ( A , s) : (Σ (A : U) , A → B))
     , ( is-section-retraction-pair A B A' s r)
 ```
 
@@ -617,12 +617,12 @@ biimplication between them.
   : is-equiv A A (\ a → r (s a))
   :=
     is-equiv-homotopy A A (\ a → r (s (a))) (identity A)
-      ( η) ( is-equiv-identity A)
+      ( η) (is-equiv-identity A)
 
 #def has-retraction-externalize
   ( A B : U)
   ( s : A → B)
-  ( (r , η) : has-retraction A B s)
+  ( ( r , η) : has-retraction A B s)
   : has-external-retraction A B s
   :=
     ( ( A , r)
@@ -631,7 +631,7 @@ biimplication between them.
 #def has-section-externalize
   ( B A' : U)
   ( r : B → A')
-  ( (s , ε) : has-section B A' r)
+  ( ( s , ε) : has-section B A' r)
   : has-external-section B A' r
   :=
     ( ( A' , s)
@@ -640,18 +640,18 @@ biimplication between them.
 #def has-retraction-internalize
   ( A B : U)
   ( s : A → B)
-  ( ((A' , r) , ( (rec-rs , η-rs) , _))
-    : has-external-retraction A B s)
+  ( ( ( A' , r) , ((rec-rs , η-rs) , _))
+ : has-external-retraction A B s)
   : has-retraction A B s
-  := ( comp B A' A rec-rs r , η-rs)
+  := (comp B A' A rec-rs r , η-rs)
 
 #def has-section-internalize
   ( B A' : U)
   ( r : B → A')
-  ( ((A , s) , (_ , (sec-rs , ε-rs)))
-    : has-external-section B A' r)
+  ( ( ( A , s) , (_ , (sec-rs , ε-rs)))
+ : has-external-section B A' r)
   : has-section B A' r
-  := ( comp A' A B s sec-rs , ε-rs)
+  := (comp A' A B s sec-rs , ε-rs)
 ```
 
 A consequence of the above is that in a section-retraction pair `(s, r)`, the
@@ -679,15 +679,15 @@ This is just a rephrasing of `is-equiv-left-factor` and `is-equiv-right-factor`.
   : is-equiv A B s
   :=
     is-equiv-right-factor A B A' s r
-    ( is-equiv-r) ( is-sec-rec-pair)
+    ( is-equiv-r) (is-sec-rec-pair)
 
 #def is-equiv-retraction-is-equiv-section-is-section-retraction-pair
   ( is-equiv-s : is-equiv A B s)
   : is-equiv B A' r
   :=
     is-equiv-left-factor A B A'
-    ( s) ( is-equiv-s)
-    ( r) ( is-sec-rec-pair)
+    ( s) (is-equiv-s)
+    ( r) (is-sec-rec-pair)
 
 #end is-equiv-is-section-retraction-pair
 ```
@@ -701,24 +701,24 @@ which has a retraction.
 #def is-retract-of
   ( A B : U)
   : U
-  := Σ ( s : A → B) , has-retraction A B s
+  := Σ (s : A → B) , has-retraction A B s
 
 #def section-is-retract-of
   ( A B : U)
-  ( (s , (_ , _)) : is-retract-of A B)
+  ( ( s , (_ , _)) : is-retract-of A B)
   : A → B
   := s
 
 #def retraction-is-retract-of
   ( A B : U)
-  ( (_ , (r , _)) : is-retract-of A B)
+  ( ( _ , (r , _)) : is-retract-of A B)
   : B → A
   := r
 
 #def homotopy-is-retract-of
   ( A B : U)
-  ( (s , (r , η)) : is-retract-of A B)
-  : homotopy A A ( \ a → r ( s a)) ( identity A)
+  ( ( s , (r , η)) : is-retract-of A B)
+  : homotopy A A (\ a → r (s a)) (identity A)
   := η
 ```
 
@@ -743,9 +743,9 @@ and `A'` as retracts of `B`.
   ( is-sr-pair-sr : is-section-retraction-pair A B A' s r)
   : is-retract-of A' B
   :=
-    ( first ( has-section-internalize B A' r ((A , s) , is-sr-pair-sr))
+    ( first (has-section-internalize B A' r ((A , s) , is-sr-pair-sr))
     , ( r
-      , second ( has-section-internalize B A' r ((A , s) , is-sr-pair-sr))))
+      , second (has-section-internalize B A' r ((A , s) , is-sr-pair-sr))))
 ```
 
 ## Function extensionality
@@ -758,10 +758,10 @@ By path induction, an identification between functions defines a homotopy.
   ( A : X → U)
   ( f g : (x : X) → A x)
   ( p : f = g)
-  : (x : X) → (f x = g x)
+  : ( x : X) → (f x = g x)
   :=
     ind-path
-      ( (x : X) → A x)
+      ( ( x : X) → A x)
       ( f)
       ( \ g' p' → (x : X) → (f x = g' x))
       ( \ x → refl)
@@ -773,13 +773,14 @@ The function extensionality axiom asserts that this map defines a family of
 equivalences.
 
 ```rzk title="The type that encodes the function extensionality axiom"
-#def FunExt : U
+#def FunExt
+  : U
   :=
-    ( X : U) →
-    ( A : X → U) →
-    ( f : (x : X) → A x) →
-    ( g : (x : X) → A x) →
-    is-equiv (f = g) ((x : X) → f x = g x) (htpy-eq X A f g)
+    ( X : U)
+  → ( A : X → U)
+  → ( f : (x : X) → A x)
+  → ( g : (x : X) → A x)
+  → is-equiv (f = g) ((x : X) → f x = g x) (htpy-eq X A f g)
 ```
 
 In the formalisations below, some definitions will assume function
@@ -811,14 +812,14 @@ identifications. This defines `#!rzk eq-htpy` to be the retraction to
   ( X : U)
   ( A : X → U)
   ( f g : (x : X) → A x)
-  : ((x : X) → f x = g x) → (f = g)
+  : ( ( x : X) → f x = g x) → (f = g)
   := first (first (funext X A f g))
 
 #def left-cancel-is-equiv uses (funext)
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
-  : (comp A B A (π₁ (π₁ is-equiv-f)) f) = (identity A)
+  : ( comp A B A (π₁ (π₁ is-equiv-f)) f) = (identity A)
   :=
     eq-htpy A (\ x' → A)
     ( comp A B A (π₁ (π₁ is-equiv-f)) f)
@@ -829,7 +830,7 @@ identifications. This defines `#!rzk eq-htpy` to be the retraction to
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
-  : (comp B A B f (π₁ (π₂ is-equiv-f))) = (identity B)
+  : ( comp B A B f (π₁ (π₂ is-equiv-f))) = (identity B)
   :=
     eq-htpy B (\ x' → B)
     ( comp B A B f (π₁ (π₂ is-equiv-f)))
@@ -846,7 +847,7 @@ dependent function types.
   ( A B : X → U)
   ( f : (x : X) → (A x) → (B x))
   ( famisequiv : (x : X) → is-equiv (A x) (B x) (f x))
-  : is-equiv ((x : X) → A x) ((x : X) → B x) ( \ a x → f x (a x))
+  : is-equiv ((x : X) → A x) ((x : X) → B x) (\ a x → f x (a x))
   :=
     ( ( ( \ b x → first (first (famisequiv x)) (b x))
       , ( \ a →
@@ -910,7 +911,7 @@ dependent function types.
   ( is-emb-f : is-emb A B f)
   ( x y : A)
   ( p : f x = f y)
-  : (x = y)
+  : ( x = y)
   := first (first (is-emb-f x y)) p
 ```
 
@@ -929,9 +930,9 @@ dependent function types.
   ( A : U)
   ( x y : A)
   ( B : (x = y) → U)
-  : ((p : y = x) → B (rev A y x p)) → ( q : x = y) → B q
+  : ( ( p : y = x) → B (rev A y x p)) → (q : x = y) → B q
   :=
-    ind-has-section-equiv (y = x) (x = y) (equiv-rev A y x) ( B)
+    ind-has-section-equiv (y = x) (x = y) (equiv-rev A y x) (B)
 ```
 
 ## Concatenation with a fixed path is an equivalence
@@ -944,13 +945,14 @@ dependent function types.
   : Equiv (y = z) (x = z)
   :=
     ( concat A x y z p
-    , ( ( concat A y x z (rev A x y p), retraction-preconcat A x y z p)
-      , ( concat A y x z (rev A x y p), section-preconcat A x y z p)))
+    , ( ( concat A y x z (rev A x y p) , retraction-preconcat A x y z p)
+      , ( concat A y x z (rev A x y p) , section-preconcat A x y z p)))
 
 #def equiv-postconcat
   ( A : U)
   ( x y z : A)
-  ( q : y = z) : Equiv (x = y) (x = z)
+  ( q : y = z)
+  : Equiv (x = y) (x = z)
   :=
     ( \ p → concat A x y z p q
     , ( ( \ r → concat A x z y r (rev A y z q)
@@ -966,10 +968,10 @@ dependent function types.
   ( A : U)
   ( C : A → U)
   ( x : A)
-  : (y : A) → ( p : x = y) → is-equiv (C x) (C y) (transport A C x y p)
+  : ( y : A) → (p : x = y) → is-equiv (C x) (C y) (transport A C x y p)
   := ind-path A x
        ( \ y p → is-equiv (C x) (C y) (transport A C x y p))
-       ( is-equiv-identity (C x) )
+       ( is-equiv-identity (C x))
 
 #def equiv-transport
   ( A : U)
@@ -990,12 +992,12 @@ dependent function types.
   ( β : B' → B)
   : U
   :=
-    Σ ( ( s',s) : product ( A' → B' ) ( A → B))
-    , ( ( a' : A') → β ( s' a') = s ( α a'))
+    Σ ( ( s' , s) : product (A' → B') (A → B))
+    , ( ( a' : A') → β (s' a') = s (α a'))
 
 #def map-Map
-  ( ((A',A),α) : Map)
-  ( ((B',B),β) : Map)
+  ( ( ( A' , A) , α) : Map)
+  ( ( ( B' , B) , β) : Map)
   : U
   := map-of-maps A' A α B' B β
 
@@ -1006,7 +1008,7 @@ dependent function types.
   ( β : B' → B)
   : U
   :=
-    Σ ( ((s', s), _) : map-of-maps A' A α B' B β)
+    Σ ( ( ( s' , s) , _) : map-of-maps A' A α B' B β)
     , ( product
         ( is-equiv A' B' s')
         ( is-equiv A B s))
@@ -1016,7 +1018,7 @@ dependent function types.
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
-  ( ((s', s), η) : map-of-maps A' A α B' B β)
+  ( ( ( s' , s) , η) : map-of-maps A' A α B' B β)
   ( is-equiv-s' : is-equiv A' B' s')
   ( is-equiv-s : is-equiv A B s)
   ( is-equiv-β : is-equiv B' B β)
@@ -1026,7 +1028,7 @@ dependent function types.
       ( is-equiv-rev-homotopy A' B
         ( comp A' B' B β s')
         ( comp A' A B s α)
-        ( η )
+        ( η)
         ( is-equiv-comp A' B' B s' is-equiv-s' β is-equiv-β))
 
 #def is-equiv-Equiv-is-equiv
@@ -1034,7 +1036,7 @@ dependent function types.
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
-  ( ( S, (is-equiv-s',is-equiv-s)) : Equiv-of-maps A' A α B' B β )
+  ( ( S , (is-equiv-s' , is-equiv-s)) : Equiv-of-maps A' A α B' B β)
   : is-equiv B' B β → is-equiv A' A α
   := is-equiv-equiv-is-equiv A' A α B' B β S is-equiv-s' is-equiv-s
 
@@ -1043,7 +1045,7 @@ dependent function types.
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
-  ( ((s', s), η) : map-of-maps A' A α B' B β)
+  ( ( ( s' , s) , η) : map-of-maps A' A α B' B β)
   ( is-equiv-s' : is-equiv A' B' s')
   ( is-equiv-s : is-equiv A B s)
   ( is-equiv-α : is-equiv A' A α)
@@ -1061,7 +1063,7 @@ dependent function types.
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
-  ( ( S, (is-equiv-s',is-equiv-s)) : Equiv-of-maps A' A α B' B β )
+  ( ( S , (is-equiv-s' , is-equiv-s)) : Equiv-of-maps A' A α B' B β)
   : is-equiv A' A α → is-equiv B' B β
   := is-equiv-equiv-is-equiv' A' A α B' B β S is-equiv-s' is-equiv-s
 ```

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -17,10 +17,10 @@ We'll require a more coherent notion of equivalence. Namely, the notion of
   ( f : A → B)
   : U
   :=
-    Σ ( has-inverse-f : (has-inverse A B f)) ,
-      ( ( a : A) →
-        ( second (second has-inverse-f) (f a)) =
-        ( ap A B
+    Σ ( has-inverse-f : (has-inverse A B f))
+    , ( ( a : A)
+      → ( second (second has-inverse-f) (f a))
+      = ( ap A B
           ( retraction-composite-has-inverse A B f has-inverse-f a)
           ( a)
           ( f)
@@ -32,14 +32,14 @@ one:
 
 ```rzk
 #def is-half-adjoint-equiv'
-  (A B : U)
-  (f : A → B)
+  ( A B : U)
+  ( f : A → B)
   : U
   :=
-    Σ ( has-inverse-f : (has-inverse A B f)) ,
-      ( ( a : A) →
-        ( second (second has-inverse-f) (f a)) =
-        ( ap A B
+    Σ ( has-inverse-f : (has-inverse A B f))
+    , ( ( a : A)
+      → ( second (second has-inverse-f) (f a))
+      = ( ap A B
           ( retraction-composite-has-inverse A B f has-inverse-f a)
           ( a)
           ( f)
@@ -70,8 +70,8 @@ one:
 
 #def coherence-is-half-adjoint-equiv
   ( a : A)
-  : section-htpy-is-half-adjoint-equiv (f a) =
-    ap A B (map-inverse-is-half-adjoint-equiv (f a)) a f
+  : section-htpy-is-half-adjoint-equiv (f a)
+  = ap A B (map-inverse-is-half-adjoint-equiv (f a)) a f
     ( retraction-htpy-is-half-adjoint-equiv a)
   := (second is-hae-f) a
 
@@ -90,7 +90,7 @@ and discard the other.
   ( has-inverse-f : has-inverse A B f)
   : homotopy A A
     ( retraction-composite-has-inverse A B f has-inverse-f) (identity A)
-  := ( first (second has-inverse-f))
+  := (first (second has-inverse-f))
 
 #def has-inverse-discarded-htpy
   ( A B : U)
@@ -120,8 +120,8 @@ following naturality square.
     ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
       ( triple-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a))
-    ( has-inverse-discarded-htpy A B f has-inverse-f (f a)) =
-    concat B
+    ( has-inverse-discarded-htpy A B f has-inverse-f (f a))
+  = concat B
     ( quintuple-composite-has-inverse A B f has-inverse-f a)
       ( triple-composite-has-inverse A B f has-inverse-f a)
       ( f a)
@@ -144,8 +144,8 @@ We build a path that will be whiskered into the naturality square above:
 ```rzk
 #def has-inverse-cocone-homotopy-coherence
   : has-inverse-kept-htpy A B f has-inverse-f
-      ( retraction-composite-has-inverse A B f has-inverse-f a) =
-    ap A A (retraction-composite-has-inverse A B f has-inverse-f a) a
+      ( retraction-composite-has-inverse A B f has-inverse-f a)
+  = ap A A (retraction-composite-has-inverse A B f has-inverse-f a) a
       ( retraction-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a)
   :=
@@ -162,8 +162,8 @@ We build a path that will be whiskered into the naturality square above:
     ( retraction-composite-has-inverse A B f has-inverse-f a)
     ( f)
     ( has-inverse-kept-htpy A B f has-inverse-f
-      ( retraction-composite-has-inverse A B f has-inverse-f a)) =
-    ap A B
+      ( retraction-composite-has-inverse A B f has-inverse-f a))
+  = ap A B
     ( retraction-composite-has-inverse A B f has-inverse-f
       ( retraction-composite-has-inverse A B f has-inverse-f a))
     ( retraction-composite-has-inverse A B f has-inverse-f a)
@@ -191,14 +191,14 @@ We build a path that will be whiskered into the naturality square above:
     ( retraction-composite-has-inverse A B f has-inverse-f a)
     ( f)
     ( has-inverse-kept-htpy A B f has-inverse-f
-      ( retraction-composite-has-inverse A B f has-inverse-f a)) =
-    ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
+      ( retraction-composite-has-inverse A B f has-inverse-f a))
+  = ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
       ( triple-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
     concat
-      ( quintuple-composite-has-inverse A B f has-inverse-f a =
-        triple-composite-has-inverse A B f has-inverse-f a)
+      ( quintuple-composite-has-inverse A B f has-inverse-f a
+      = triple-composite-has-inverse A B f has-inverse-f a)
       ( ap A B
         ( retraction-composite-has-inverse A B f has-inverse-f
           ( retraction-composite-has-inverse A B f has-inverse-f a))
@@ -242,8 +242,8 @@ rotation.
       ( f)
       ( has-inverse-kept-htpy A B f has-inverse-f
         ( retraction-composite-has-inverse A B f has-inverse-f a)))
-    ( has-inverse-discarded-htpy A B f has-inverse-f (f a)) =
-    concat B
+    ( has-inverse-discarded-htpy A B f has-inverse-f (f a))
+  = concat B
     ( quintuple-composite-has-inverse A B f has-inverse-f a)
     ( triple-composite-has-inverse A B f has-inverse-f a)
     ( f a)
@@ -307,36 +307,36 @@ This will replace the discarded homotopy.
   :=
     \ b →
       concat B
-        ( (section-composite-has-inverse A B f has-inverse-f) b)
-        ( (section-composite-has-inverse A B f has-inverse-f)
-          ((section-composite-has-inverse A B f has-inverse-f) b))
+        ( ( section-composite-has-inverse A B f has-inverse-f) b)
+        ( ( section-composite-has-inverse A B f has-inverse-f)
+          ( ( section-composite-has-inverse A B f has-inverse-f) b))
         ( b)
         ( rev B
-          ( (section-composite-has-inverse A B f has-inverse-f)
-            ((section-composite-has-inverse A B f has-inverse-f) b))
-          ( (section-composite-has-inverse A B f has-inverse-f) b)
+          ( ( section-composite-has-inverse A B f has-inverse-f)
+            ( ( section-composite-has-inverse A B f has-inverse-f) b))
+          ( ( section-composite-has-inverse A B f has-inverse-f) b)
           ( has-inverse-discarded-htpy A B f has-inverse-f
-            ((section-composite-has-inverse A B f has-inverse-f) b)))
+            ( ( section-composite-has-inverse A B f has-inverse-f) b)))
         ( concat B
-          ( (section-composite-has-inverse A B f has-inverse-f)
-            ((section-composite-has-inverse A B f has-inverse-f) b))
-          ( (section-composite-has-inverse A B f has-inverse-f) b)
+          ( ( section-composite-has-inverse A B f has-inverse-f)
+            ( ( section-composite-has-inverse A B f has-inverse-f) b))
+          ( ( section-composite-has-inverse A B f has-inverse-f) b)
           ( b)
           ( ap A B
-            ( (retraction-composite-has-inverse A B f has-inverse-f)
-              (map-inverse-has-inverse A B f has-inverse-f b))
+            ( ( retraction-composite-has-inverse A B f has-inverse-f)
+              ( map-inverse-has-inverse A B f has-inverse-f b))
             ( map-inverse-has-inverse A B f has-inverse-f b) f
-            ( (first (second has-inverse-f))
-              (map-inverse-has-inverse A B f has-inverse-f b)))
-          ( (has-inverse-discarded-htpy A B f has-inverse-f b)))
+            ( ( first (second has-inverse-f))
+              ( map-inverse-has-inverse A B f has-inverse-f b)))
+          ( ( has-inverse-discarded-htpy A B f has-inverse-f b)))
 ```
 
 The following is the half adjoint coherence.
 
 ```rzk
 #def has-inverse-coherence
-  : ( has-inverse-corrected-htpy (f a)) =
-    ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
+  : ( has-inverse-corrected-htpy (f a))
+  = ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
     triangle-rotation B
@@ -344,18 +344,18 @@ The following is the half adjoint coherence.
       ( triple-composite-has-inverse A B f has-inverse-f a)
       ( f a)
       ( concat B
-        ( (section-composite-has-inverse A B f has-inverse-f)
-          ((section-composite-has-inverse A B f has-inverse-f) (f a)))
-        ( (section-composite-has-inverse A B f has-inverse-f) (f a))
+        ( ( section-composite-has-inverse A B f has-inverse-f)
+          ( ( section-composite-has-inverse A B f has-inverse-f) (f a)))
+        ( ( section-composite-has-inverse A B f has-inverse-f) (f a))
         ( f a)
         ( ap A B
-          ( (retraction-composite-has-inverse A B f has-inverse-f)
-            (map-inverse-has-inverse A B f has-inverse-f (f a)))
+          ( ( retraction-composite-has-inverse A B f has-inverse-f)
+            ( map-inverse-has-inverse A B f has-inverse-f (f a)))
           ( map-inverse-has-inverse A B f has-inverse-f (f a))
             ( f)
-            ( (first (second has-inverse-f))
-              (map-inverse-has-inverse A B f has-inverse-f (f a))))
-        ( (has-inverse-discarded-htpy A B f has-inverse-f (f a))))
+            ( ( first (second has-inverse-f))
+              ( map-inverse-has-inverse A B f has-inverse-f (f a))))
+        ( ( has-inverse-discarded-htpy A B f has-inverse-f (f a))))
       ( has-inverse-discarded-htpy A B f has-inverse-f
         ( triple-composite-has-inverse A B f has-inverse-f a))
       ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
@@ -380,9 +380,9 @@ one.
   ( has-inverse-f : has-inverse A B f)
   : has-inverse A B f
   :=
-    ( map-inverse-has-inverse A B f has-inverse-f ,
-      ( has-inverse-kept-htpy A B f has-inverse-f ,
-        has-inverse-corrected-htpy A B f has-inverse-f))
+    ( map-inverse-has-inverse A B f has-inverse-f
+    , ( has-inverse-kept-htpy A B f has-inverse-f
+      , has-inverse-corrected-htpy A B f has-inverse-f))
 ```
 
 ```rzk title="Invertible maps are half adjoint equivalences!"
@@ -392,8 +392,8 @@ one.
   ( has-inverse-f : has-inverse A B f)
   : is-half-adjoint-equiv A B f
   :=
-    ( corrected-has-inverse-has-inverse A B f has-inverse-f ,
-      has-inverse-coherence A B f has-inverse-f)
+    ( corrected-has-inverse-has-inverse A B f has-inverse-f
+    , has-inverse-coherence A B f has-inverse-f)
 ```
 
 ```rzk title="Equivalences are half adjoint equivalences!"
@@ -423,29 +423,29 @@ have equivalent identity types by showing that equivalences are embeddings.
   ( x y : A)
   : iff (x = y) (f x = f y)
   :=
-    ( ap A B x y f ,
-      \ q →
+    ( ap A B x y f
+    , \ q →
       triple-concat A
         ( x)
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
         ( y)
         ( rev A (retraction-composite-has-inverse A B f (first is-hae-f) x) x
-          ( (first (second (first is-hae-f))) x))
+          ( ( first (second (first is-hae-f))) x))
         ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q)
-        ( (first (second (first is-hae-f))) y))
+        ( ( first (second (first is-hae-f))) y))
 
 #def has-retraction-ap-is-half-adjoint-equiv
-  (x y : A)
+  ( x y : A)
   : has-retraction (x = y) (f x = f y) (ap A B x y f)
   :=
-    ( ( second (iff-ap-is-half-adjoint-equiv x y)) ,
-      ( ind-path
+    ( ( second (iff-ap-is-half-adjoint-equiv x y))
+    , ( ind-path
           ( A)
           ( x)
           ( \ y' p' →
-            ( second (iff-ap-is-half-adjoint-equiv x y')) (ap A B x y' f p') =
-            ( p'))
+            ( second (iff-ap-is-half-adjoint-equiv x y')) (ap A B x y' f p')
+          = ( p'))
           ( rev-refl-id-triple-concat A
             ( map-inverse-has-inverse A B f (first is-hae-f) (f x))
             ( x)
@@ -455,33 +455,33 @@ have equivalent identity types by showing that equivalences are embeddings.
 #def ap-triple-concat-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
-  : ap A B x y f ((second (iff-ap-is-half-adjoint-equiv x y)) q) =
-    (triple-concat B
+  : ap A B x y f ((second (iff-ap-is-half-adjoint-equiv x y)) q)
+  = ( triple-concat B
       ( f x)
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
       ( f y)
       ( ap A B x ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) f
         ( rev A (retraction-composite-has-inverse A B f (first is-hae-f) x) x
-          ( (first (second (first is-hae-f))) x)))
+          ( ( first (second (first is-hae-f))) x)))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
         ( f)
         ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
       ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-        ( (first (second (first is-hae-f))) y)))
+        ( ( first (second (first is-hae-f))) y)))
   :=
     ap-triple-concat A B
       ( x)
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
       ( y)
       ( f)
       ( rev A (retraction-composite-has-inverse A B f (first is-hae-f) x) x
-        ( (first (second (first is-hae-f))) x))
+        ( ( first (second (first is-hae-f))) x))
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q)
-      ( (first (second (first is-hae-f))) y)
+      ( ( first (second (first is-hae-f))) y)
 
 #def ap-rev-triple-concat-eq-first-is-half-adjoint-equiv
   ( x y : A)
@@ -492,33 +492,33 @@ have equivalent identity types by showing that equivalences are embeddings.
     ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
     ( f y)
     ( ap A B x ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) f
-      (rev A (retraction-composite-has-inverse A B f (first is-hae-f) x) x
-        ( (first (second (first is-hae-f))) x)))
+      ( rev A (retraction-composite-has-inverse A B f (first is-hae-f) x) x
+        ( ( first (second (first is-hae-f))) x)))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
       ( f)
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
     ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-      ( (first (second (first is-hae-f))) y)) =
-    triple-concat B
+      ( ( first (second (first is-hae-f))) y))
+  = triple-concat B
     ( f x)
     ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)))
     ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
     ( f y)
     ( rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
       ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-        ( (first (second (first is-hae-f))) x)))
+        ( ( first (second (first is-hae-f))) x)))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
       ( f)
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
       ( y)
       ( f)
-      ( (first (second (first is-hae-f))) y))
+      ( ( first (second (first is-hae-f))) y))
   :=
     triple-concat-eq-first B
     ( f x)
@@ -528,24 +528,24 @@ have equivalent identity types by showing that equivalences are embeddings.
     ( ap A B
       ( x) ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) f
       ( rev A (retraction-composite-has-inverse A B f (first is-hae-f) x) x
-        ( (first (second (first is-hae-f))) x)))
+        ( ( first (second (first is-hae-f))) x)))
     ( rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
       ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-        ( (first (second (first is-hae-f))) x)))
+        ( ( first (second (first is-hae-f))) x)))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-      ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+      ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
       ( f)
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
     ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-      ( (first (second (first is-hae-f))) y))
+      ( ( first (second (first is-hae-f))) y))
     ( ap-rev A B (retraction-composite-has-inverse A B f (first is-hae-f) x) x f
-      ( (first (second (first is-hae-f))) x))
+      ( ( first (second (first is-hae-f))) x))
 
 #def ap-ap-triple-concat-eq-first-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
-  : (triple-concat B
+  : ( triple-concat B
       ( f x)
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
@@ -554,16 +554,16 @@ have equivalent identity types by showing that equivalences are embeddings.
         ( f (retraction-composite-has-inverse A B f (first is-hae-f) x))
         ( f x)
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-          ( (first (second (first is-hae-f))) x)))
+          ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
+          ( ( first (second (first is-hae-f))) x)))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
         ( f)
         ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
       ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-        ( (first (second (first is-hae-f))) y))) =
-    ( triple-concat B
+        ( ( first (second (first is-hae-f))) y)))
+  = ( triple-concat B
       ( f x)
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
@@ -571,7 +571,7 @@ have equivalent identity types by showing that equivalences are embeddings.
       ( rev B
         ( f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
         ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-          ( (first (second (first is-hae-f))) x)))
+          ( ( first (second (first is-hae-f))) x)))
       ( ap B B (f x) (f y)
         ( section-composite-has-inverse A B f (first is-hae-f)) q)
       ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y
@@ -582,17 +582,17 @@ have equivalent identity types by showing that equivalences are embeddings.
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
       ( f y)
-      ( rev B ( f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
+      ( rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
         ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-          ( (first (second (first is-hae-f))) x)))
+          ( ( first (second (first is-hae-f))) x)))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-        ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+        ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y))
         ( f)
         ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
       ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-hae-f)) q)
       ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-        ( (first (second (first is-hae-f))) y))
+        ( ( first (second (first is-hae-f))) y))
       ( rev-ap-comp B A B (f x) (f y)
         ( map-inverse-has-inverse A B f (first is-hae-f)) f q)
 
@@ -605,27 +605,27 @@ have equivalent identity types by showing that equivalences are embeddings.
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
       ( f y)
-      ( rev B ( f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
-        ( (second (second (first is-hae-f))) (f x)))
+      ( rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
+        ( ( second (second (first is-hae-f))) (f x)))
       ( ap B B (f x) (f y)
         ( section-composite-has-inverse A B f (first is-hae-f)) q)
-      ( (second (second (first is-hae-f))) (f y)) =
-    triple-concat B
+      ( ( second (second (first is-hae-f))) (f y))
+  = triple-concat B
       ( f x)
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
       ( f y)
-      (rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
-        (ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f ((first (second (first is-hae-f))) x)))
-        (ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-hae-f)) q)
-        (ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f ((first (second (first is-hae-f))) y))
+      ( rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
+        ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f ((first (second (first is-hae-f))) x)))
+        ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-hae-f)) q)
+        ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f ((first (second (first is-hae-f))) y))
   :=
     triple-concat-higher-homotopy A B
       ( triple-composite-has-inverse A B f (first is-hae-f)) f
       ( \ a → (((second (second (first is-hae-f)))) (f a)))
       ( \ a →
         ( ap A B (retraction-composite-has-inverse A B f (first is-hae-f) a) a f
-          ( ((first (second (first is-hae-f)))) a)))
+          ( ( ( first (second (first is-hae-f)))) a)))
       ( second is-hae-f)
       ( x)
       ( y)
@@ -641,15 +641,15 @@ have equivalent identity types by showing that equivalences are embeddings.
     ( f ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)))
     ( f y)
     ( rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
-      ( ((second (second (first is-hae-f)))) (f x)))
+      ( ( ( second (second (first is-hae-f)))) (f x)))
     ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-hae-f)) q)
-    ( ((second (second (first is-hae-f)))) (f y))
+    ( ( ( second (second (first is-hae-f)))) (f y))
     = ap B B (f x) (f y) (identity B) q
   :=
     triple-concat-nat-htpy B B
       ( section-composite-has-inverse A B f (first is-hae-f))
       ( identity B)
-      ( (second (second (first is-hae-f))))
+      ( ( second (second (first is-hae-f))))
       ( f x)
       ( f y)
       q
@@ -664,11 +664,11 @@ have equivalent identity types by showing that equivalences are embeddings.
     ( f y)
     ( rev B (f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
       ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-        ( (first (second (first is-hae-f))) x)))
+        ( ( first (second (first is-hae-f))) x)))
     ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-hae-f)) q)
     ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-      ( (first (second (first is-hae-f))) y)) =
-    ap B B (f x) (f y) (identity B) q
+      ( ( first (second (first is-hae-f))) y))
+  = ap B B (f x) (f y) (identity B) q
   :=
     zag-zig-concat (f x = f y)
       ( triple-concat B
@@ -679,7 +679,7 @@ have equivalent identity types by showing that equivalences are embeddings.
         ( rev B
           ( f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
           ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-            ( (first (second (first is-hae-f))) x)))
+            ( ( first (second (first is-hae-f))) x)))
         ( ap B B (f x) (f y)
           ( section-composite-has-inverse A B f (first is-hae-f)) q)
         ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y
@@ -692,10 +692,10 @@ have equivalent identity types by showing that equivalences are embeddings.
         ( rev B
           ( f (retraction-composite-has-inverse A B f (first is-hae-f) x))
           ( f x)
-          ( ((second (second (first is-hae-f)))) (f x)))
+          ( ( ( second (second (first is-hae-f)))) (f x)))
         ( ap B B (f x) (f y)
           ( section-composite-has-inverse A B f (first is-hae-f)) q)
-        ( ((second (second (first is-hae-f)))) (f y)))
+        ( ( ( second (second (first is-hae-f)))) (f y)))
       ( ap B B (f x) (f y) (identity B) q)
       ( triple-concat-higher-homotopy-is-half-adjoint-equiv x y q)
       ( triple-concat-nat-htpy-is-half-adjoint-equiv x y q)
@@ -720,13 +720,13 @@ have equivalent identity types by showing that equivalences are embeddings.
         ( f y)
         ( ap A B x ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) f
           ( rev A (retraction-composite-has-inverse A B f (first is-hae-f) x) x
-            ( (first (second (first is-hae-f))) x)))
+            ( ( first (second (first is-hae-f))) x)))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-          ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y)) f
+          ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+          ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y)) f
           ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
         ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-          ( (first (second (first is-hae-f))) y)))
+          ( ( first (second (first is-hae-f))) y)))
       ( ap-triple-concat-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
@@ -736,13 +736,13 @@ have equivalent identity types by showing that equivalences are embeddings.
         ( rev B
           ( f (retraction-composite-has-inverse A B f (first is-hae-f) x)) (f x)
           ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-            ( (first (second (first is-hae-f))) x)))
+            ( ( first (second (first is-hae-f))) x)))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first is-hae-f)) (f x))
-          ( (map-inverse-has-inverse A B f (first is-hae-f)) (f y)) f
+          ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f x))
+          ( ( map-inverse-has-inverse A B f (first is-hae-f)) (f y)) f
           ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-hae-f)) q))
         ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y f
-          ( (first (second (first is-hae-f))) y)))
+          ( ( first (second (first is-hae-f))) y)))
       ( ap-rev-triple-concat-eq-first-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
@@ -753,7 +753,7 @@ have equivalent identity types by showing that equivalences are embeddings.
           ( f (retraction-composite-has-inverse A B f (first is-hae-f) x))
           ( f x)
           ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f x)) x f
-            ( (first (second (first is-hae-f))) x)))
+            ( ( first (second (first is-hae-f))) x)))
         ( ap B B (f x) (f y)
           ( section-composite-has-inverse A B f (first is-hae-f)) q)
         ( ap A B ((map-inverse-has-inverse A B f (first is-hae-f)) (f y)) y
@@ -768,15 +768,15 @@ have equivalent identity types by showing that equivalences are embeddings.
   ( x y : A)
   : has-section (x = y) (f x = f y) (ap A B x y f)
   :=
-    ( second (iff-ap-is-half-adjoint-equiv x y) ,
-      section-htpy-ap-is-half-adjoint-equiv x y)
+    ( second (iff-ap-is-half-adjoint-equiv x y)
+    , section-htpy-ap-is-half-adjoint-equiv x y)
 
 #def is-equiv-ap-is-half-adjoint-equiv uses (is-hae-f)
   ( x y : A)
   : is-equiv (x = y) (f x = f y) (ap A B x y f)
   :=
-    ( has-retraction-ap-is-half-adjoint-equiv x y ,
-      has-section-ap-is-half-adjoint-equiv x y)
+    ( has-retraction-ap-is-half-adjoint-equiv x y
+    , has-section-ap-is-half-adjoint-equiv x y)
 
 #end equiv-identity-types-equiv
 
@@ -824,61 +824,61 @@ reversals.
 
 ```rzk
 #def ap-rev-retr-htpy-concat-sec-htpy-is-refl-is-hae
-  (A B : U)
-  (f : A → B)
-  (a : A)
-  (b : B)
-  (q : (f a) = b)
-  (is-hae : is-half-adjoint-equiv A B f)
-  : (concat ( B)
+  ( A B : U)
+  ( f : A → B)
+  ( a : A)
+  ( b : B)
+  ( q : (f a) = b)
+  ( is-hae : is-half-adjoint-equiv A B f)
+  : ( concat (B)
       ( f a)
-      ( f ((map-inverse-is-half-adjoint-equiv  A B f is-hae) (f a )))
+      ( f ((map-inverse-is-half-adjoint-equiv  A B f is-hae) (f a)))
       ( f a)
-      (ap ( A) ( B)
+      ( ap (A) (B)
         ( a)
-        (((map-inverse-is-half-adjoint-equiv A B f is-hae) ( f a)))
+        ( ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
         ( f)
-        ( rev ( A)
-          ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+        ( rev (A)
+          ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
           ( a)
-          ((retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
-      ( (section-htpy-is-half-adjoint-equiv A B f is-hae) (f a)))
+          ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
+      ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) (f a)))
       = refl
   :=
   htpy-id-cancel-left-concat-left-eq
   ( B)
-  (f a)
+  ( f a)
   ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
-  ( ap ( A) ( B)
+  ( ap (A) (B)
     ( a)
-    ( (map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+    ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
     ( f)
-    (rev ( A)
-      (((map-inverse-is-half-adjoint-equiv A B f is-hae) ( f a)))
+    ( rev (A)
+      ( ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
       ( a)
-      ( (retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
-  ( rev ( B)
+      ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
+  ( rev (B)
     ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
     ( f a)
-    ( ap ( A) ( B)
-      ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+    ( ap (A) (B)
+      ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
       ( a)
       ( f)
-      (( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a) ))
-  ( ap-rev ( A) ( B)
-    (((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
+      ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
+  ( ap-rev (A) (B)
+    ( ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
     ( a)
     ( f)
     ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a))
-  ( (section-htpy-is-half-adjoint-equiv A B f is-hae) (f a))
+  ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) (f a))
   ( cancel-left-path
     ( B)
     ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
     ( f a)
-    ( (section-htpy-is-half-adjoint-equiv A B f is-hae) (f a))
+    ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) (f a))
     ( ( ap A B ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)) a f
-        (( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
-    ( ((coherence-is-half-adjoint-equiv A B f is-hae) a)))
+        ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
+    ( ( ( coherence-is-half-adjoint-equiv A B f is-hae) a)))
 ```
 
 Let $f : A → B$ be an equivalence between $A$ and $B$. We prove that
@@ -908,71 +908,71 @@ An alternate proof could use `triple-concat-eq-first` and
   ( a : A)
   ( b : B)
   ( q : (f a) = b)
-  (is-hae : is-half-adjoint-equiv A B f)
-  :(concat ( B)
+  ( is-hae : is-half-adjoint-equiv A B f)
+  : ( concat (B)
     ( f a)
     ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (b)))
-    ( b )
-    (concat ( B)
+    ( b)
+    ( concat (B)
       ( f a)
       ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
       ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) b))
-      ( ap ( A) ( B) ( a)
-        ( (map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+      ( ap (A) (B) (a)
+        ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
         ( f)
-        (rev ( A)
-          ( (map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+        ( rev (A)
+          ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
           ( a)
-          ( (retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
-      ( ap ( B) ( B) ( f a) ( b)
-        ( \z → (f ((map-inverse-is-half-adjoint-equiv A B f is-hae) z)))
+          ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
+      ( ap (B) (B) (f a) (b)
+        ( \ z → (f ((map-inverse-is-half-adjoint-equiv A B f is-hae) z)))
         ( q)))
     ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) (b))) = q
   :=
   concat
-  ((f a) = b)
-  ((concat ( B)
+  ( ( f a) = b)
+  ( ( concat (B)
     ( f a)
     ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (b)))
-    ( b )
-    (concat ( B)
+    ( b)
+    ( concat (B)
       ( f a)
       ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
       ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) b))
-      ( ap ( A) ( B) ( a)
-        ( (map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+      ( ap (A) (B) (a)
+        ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
         ( f)
-        (rev ( A)
-          ( (map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+        ( rev (A)
+          ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
           ( a)
-          ( (retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
-      ( ap ( B) ( B) ( f a) ( b)
-        ( \z → (f ((map-inverse-is-half-adjoint-equiv A B f is-hae) z)))
+          ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
+      ( ap (B) (B) (f a) (b)
+        ( \ z → (f ((map-inverse-is-half-adjoint-equiv A B f is-hae) z)))
         ( q)))
-    ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) (b))) )
-  ((ap B B (f a) b (identity B) q))
+    ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) (b))))
+  ( ( ap B B (f a) b (identity B) q))
   ( q)
-  (rev-eq-top-cancel-commutative-square'
+  ( rev-eq-top-cancel-commutative-square'
     ( B)
-    (f a)
+    ( f a)
     ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (f a)))
     ( f ((map-inverse-is-half-adjoint-equiv A B f is-hae)  b))
     ( b)
-    (ap ( A) ( B)
+    ( ap (A) (B)
       ( a)
-      ( (map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+      ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
       ( f)
-      ( rev ( A)
-        ( (map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
+      ( rev (A)
+        ( ( map-inverse-is-half-adjoint-equiv A B f is-hae) (f a))
         ( a)
-        ( (retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
-    ((section-htpy-is-half-adjoint-equiv A B f is-hae) (f a))
-    (ap ( B) ( B) ( f a) ( b)
-      (\z → (f ((map-inverse-is-half-adjoint-equiv A B f is-hae) z)))
+        ( ( retraction-htpy-is-half-adjoint-equiv A B f is-hae) a)))
+    ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) (f a))
+    ( ap (B) (B) (f a) (b)
+      ( \ z → (f ((map-inverse-is-half-adjoint-equiv A B f is-hae) z)))
       ( q))
-    ( ap B B (f a) b (identity B) q )
-    ( (section-htpy-is-half-adjoint-equiv A B f is-hae) b)
-    (rev-nat-htpy ( B) ( B)
+    ( ap B B (f a) b (identity B) q)
+    ( ( section-htpy-is-half-adjoint-equiv A B f is-hae) b)
+    ( rev-nat-htpy (B) (B)
       ( \ x → f ((map-inverse-is-half-adjoint-equiv A B f is-hae) (x)))
       ( identity B)
       ( section-htpy-is-half-adjoint-equiv A B f is-hae)
@@ -980,5 +980,5 @@ An alternate proof could use `triple-concat-eq-first` and
       ( b)
       ( q))
     ( ap-rev-retr-htpy-concat-sec-htpy-is-refl-is-hae A B f a b q is-hae))
-  (ap-id B (f a) b q )
+  ( ap-id B (f a) b q)
 ```

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -14,12 +14,12 @@ naming the variable `x : A`.
   ( A : U)
   ( B : A → U)
   : U
-  := Σ (x : A), B x
+  := Σ (x : A) , B x
 
 #def projection-total-type
   ( A : U)
   ( B : A → U)
-  : (total-type A B) → A
+  : ( total-type A B) → A
   := \ z → first z
 ```
 
@@ -72,16 +72,16 @@ naming the variable `x : A`.
 #def second-path-Σ
   ( s t : Σ (a : A) , B a)
   ( e : s = t)
-  : ( transport A B (first s) (first t) (first-path-Σ s t e) (second s)) =
-    ( second t)
+  : ( transport A B (first s) (first t) (first-path-Σ s t e) (second s))
+  = ( second t)
   :=
     ind-path
-      ( Σ (a : A) , B a)
+      ( Σ ( a : A) , B a)
       ( s)
       ( \ t' e' →
         ( transport A B
-          ( first s) (first t') (first-path-Σ s t' e') (second s)) =
-        ( second t'))
+          ( first s) (first t') (first-path-Σ s t' e') (second s))
+      = ( second t'))
       ( refl)
       ( t)
       ( e)
@@ -92,8 +92,8 @@ naming the variable `x : A`.
   ( s t : Σ (a : A) , B a)
   : U
   :=
-    Σ ( p : (first s) = (first t)) ,
-      ( transport A B (first s) (first t) p (second s)) = (second t)
+    Σ ( p : (first s) = (first t))
+    , ( transport A B (first s) (first t) p (second s)) = (second t)
 ```
 
 ```rzk title="Rijke 22, Definition 9.3.3"
@@ -111,7 +111,7 @@ A path in a fiber defines a path in the total space.
   ( x : A)
   ( u v : B x)
   ( p : u = v)
-  : (x , u) =_{Σ (a : A) , B a} (x , v)
+  : ( x , u) =_{Σ (a : A) , B a} (x , v)
   := ind-path (B x) (u) (\ v' p' → (x , u) = (x , v')) (refl) (v) (p)
 ```
 
@@ -121,17 +121,17 @@ The following is essentially `#!rzk eq-pair` but with explicit arguments.
 #def path-of-pairs-pair-of-paths
   ( x y : A)
   ( p : x = y)
-  : ( u : B x) →
-    ( v : B y) →
-    ( (transport A B x y p u) = v) →
-    ( x , u) =_{Σ (z : A) , B z} (y , v)
+  : ( u : B x)
+  → ( v : B y)
+  → ( ( transport A B x y p u) = v)
+  → ( x , u) =_{Σ (z : A) , B z} (y , v)
   :=
     ind-path
       ( A)
       ( x)
-      ( \ y' p' → (u' : B x) → (v' : B y') →
-        ((transport A B x y' p' u') = v') →
-        (x , u') =_{Σ (z : A) , B z} (y' , v'))
+      ( \ y' p' → (u' : B x) → (v' : B y')
+      → ( ( transport A B x y' p' u') = v')
+      → ( x , u') =_{Σ (z : A) , B z} (y' , v'))
       ( \ u' v' q' → (eq-eq-fiber-Σ x u' v' q'))
       ( y)
       ( p)
@@ -141,7 +141,7 @@ The following is essentially `#!rzk eq-pair` but with explicit arguments.
 #def eq-pair
   ( s t : Σ (a : A) , B a)
   ( e : Eq-Σ s t)
-  : (s = t)
+  : ( s = t)
   :=
     path-of-pairs-pair-of-paths
       ( first s) (first t) (first e) (second s) (second t) (second e)
@@ -149,10 +149,10 @@ The following is essentially `#!rzk eq-pair` but with explicit arguments.
 #def eq-pair-pair-eq
   ( s t : Σ (a : A) , B a)
   ( e : s = t)
-  : (eq-pair s t (pair-eq s t e)) = e
+  : ( eq-pair s t (pair-eq s t e)) = e
   :=
     ind-path
-      ( Σ (a : A) , (B a))
+      ( Σ ( a : A) , (B a))
       ( s)
       ( \ t' e' → (eq-pair s t' (pair-eq s t' e')) = e')
       ( refl)
@@ -169,9 +169,9 @@ Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
   ( s1 : B s0)
   ( t0 : A)
   ( e0 : s0 = t0)
-  : ( t1 : B t0) →
-    ( e1 : (transport A B s0 t0 e0 s1) = t1) →
-    ( ( pair-eq (s0 , s1) (t0 , t1) (eq-pair (s0 , s1) (t0 , t1) (e0 , e1)))
+  : ( t1 : B t0)
+  → ( e1 : (transport A B s0 t0 e0 s1) = t1)
+  → ( ( pair-eq (s0 , s1) (t0 , t1) (eq-pair (s0 , s1) (t0 , t1) (e0 , e1)))
       =_{Eq-Σ (s0 , s1) (t0 , t1)}
       ( e0 , e1))
   :=
@@ -179,9 +179,9 @@ Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
       ( A)
       ( s0)
       ( \ t0' e0' →
-        ( t1 : B t0') →
-        ( e1 : (transport A B s0 t0' e0' s1) = t1) →
-        ( pair-eq (s0 , s1) (t0' , t1) (eq-pair (s0 , s1) (t0' , t1) (e0' , e1)))
+        ( t1 : B t0')
+      → ( e1 : (transport A B s0 t0' e0' s1) = t1)
+      → ( pair-eq (s0 , s1) (t0' , t1) (eq-pair (s0 , s1) (t0' , t1) (e0' , e1)))
         =_{Eq-Σ (s0 , s1) (t0' , t1)}
         ( e0' , e1))
       ( ind-path
@@ -211,25 +211,25 @@ Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
   ( s t : Σ (a : A) , B a)
   : Equiv (s = t) (Eq-Σ s t)
   :=
-    ( pair-eq s t ,
-      ( ( eq-pair s t , eq-pair-pair-eq s t) ,
-        ( eq-pair s t , pair-eq-eq-pair s t)))
+    ( pair-eq s t
+    , ( ( eq-pair s t , eq-pair-pair-eq s t)
+      , ( eq-pair s t , pair-eq-eq-pair s t)))
 
 #end paths-in-sigma
 
 #def first-path-Σ-eq-pair
   ( A : U)
   ( B : A → U)
-  ( (a,b) (a',b') : Σ (a : A), B a)
-  ( (e0, e1) : Eq-Σ A B (a,b) (a',b'))
-  : first-path-Σ A B (a,b) (a',b') (eq-pair A B (a,b) (a',b') (e0, e1)) = e0
+  ( ( a , b) (a' , b') : Σ (a : A) , B a)
+  ( ( e0 , e1) : Eq-Σ A B (a , b) (a' , b'))
+  : first-path-Σ A B (a , b) (a' , b') (eq-pair A B (a , b) (a' , b') (e0 , e1)) = e0
   :=
     first-path-Σ
-      ( a = a' )
-      ( \ p → transport A B a a' p b = b' )
-      ( pair-eq A B (a,b) (a',b') (eq-pair A B (a,b) (a',b') (e0,e1)) )
-      ( e0, e1 )
-      ( pair-eq-eq-pair A B (a,b) (a',b') (e0,e1))
+      ( a = a')
+      ( \ p → transport A B a a' p b = b')
+      ( pair-eq A B (a , b) (a' , b') (eq-pair A B (a , b) (a' , b') (e0 , e1)))
+      ( e0 , e1)
+      ( pair-eq-eq-pair A B (a , b) (a' , b') (e0 , e1))
 ```
 
 ## Identity types of Sigma types over a product
@@ -260,12 +260,12 @@ Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
   : U
   :=
-    Σ ( p : (first s) = (first t)) ,
-      ( Σ ( q : (first (second s)) = (first (second t))) ,
-          ( product-transport
+    Σ ( p : (first s) = (first t))
+    , ( Σ ( q : (first (second s)) = (first (second t)))
+        , ( product-transport
             ( first s) (first t)
-            ( first (second s)) (first (second t)) p q (second (second s)) =
-            ( second (second t))))
+            ( first (second s)) (first (second t)) p q (second (second s))
+          = ( second (second t))))
 ```
 
 !!! warning
@@ -280,7 +280,7 @@ Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
   : Eq-Σ-over-product s t
   :=
     ind-path
-      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( Σ ( a : A) , (Σ (b : B) , C a b))
       ( s)
       ( \ t' e' → (Eq-Σ-over-product s t'))
       ( ( refl , (refl , refl)))
@@ -298,23 +298,23 @@ saying that when `#!rzk p` is `#!rzk refl` this is ordinary transport.
   ( u u' : B)
   ( c : C a u)
   ( p : a = a')
-  : ( q : u = u') →
-    ( c' : C a' u') →
-    ( r : product-transport a a' u u' p q c = c') →
-    ( (a , (u , c)) =_{(Σ (x : A) , (Σ (y : B) , C x y))} (a' , (u' , c')))
+  : ( q : u = u')
+  → ( c' : C a' u')
+  → ( r : product-transport a a' u u' p q c = c')
+  → ( ( a , (u , c)) =_{(Σ (x : A) , (Σ (y : B) , C x y))} (a' , (u' , c')))
   :=
     ind-path
       ( A)
       ( a)
       ( \ a'' p' →
-        ( q : u = u') →
-        ( c' : C a'' u') →
-        ( r : product-transport a a'' u u' p' q c = c') →
-        ( (a , (u , c)) =_{(Σ (x : A) , (Σ (y : B) , C x y))} (a'' , (u' , c'))))
+        ( q : u = u')
+      → ( c' : C a'' u')
+      → ( r : product-transport a a'' u u' p' q c = c')
+      → ( ( a , (u , c)) =_{(Σ (x : A) , (Σ (y : B) , C x y))} (a'' , (u' , c'))))
       ( \ q c' r →
         eq-eq-fiber-Σ
           ( A) (\ x → (Σ (v : B) , C x v)) (a)
-          ( u , c) ( u' , c')
+          ( u , c) (u' , c')
           ( path-of-pairs-pair-of-paths B (\ y → C a y) u u' q c c' r))
       ( a')
       ( p)
@@ -322,7 +322,7 @@ saying that when `#!rzk p` is `#!rzk refl` this is ordinary transport.
 #def eq-triple
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
   ( e : Eq-Σ-over-product s t)
-  : (s = t)
+  : ( s = t)
   :=
     triple-of-paths-path-of-triples
     ( first s) (first t)
@@ -334,10 +334,10 @@ saying that when `#!rzk p` is `#!rzk refl` this is ordinary transport.
 #def eq-triple-triple-eq
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
   ( e : s = t)
-  : (eq-triple s t (triple-eq s t e)) = e
+  : ( eq-triple s t (triple-eq s t e)) = e
   :=
     ind-path
-      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( Σ ( a : A) , (Σ (b : B) , C a b))
       ( s)
       ( \ t' e' → (eq-triple s t' (triple-eq s t' e')) = e')
       ( refl)
@@ -353,36 +353,36 @@ Here we've decomposed `#!rzk s`, `#!rzk t` and `#!rzk e` for induction purposes:
   ( b b' : B)
   ( c : C a b)
 
-  : ( p : a = a') →
-    ( q : b = b') →
-    ( c' : C a' b') →
-    ( r : product-transport a a' b b' p q c = c') →
-    ( triple-eq
+  : ( p : a = a')
+  → ( q : b = b')
+  → ( c' : C a' b')
+  → ( r : product-transport a a' b b' p q c = c')
+  → ( triple-eq
       ( a , (b , c)) (a' , (b' , c'))
-      ( eq-triple (a , (b , c)) (a' , (b' , c')) (p , (q , r)))) =
-    ( p , (q , r))
+      ( eq-triple (a , (b , c)) (a' , (b' , c')) (p , (q , r))))
+  = ( p , (q , r))
   :=
     ind-path
       ( A)
       ( a)
       ( \ a'' p' →
-        ( q : b = b') →
-        ( c' : C a'' b') →
-        ( r : product-transport a a'' b b' p' q c = c') →
-        ( triple-eq
+        ( q : b = b')
+      → ( c' : C a'' b')
+      → ( r : product-transport a a'' b b' p' q c = c')
+      → ( triple-eq
           ( a , (b , c)) (a'' , (b' , c'))
-          ( eq-triple (a , (b , c)) (a'' , (b' , c')) (p' , (q , r)))) =
-        ( p' , (q , r)))
+          ( eq-triple (a , (b , c)) (a'' , (b' , c')) (p' , (q , r))))
+      = ( p' , (q , r)))
       ( ind-path
         ( B)
         ( b)
         ( \ b'' q' →
-          ( c' : C a b'') →
-          ( r : product-transport a a b b'' refl q' c = c') →
-          ( triple-eq
+          ( c' : C a b'')
+        → ( r : product-transport a a b b'' refl q' c = c')
+        → ( triple-eq
             ( a , (b , c)) (a , (b'' , c'))
-            ( eq-triple (a , (b , c)) (a , (b'' , c')) (refl , (q' , r)))) =
-          ( refl , (q' , r)))
+            ( eq-triple (a , (b , c)) (a , (b'' , c')) (refl , (q' , r))))
+        = ( refl , (q' , r)))
         ( ind-path
             ( C a b)
             ( c)
@@ -391,8 +391,8 @@ Here we've decomposed `#!rzk s`, `#!rzk t` and `#!rzk e` for induction purposes:
                 ( a , (b , c)) (a , (b , c''))
                 ( eq-triple
                   ( a , (b , c)) (a , (b , c''))
-                  ( refl , (refl , r'))) =
-                ( refl , (refl , r')))
+                  ( refl , (refl , r')))
+              = ( refl , (refl , r')))
             ( refl))
         ( b'))
       ( a')
@@ -400,7 +400,7 @@ Here we've decomposed `#!rzk s`, `#!rzk t` and `#!rzk e` for induction purposes:
 #def triple-eq-eq-triple
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
   ( e : Eq-Σ-over-product s t)
-  : (triple-eq s t (eq-triple s t e)) = e
+  : ( triple-eq s t (eq-triple s t e)) = e
   :=
     triple-eq-eq-triple-split
       ( first s) (first t)
@@ -413,9 +413,9 @@ Here we've decomposed `#!rzk s`, `#!rzk t` and `#!rzk e` for induction purposes:
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
   : Equiv (s = t) (Eq-Σ-over-product s t)
   :=
-    ( triple-eq s t ,
-      ( ( eq-triple s t , eq-triple-triple-eq s t) ,
-        ( eq-triple s t , triple-eq-eq-triple s t)))
+    ( triple-eq s t
+    , ( ( eq-triple s t , eq-triple-triple-eq s t)
+      , ( eq-triple s t , triple-eq-eq-triple s t)))
 
 #end paths-in-sigma-over-product
 ```
@@ -427,9 +427,9 @@ Here we've decomposed `#!rzk s`, `#!rzk t` and `#!rzk e` for induction purposes:
   ( A B : U)
   : Equiv (product A B) (product B A)
   :=
-    ( \ (a , b) → (b , a) ,
-      ( ( \ (b , a) → (a , b) ,\ p → refl) ,
-        ( \ (b , a) → (a , b) ,\ p → refl)))
+    ( \ (a , b) → (b , a)
+    , ( ( \ (b , a) → (a , b) , \ p → refl)
+      , ( \ (b , a) → (a , b) , \ p → refl)))
 ```
 
 ## Fubini
@@ -441,13 +441,13 @@ unimportant.
 #def fubini-Σ
   ( A B : U)
   ( C : A → B → U)
-  : Equiv ( Σ (x : A) , Σ (y : B) , C x y) (Σ (y : B) , Σ (x : A) , C x y)
+  : Equiv (Σ (x : A) , Σ (y : B) , C x y) (Σ (y : B) , Σ (x : A) , C x y)
   :=
-    ( \ t → (first (second t) , (first t , second (second t))) ,
-      ( ( \ t → (first (second t) , (first t , second (second t))) ,
-          \ t → refl) ,
-        ( \ t → (first (second t) , (first t , second (second t))) ,
-          \ t → refl)))
+    ( \ t → (first (second t) , (first t , second (second t)))
+    , ( ( \ t → (first (second t) , (first t , second (second t)))
+        , \ t → refl)
+      , ( \ t → (first (second t) , (first t , second (second t)))
+        , \ t → refl)))
 ```
 
 ```rzk title="Products distribute inside Sigma types"
@@ -456,9 +456,9 @@ unimportant.
   ( C : B → U)
   : Equiv (product A (Σ (b : B) , C b)) (Σ (b : B) , product A (C b))
   :=
-    ( \ (a , (b , c)) → (b , (a , c)) ,
-      ( ( \ (b , (a , c)) → (a , (b , c)) , \ z → refl) ,
-        ( \ (b , (a , c)) → (a , (b , c)) , \ z → refl)))
+    ( \ (a , (b , c)) → (b , (a , c))
+    , ( ( \ (b , (a , c)) → (a , (b , c)) , \ z → refl)
+      , ( \ (b , (a , c)) → (a , (b , c)) , \ z → refl)))
 ```
 
 ## Associativity
@@ -469,12 +469,12 @@ unimportant.
   ( B : A → U)
   ( C : (a : A) → B a → U)
   : Equiv
-      ( Σ (a : A) , Σ (b : B a) , C a b)
-      ( Σ (ab : Σ (a : A) , B a) , C (first ab) (second ab))
+      ( Σ ( a : A) , Σ (b : B a) , C a b)
+      ( Σ ( ab : Σ (a : A) , B a) , C (first ab) (second ab))
   :=
-    ( \ (a , (b , c)) → ((a , b) , c) ,
-      ( ( \ ((a , b) , c) → (a , (b , c)) , \ _ → refl) ,
-        ( \ ((a , b) , c) → (a , (b , c)) , \ _ → refl)))
+    ( \ (a , (b , c)) → ((a , b) , c)
+    , ( ( \ ((a , b) , c) → (a , (b , c)) , \ _ → refl)
+      , ( \ ((a , b) , c) → (a , (b , c)) , \ _ → refl)))
 ```
 
 ## Currying
@@ -487,14 +487,14 @@ This is the dependent version of the currying equivalence.
   ( B : A → U)
   ( C : (a : A) → B a → U)
   : Equiv
-      ((p : Σ (a : A) , (B a)) → C (first p) (second p))
-      ((a : A) → (b : B a) → C a b)
+      ( ( p : Σ (a : A) , (B a)) → C (first p) (second p))
+      ( ( a : A) → (b : B a) → C a b)
   :=
-    ( ( \ s a b → s (a , b)) ,
-      ( ( ( \ f (a , b) → f a b ,
-            \ f → refl) ,
-          ( \ f (a , b) → f a b ,
-            \ s → refl))))
+    ( ( \ s a b → s (a , b))
+    , ( ( ( \ f (a , b) → f a b
+          , \ f → refl)
+        , ( \ f (a , b) → f a b
+          , \ s → refl))))
 ```
 
 ## Type theoretic principle of choice
@@ -504,16 +504,16 @@ This is the dependent version of the currying equivalence.
   ( A : U)
   ( B : A → U)
   ( C : (x : A) → B x → U)
-  : ( (x : A) → Σ (y : B x) , C x y) →
-    ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
+  : ( ( x : A) → Σ (y : B x) , C x y)
+  → ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
   := \ h → (\ x → first (h x) , \ x → second (h x))
 
 #def choice-inverse
   ( A : U)
   ( B : A → U)
   ( C : (x : A) → B x → U)
-  : ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x)) →
-    ( (x : A) → Σ (y : B x) , C x y)
+  : ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
+  → ( ( x : A) → Σ (y : B x) , C x y)
   := \ s → \ x → ((first s) x , (second s) x)
 
 #def is-equiv-choice
@@ -521,22 +521,22 @@ This is the dependent version of the currying equivalence.
   ( B : A → U)
   ( C : (x : A) → B x → U)
   : is-equiv
-      ( (x : A) → Σ (y : B x) , C x y)
+      ( ( x : A) → Σ (y : B x) , C x y)
       ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
       ( choice A B C)
   :=
     is-equiv-has-inverse
-      ( (x : A) → Σ (y : B x) , C x y)
+      ( ( x : A) → Σ (y : B x) , C x y)
       ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
       ( choice A B C)
-      ( choice-inverse A B C , ( \ h → refl , \ s → refl))
+      ( choice-inverse A B C , (\ h → refl , \ s → refl))
 
 #def equiv-choice
   ( A : U)
   ( B : A → U)
   ( C : (x : A) → B x → U)
   : Equiv
-    ( (x : A) → Σ (y : B x) , C x y)
+    ( ( x : A) → Σ (y : B x) , C x y)
     ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
   := (choice A B C , is-equiv-choice A B C)
 
@@ -546,10 +546,10 @@ This is the dependent version of the currying equivalence.
   ( C : (x : A) → B x → U)
   : Equiv
     ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
-    ( (x : A) → Σ (y : B x) , C x y)
+    ( ( x : A) → Σ (y : B x) , C x y)
   :=
   inv-equiv
-  ( (x : A) → Σ (y : B x) , C x y)
+  ( ( x : A) → Σ (y : B x) , C x y)
   ( Σ ( f : (x : A) → B x) , (x : A) → C x (f x))
   ( equiv-choice A B C)
 ```

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -9,7 +9,8 @@ This is a literate `rzk` file:
 ## Contractible types
 
 ```rzk title="The type of contractibility proofs"
-#def is-contr (A : U) : U
+#def is-contr (A : U)
+  : U
   := Σ (x : A) , ((y : A) → x = y)
 ```
 
@@ -36,9 +37,9 @@ This is a literate `rzk` file:
   :=
     \ z →
       ( concat A center-contraction center-contraction z
-          (rev A center-contraction center-contraction
+          ( rev A center-contraction center-contraction
             ( homotopy-contraction center-contraction))
-          (homotopy-contraction z))
+          ( homotopy-contraction z))
 
 #def path-realign-homotopy-contraction uses (is-contr-A)
   : ( realign-homotopy-contraction center-contraction) = refl
@@ -49,7 +50,7 @@ This is a literate `rzk` file:
 
 ```rzk title="A path between any pair of terms in a contractible type"
 #def all-elements-equal-is-contr uses (is-contr-A)
-  (x y : A)
+  ( x y : A)
   : x = y
   :=
     zag-zig-concat A x center-contraction y
@@ -72,7 +73,7 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
 
 #def is-contr-Unit
   : is-contr Unit
-  := (unit, \ _ → refl)
+  := (unit , \ _ → refl)
 ```
 
 ```rzk title="The terminal projection as a constant map"
@@ -89,20 +90,20 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
   ( x y : Unit)
   : has-retraction (x = y) Unit (terminal-map (x = y))
   :=
-    ( \ a → refl ,
-      \ p → ind-path (Unit) (x) (\ y' p' → refl =_{x = y'} p') (refl) (y) (p))
+    ( \ a → refl
+    , \ p → ind-path (Unit) (x) (\ y' p' → refl =_{x = y'} p') (refl) (y) (p))
 
 #def has-section-terminal-map-path-types-Unit
   ( x y : Unit)
   : has-section (x = y) Unit (terminal-map (x = y))
-  := ( \ a → refl , \ a → refl)
+  := (\ a → refl , \ a → refl)
 
 #def is-equiv-terminal-map-path-types-Unit
   ( x y : Unit)
   : is-equiv (x = y) Unit (terminal-map (x = y))
   :=
-    ( has-retraction-terminal-map-path-types-Unit x y ,
-      has-section-terminal-map-path-types-Unit x y)
+    ( has-retraction-terminal-map-path-types-Unit x y
+    , has-section-terminal-map-path-types-Unit x y)
 ```
 
 ## Characterization of contractibility
@@ -120,35 +121,35 @@ A type is contractible if and only if its terminal map is an equivalence.
   ( is-contr-A : is-contr A)
   : has-retraction A Unit (terminal-map A)
   :=
-    ( constant Unit A (center-contraction A is-contr-A) ,
-      \ y → (homotopy-contraction A is-contr-A) y)
+    ( constant Unit A (center-contraction A is-contr-A)
+    , \ y → (homotopy-contraction A is-contr-A) y)
 
 #def has-section-terminal-map-is-contr
   ( A : U)
   ( is-contr-A : is-contr A)
   : has-section A Unit (terminal-map A)
-  := ( constant Unit A (center-contraction A is-contr-A) , \ z → refl)
+  := (constant Unit A (center-contraction A is-contr-A) , \ z → refl)
 
 #def is-equiv-terminal-map-is-contr
   ( A : U)
   ( is-contr-A : is-contr A)
   : is-equiv A Unit (terminal-map A)
   :=
-    ( has-retraction-terminal-map-is-contr A is-contr-A ,
-      has-section-terminal-map-is-contr A is-contr-A)
+    ( has-retraction-terminal-map-is-contr A is-contr-A
+    , has-section-terminal-map-is-contr A is-contr-A)
 
 #def is-contr-is-equiv-terminal-map
   ( A : U)
-  (e : terminal-map-is-equiv A)
+  ( e : terminal-map-is-equiv A)
   : is-contr A
-  := ( (first (first e)) unit , (second (first e)))
+  := ((first (first e)) unit , (second (first e)))
 
 #def is-equiv-terminal-map-iff-is-contr
   ( A : U)
   : iff (is-contr A) (terminal-map-is-equiv A)
   :=
-    ( ( is-equiv-terminal-map-is-contr A) ,
-      ( is-contr-is-equiv-terminal-map A))
+    ( ( is-equiv-terminal-map-is-contr A)
+    , ( is-contr-is-equiv-terminal-map A))
 
 #def equiv-with-contractible-domain-implies-contractible-codomain
   ( A B : U)
@@ -160,8 +161,8 @@ A type is contractible if and only if its terminal map is an equivalence.
       ( second
         ( equiv-comp B A Unit
           ( inv-equiv A B f)
-          ( ( terminal-map A) ,
-            ( is-equiv-terminal-map-is-contr A is-contr-A)))))
+          ( ( terminal-map A)
+          , ( is-equiv-terminal-map-is-contr A is-contr-A)))))
 
 #def is-contr-path-types-Unit
   ( x y : Unit)
@@ -217,8 +218,8 @@ A retract of contractible types is contractible.
   ( is-contr-B : is-contr B)
   : is-contr A
   :=
-    ( is-inhabited-is-contr-is-retract-of is-contr-B ,
-      has-homotopy-is-contr-is-retract-of is-contr-B)
+    ( is-inhabited-is-contr-is-retract-of is-contr-B
+    , has-homotopy-is-contr-is-retract-of is-contr-B)
 
 #end is-contr-is-retract-of-is-contr
 ```
@@ -237,11 +238,11 @@ A retract of contractible types is contractible.
   ( f : A → B)
   : is-equiv A B f
   :=
-    ( ( \ b → center-contraction A is-contr-A ,
-        \ a → homotopy-contraction A is-contr-A a) ,
-      ( \ b → center-contraction A is-contr-A ,
-        \ b → all-elements-equal-is-contr B is-contr-B
-                (f (center-contraction A is-contr-A)) b))
+    ( ( \ b → center-contraction A is-contr-A
+      , \ a → homotopy-contraction A is-contr-A a)
+    , ( \ b → center-contraction A is-contr-A
+      , \ b → all-elements-equal-is-contr B is-contr-B
+                ( f (center-contraction A is-contr-A)) b))
 ```
 
 ```rzk title="A type equivalent to a contractible type is contractible"
@@ -292,7 +293,7 @@ The center of contraction in the based path space is `#!rzk (a , refl)`.
 #def center-based-paths
   ( A : U)
   ( a : A)
-  : Σ (x : A) , (a = x)
+  : Σ ( x : A) , (a = x)
   := (a , refl)
 ```
 
@@ -301,10 +302,10 @@ The center of contraction in the based path space is `#!rzk (a , refl)`.
   ( A : U)
   ( a : A)
   ( p : Σ (x : A) , a = x)
-  : (center-based-paths A a) = p
+  : ( center-based-paths A a) = p
   :=
     path-of-pairs-pair-of-paths
-      A ( \ z → a = z) a (first p) (second p) (refl) (second p)
+      A (\ z → a = z) a (first p) (second p) (refl) (second p)
       ( concat
         ( a = (first p))
         ( transport A (\ z → (a = z)) a (first p) (second p) (refl))
@@ -331,8 +332,8 @@ The center of contraction in the based path space is `#!rzk (a , refl)`.
   ( is-contr-B : is-contr B)
   : is-contr (product A B)
   :=
-    ( (first is-contr-A , first is-contr-B) ,
-      \ p → path-product A B
+    ( ( first is-contr-A , first is-contr-B)
+    , \ p → path-product A B
               ( first is-contr-A) (first p)
               ( first is-contr-B) (second p)
               ( second is-contr-A (first p))
@@ -343,8 +344,8 @@ The center of contraction in the based path space is `#!rzk (a , refl)`.
   ( AxB-is-contr : is-contr (product A B))
   : is-contr A
   :=
-    ( first (first AxB-is-contr) ,
-      \ a → first-path-product A B
+    ( first (first AxB-is-contr)
+    , \ a → first-path-product A B
               ( first AxB-is-contr)
               ( a , second (first AxB-is-contr))
               ( second AxB-is-contr (a , second (first AxB-is-contr))))
@@ -356,8 +357,8 @@ The center of contraction in the based path space is `#!rzk (a , refl)`.
   ( is-contr-AB : is-contr (Σ (a : A) , B a))
   : is-contr A
   :=
-    ( first (first is-contr-AB) ,
-      \ a → first-path-Σ A B
+    ( first (first is-contr-AB)
+    , \ a → first-path-Σ A B
               ( first is-contr-AB)
               ( a , b a)
               ( second is-contr-AB (a , b a)))
@@ -373,11 +374,12 @@ However, for various applications it may be useful to have it stated as a
 separate hypothesis.
 
 ```rzk title="Weak function extensionality gives us contractible pi types"
-#def WeakFunExt : U
+#def WeakFunExt
+  : U
   :=
-    ( A : U ) → (C : A → U) →
-    (is-contr-C : (a : A) → is-contr (C a) ) →
-    (is-contr ( (a : A) → C a ))
+    ( A : U) → (C : A → U)
+  → ( is-contr-C : (a : A) → is-contr (C a))
+  → ( is-contr ((a : A) → C a))
 
 ```
 
@@ -385,20 +387,20 @@ Function extensionality implies weak function extensionality.
 
 ```rzk
 #def map-weakfunext
-  (A : U)
-  (C : A → U)
-  (is-contr-C : (a : A) → is-contr (C a))
-  : (a : A) → C a
+  ( A : U)
+  ( C : A → U)
+  ( is-contr-C : (a : A) → is-contr (C a))
+  : ( a : A) → C a
   :=
   \ a → first (is-contr-C a)
 
 #def weakfunext-funext
-  (funext : FunExt)
+  ( funext : FunExt)
   : WeakFunExt
   :=
   \ A C is-contr-C →
-  ( map-weakfunext A C is-contr-C ,
-    ( \ g →
+  ( map-weakfunext A C is-contr-C
+  , ( \ g →
       ( eq-htpy funext
         ( A)
         ( C)
@@ -416,7 +418,7 @@ A type is contractible if and only if it has singleton induction.
   ( A : U)
   ( a : A)
   ( B : A → U)
-  : ((x : A) → B x) → B a
+  : ( ( x : A) → B x) → B a
   := \ f → f a
 
 #def has-singleton-induction-pointed
@@ -430,20 +432,20 @@ A type is contractible if and only if it has singleton induction.
   ( A : U)
   ( a : A)
   : U
-  := ( B : A → U) → has-section ((x : A) → B x) (B a) (ev-pt A a B)
+  := (B : A → U) → has-section ((x : A) → B x) (B a) (ev-pt A a B)
 
 #def has-singleton-induction
   ( A : U)
   : U
-  := Σ ( a : A) , (B : A → U) → (has-singleton-induction-pointed A a B)
+  := Σ (a : A) , (B : A → U) → (has-singleton-induction-pointed A a B)
 
 #def ind-sing
   ( A : U)
   ( a : A)
   ( B : A → U)
-  (singleton-ind-A : has-singleton-induction-pointed A a B)
-  : (B a) → ((x : A) → B x)
-  := ( first singleton-ind-A)
+  ( singleton-ind-A : has-singleton-induction-pointed A a B)
+  : ( B a) → ((x : A) → B x)
+  := (first singleton-ind-A)
 
 #def compute-ind-sing
   ( A : U)
@@ -455,7 +457,7 @@ A type is contractible if and only if it has singleton induction.
       ( B a)
       ( comp
         ( B a)
-        ( (x : A) → B x)
+        ( ( x : A) → B x)
         ( B a)
         ( ev-pt A a B)
         ( ind-sing A a B singleton-ind-A))
@@ -465,18 +467,18 @@ A type is contractible if and only if it has singleton induction.
 #def contr-implies-singleton-induction-ind
   ( A : U)
   ( is-contr-A : is-contr A)
-  : (has-singleton-induction A)
+  : ( has-singleton-induction A)
   :=
-    ( ( center-contraction A is-contr-A) ,
-      \ B →
+    ( ( center-contraction A is-contr-A)
+    , \ B →
         ( ( \ b x →
                 ( transport A B
                   ( center-contraction A is-contr-A) x
-                  ( realign-homotopy-contraction A is-contr-A x) b)) ,
-          ( \ b →
+                  ( realign-homotopy-contraction A is-contr-A x) b))
+        , ( \ b →
                 ( ap
-                  ( (center-contraction A is-contr-A) =
-                    (center-contraction A is-contr-A))
+                  ( ( center-contraction A is-contr-A)
+                  = ( center-contraction A is-contr-A))
                   ( B (center-contraction A is-contr-A))
                   ( realign-homotopy-contraction A is-contr-A
                     ( center-contraction A is-contr-A))
@@ -490,14 +492,14 @@ A type is contractible if and only if it has singleton induction.
   ( is-contr-A : is-contr A)
   ( B : A → U)
   : has-singleton-induction-pointed A (center-contraction A is-contr-A) B
-  := ( second (contr-implies-singleton-induction-ind A is-contr-A)) B
+  := (second (contr-implies-singleton-induction-ind A is-contr-A)) B
 
 #def singleton-induction-ind-implies-contr
   ( A : U)
   ( a : A)
   ( f : has-singleton-induction-pointed-structure A a)
   : ( is-contr A)
-  := ( a , (first (f ( \ x → a = x))) (refl_{a}))
+  := (a , (first (f (\ x → a = x))) (refl_{a}))
 ```
 
 ## Identity types of contractible types
@@ -514,7 +516,7 @@ In a contractible type any path $p : x = y$ is equal to the path constructed in
   ( is-contr-A : is-contr A)
   ( x y : A)
   ( p : x = y)
-  : ((all-elements-equal-is-contr A is-contr-A x y) = p)
+  : ( ( all-elements-equal-is-contr A is-contr-A x y) = p)
   :=
     ind-path
     ( A)
@@ -537,15 +539,15 @@ together the two identifications to the out and back path.
  ( is-contr-A : is-contr A)
  ( x y : A)
  ( p q : x = y)
- : (p = q)
- :=
+  : ( p = q)
+  :=
   concat
     ( x = y)
     ( p)
     ( all-elements-equal-is-contr A is-contr-A x y)
     ( q)
     ( rev
-      (x = y)
+      ( x = y)
       ( all-elements-equal-is-contr A is-contr-A x y)
       ( p)
       ( path-eq-path-through-center-is-contr A is-contr-A x y p))

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -36,17 +36,17 @@ We calculate the transport of `#!rzk (a , q) : fib b` along `#!rzk p : a = a'`:
   ( a a' : A)
   ( u : (f a) = b)
   ( p : a = a')
-  : ( transport A ( \ x → (f x) = b) a a' p u) =
-    ( concat B (f a') (f a) b (ap A B a' a f (rev A a a' p)) u)
+  : ( transport A (\ x → (f x) = b) a a' p u)
+  = ( concat B (f a') (f a) b (ap A B a' a f (rev A a a' p)) u)
   :=
     ind-path
       ( A)
       ( a)
       ( \ a'' p' →
-        ( transport (A) (\ x → (f x) = b) (a) (a'') (p') (u)) =
-        ( concat (B) (f a'') (f a) (b) (ap A B a'' a f (rev A a a'' p')) (u)))
+        ( transport (A) (\ x → (f x) = b) (a) (a'') (p') (u))
+      = ( concat (B) (f a'') (f a) (b) (ap A B a'' a f (rev A a a'' p')) (u)))
       ( rev
-        ( (f a) = b) (concat B (f a) (f a) b refl u) (u)
+        ( ( f a) = b) (concat B (f a) (f a) b refl u) (u)
         ( left-unit-concat B (f a) b u))
       ( a')
       ( p)
@@ -63,31 +63,31 @@ of the form `#!rzk (a, refl : f a = f a) : fib A B f`.
   ( A B : U)
   ( f : A → B)
   ( C : (b : B) → fib A B f b → U)
-  ( s : (a : A) → C (f a) (a, refl))
+  ( s : (a : A) → C (f a) (a , refl))
   ( b : B)
-  ( (a, q) : fib A B f b)
-  : C b (a, q)
+  ( ( a , q) : fib A B f b)
+  : C b (a , q)
   :=
-    ind-path B (f a) (\ b p → C b (a, p)) (s a) b q
+    ind-path B (f a) (\ b p → C b (a , p)) (s a) b q
 
 #def ind-rev-fib
   ( A B : U)
   ( f : A → B)
   ( C : (b : B) → rev-fib A B f b → U)
-  ( s : (a : A) → C (f a) (a, refl))
+  ( s : (a : A) → C (f a) (a , refl))
   ( b : B)
-  ( (a, q) : rev-fib A B f b)
-  : C b (a, q)
+  ( ( a , q) : rev-fib A B f b)
+  : C b (a , q)
   :=
-    ind-path-end B (f a) (\ b p → C b (a, p)) (s a) b q
+    ind-path-end B (f a) (\ b p → C b (a , p)) (s a) b q
 
 #def compute-ind-fib
   ( A B : U)
   ( f : A → B)
   ( C : (b : B) → fib A B f b → U)
-  ( s : (a : A) → C (f a) (a, refl))
+  ( s : (a : A) → C (f a) (a , refl))
   ( a : A)
-  : ind-fib A B f C s (f a) (a, refl) = s a
+  : ind-fib A B f C s (f a) (a , refl) = s a
   := refl
 ```
 
@@ -123,17 +123,17 @@ Contractible maps are equivalences:
 #def has-section-is-contr-map
   : has-section A B f
   :=
-    ( is-contr-map-inverse ,
-      \ b → second (center-contraction (fib A B f b) (is-contr-f b)))
+    ( is-contr-map-inverse
+    , \ b → second (center-contraction (fib A B f b) (is-contr-f b)))
 
 #def is-contr-map-data-in-fiber uses (is-contr-f)
-  (a : A)
+  ( a : A)
   : fib A B f (f a)
   := (is-contr-map-inverse (f a) , (second has-section-is-contr-map) (f a))
 
 #def is-contr-map-path-in-fiber
-  (a : A)
-  : (is-contr-map-data-in-fiber a) =_{fib A B f (f a)} (a , refl)
+  ( a : A)
+  : ( is-contr-map-data-in-fiber a) =_{fib A B f (f a)} (a , refl)
   :=
     all-elements-equal-is-contr
       ( fib A B f (f a))
@@ -144,10 +144,10 @@ Contractible maps are equivalences:
 #def is-contr-map-has-retraction uses (is-contr-f)
   : has-retraction A B f
   :=
-    ( is-contr-map-inverse ,
-      \ a → ( ap (fib A B f (f a)) A
+    ( is-contr-map-inverse
+    , \ a → (ap (fib A B f (f a)) A
                 ( is-contr-map-data-in-fiber a)
-                ( (a , refl))
+                ( ( a , refl))
                 ( \ u → first u)
                 ( is-contr-map-path-in-fiber a)))
 
@@ -175,12 +175,12 @@ work from the assumption that `f` is a half adjoint equivalence.
   ( b : B)
   : fib A B f b
   :=
-    ( map-inverse-is-half-adjoint-equiv A B f is-hae-f b,
-      section-htpy-is-half-adjoint-equiv A B f is-hae-f b)
+    ( map-inverse-is-half-adjoint-equiv A B f is-hae-f b
+    , section-htpy-is-half-adjoint-equiv A B f is-hae-f b)
 
 #def calculate-is-split-surjection-is-half-adjoint-equiv
   ( a : A)
-  : is-split-surjection-is-half-adjoint-equiv (f a) = (a, refl)
+  : is-split-surjection-is-half-adjoint-equiv (f a) = (a , refl)
   :=
     path-of-pairs-pair-of-paths
     ( A)
@@ -192,7 +192,7 @@ work from the assumption that `f` is a half adjoint equivalence.
     ( refl)
     ( triple-concat
       ( f a = f a)
-      ( transport A ( \ x → (f x) = (f a))
+      ( transport A (\ x → (f x) = (f a))
         ( map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a))
         ( a)
         ( retraction-htpy-is-half-adjoint-equiv A B f is-hae-f a)
@@ -205,7 +205,7 @@ work from the assumption that `f` is a half adjoint equivalence.
           ( a)
           ( map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a))
           ( f)
-          ( rev A ( map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a)) a
+          ( rev A (map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a)) a
             ( retraction-htpy-is-half-adjoint-equiv A B f is-hae-f a)))
         ( section-htpy-is-half-adjoint-equiv A B f is-hae-f (f a)))
       ( concat B
@@ -234,12 +234,12 @@ work from the assumption that `f` is a half adjoint equivalence.
           ( a)
           ( map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a))
           ( f)
-          ( rev A ( map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a)) a
+          ( rev A (map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a)) a
             ( retraction-htpy-is-half-adjoint-equiv A B f is-hae-f a)))
         ( section-htpy-is-half-adjoint-equiv A B f is-hae-f (f a))
         ( ap A B (map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a)) a f
           ( retraction-htpy-is-half-adjoint-equiv A B f is-hae-f a))
-        (coherence-is-half-adjoint-equiv A B f is-hae-f a))
+        ( coherence-is-half-adjoint-equiv A B f is-hae-f a))
       ( concat-ap-rev-ap-id A B
         ( map-inverse-is-half-adjoint-equiv A B f is-hae-f (f a))
         ( a)
@@ -262,8 +262,8 @@ work from the assumption that `f` is a half adjoint equivalence.
   : is-contr-map A B f
   :=
     \ b →
-      ( is-split-surjection-is-half-adjoint-equiv b,
-        contraction-fib-is-half-adjoint-equiv b)
+      ( is-split-surjection-is-half-adjoint-equiv b
+      , contraction-fib-is-half-adjoint-equiv b)
 
 #end is-contr-map-is-equiv
 ```
@@ -279,8 +279,8 @@ work from the assumption that `f` is a half adjoint equivalence.
   :=
     \ b →
     ( is-split-surjection-is-half-adjoint-equiv A B f
-      ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) b ,
-      \ z → contraction-fib-is-half-adjoint-equiv A B f
+      ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) b
+    , \ z → contraction-fib-is-half-adjoint-equiv A B f
         ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) b z)
 
 #def is-contr-map-iff-is-equiv
@@ -305,59 +305,59 @@ temporarily refer to the fiber as the "homotopy fiber" and `#!rzk B a` as the
 #variable B : A → U
 
 #def homotopy-fiber-strict-fiber
-  (a : A)
-  (b : B a)
+  ( a : A)
+  ( b : B a)
   : fib (total-type A B) A (projection-total-type A B) a
-  := ((a, b), refl)
+  := ((a , b) , refl)
 
 #def strict-fiber-homotopy-fiber
-  (a : A)
-  (((a', b'), p) : fib (total-type A B) A (projection-total-type A B) a)
+  ( a : A)
+  ( ( ( a' , b') , p) : fib (total-type A B) A (projection-total-type A B) a)
   : B a
   := transport A B a' a p b'
 
 #def retract-homotopy-fiber-strict-fiber
-  (a : A)
-  (b : B a)
+  ( a : A)
+  ( b : B a)
   : strict-fiber-homotopy-fiber a (homotopy-fiber-strict-fiber a b) = b
   := refl
 
 #def calculation-retract-strict-fiber-homotopy-fiber
-  (a : A)
-  (b : B a)
+  ( a : A)
+  ( b : B a)
   : homotopy-fiber-strict-fiber a
-    ( strict-fiber-homotopy-fiber a ((a, b), refl)) =
-    ( (a, b), refl)
+    ( strict-fiber-homotopy-fiber a ((a , b) , refl))
+  = ( ( a , b) , refl)
   := refl
 
 #def retract-strict-fiber-homotopy-fiber
-  (a : A)
-  (((a', b'), p) : fib (total-type A B) A (projection-total-type A B) a)
-  : homotopy-fiber-strict-fiber a (strict-fiber-homotopy-fiber a ((a', b'), p))
-    = ((a', b'), p)
+  ( a : A)
+  ( ( ( a' , b') , p) : fib (total-type A B) A (projection-total-type A B) a)
+  : homotopy-fiber-strict-fiber a (strict-fiber-homotopy-fiber a ((a' , b') , p))
+    = ( ( a' , b') , p)
   :=
     ind-fib
     ( total-type A B)
     ( A)
     ( projection-total-type A B)
-    ( \ a0 ((a'', b''), p') →
+    ( \ a0 ((a'' , b'') , p') →
       homotopy-fiber-strict-fiber a0
-      ( strict-fiber-homotopy-fiber a0 ((a'', b''), p')) = ((a'', b''), p'))
-    ( \ (a'', b'') → refl)
+      ( strict-fiber-homotopy-fiber a0 ((a'' , b'') , p')) = ((a'' , b'') , p'))
+    ( \ (a'' , b'') → refl)
     ( a)
-    ( ((a', b'), p))
+    ( ( ( a' , b') , p))
 
 #def equiv-homotopy-fiber-strict-fiber
-  (a : A)
+  ( a : A)
   : Equiv
     ( B a)
     ( fib (total-type A B) A (projection-total-type A B) a)
   :=
-    ( homotopy-fiber-strict-fiber a,
-      ( ( strict-fiber-homotopy-fiber a,
-          retract-homotopy-fiber-strict-fiber a),
-        ( strict-fiber-homotopy-fiber a,
-          retract-strict-fiber-homotopy-fiber a)))
+    ( homotopy-fiber-strict-fiber a
+    , ( ( strict-fiber-homotopy-fiber a
+        , retract-homotopy-fiber-strict-fiber a)
+      , ( strict-fiber-homotopy-fiber a
+        , retract-strict-fiber-homotopy-fiber a)))
 
 #end strict-vs-homotopy-fiber
 ```
@@ -375,21 +375,21 @@ of the fibers of the first function.
 #variable g : B → C
 
 #def fiber-sum-fiber-comp
-  (c : C)
-  ((a, r) : fib A C (comp A B C g f) c)
-  : ( Σ ((b, q) : fib B C g c), fib A B f b)
-  := ((f a, r), (a, refl))
+  ( c : C)
+  ( ( a , r) : fib A C (comp A B C g f) c)
+  : ( Σ ( ( b , q) : fib B C g c) , fib A B f b)
+  := ((f a , r) , (a , refl))
 
 #def fiber-comp-fiber-sum
-  (c : C)
-  ( ((b, q), (a, p)) : Σ ((b, q) : fib B C g c), fib A B f b)
+  ( c : C)
+  ( ( ( b , q) , (a , p)) : Σ ((b , q) : fib B C g c) , fib A B f b)
   : fib A C (comp A B C g f) c
-  := (a, concat C (g (f a)) (g b) c (ap B C (f a) b g p) q)
+  := (a , concat C (g (f a)) (g b) c (ap B C (f a) b g p) q)
 
 #def is-retract-fiber-sum-fiber-comp
-  (c : C)
-  ((a, r) : fib A C (comp A B C g f) c)
-  : fiber-comp-fiber-sum c (fiber-sum-fiber-comp c (a, r)) = (a, r)
+  ( c : C)
+  ( ( a , r) : fib A C (comp A B C g f) c)
+  : fiber-comp-fiber-sum c (fiber-sum-fiber-comp c (a , r)) = (a , r)
   :=
     eq-eq-fiber-Σ
     ( A)
@@ -400,46 +400,46 @@ of the fibers of the first function.
     ( left-unit-concat C (g (f a)) c r)
 
 #def is-retract-fiber-comp-fiber-sum'
-  (c : C)
-  ((b, q) : fib B C g c)
-  : ((a, p) : fib A B f b) →
-    fiber-sum-fiber-comp c (fiber-comp-fiber-sum c ((b, q), (a, p))) =
-    ((b, q), (a, p))
+  ( c : C)
+  ( ( b , q) : fib B C g c)
+  : ( ( a , p) : fib A B f b)
+  → fiber-sum-fiber-comp c (fiber-comp-fiber-sum c ((b , q) , (a , p)))
+  = ( ( b , q) , (a , p))
   :=
     ind-fib B C g
-    ( \ c' (b', q') → ((a, p) : fib A B f b') →
-      fiber-sum-fiber-comp c' (fiber-comp-fiber-sum c' ((b', q'), (a, p))) =
-      ((b', q'), (a, p)))
-    ( \ b0 (a, p) →
+    ( \ c' (b' , q') → ((a , p) : fib A B f b')
+    → fiber-sum-fiber-comp c' (fiber-comp-fiber-sum c' ((b' , q') , (a , p)))
+    = ( ( b' , q') , (a , p)))
+    ( \ b0 (a , p) →
       ( ind-fib A B f
-        ( \b0' (a', p') →
+        ( \ b0' (a' , p') →
           fiber-sum-fiber-comp (g b0')
-          ( fiber-comp-fiber-sum (g b0') ((b0', refl), (a', p'))) =
-          ((b0', refl), (a', p')))
-        ( \a0 → refl)
+          ( fiber-comp-fiber-sum (g b0') ((b0' , refl) , (a' , p')))
+        = ( ( b0' , refl) , (a' , p')))
+        ( \ a0 → refl)
         ( b0)
-        ( (a, p))))
+        ( ( a , p))))
     ( c)
-    ( (b, q))
+    ( ( b , q))
 
 #def is-retract-fiber-comp-fiber-sum
-  (c : C)
-  ( ((b, q), (a, p)) : Σ ((b, q) : fib B C g c), fib A B f b)
-  : fiber-sum-fiber-comp c (fiber-comp-fiber-sum c ((b, q), (a, p))) =
-    ((b, q), (a, p))
-  := is-retract-fiber-comp-fiber-sum' c (b, q) (a, p)
+  ( c : C)
+  ( ( ( b , q) , (a , p)) : Σ ((b , q) : fib B C g c) , fib A B f b)
+  : fiber-sum-fiber-comp c (fiber-comp-fiber-sum c ((b , q) , (a , p)))
+  = ( ( b , q) , (a , p))
+  := is-retract-fiber-comp-fiber-sum' c (b , q) (a , p)
 
 #def equiv-fiber-sum-fiber-comp
-  (c : C)
+  ( c : C)
   : Equiv
     ( fib A C (comp A B C g f) c)
-    ( Σ ((b, q) : fib B C g c), fib A B f b)
+    ( Σ ( ( b , q) : fib B C g c) , fib A B f b)
   :=
-    ( fiber-sum-fiber-comp c,
-      ( ( fiber-comp-fiber-sum c,
-          is-retract-fiber-sum-fiber-comp c),
-        ( fiber-comp-fiber-sum c,
-          is-retract-fiber-comp-fiber-sum c)))
+    ( fiber-sum-fiber-comp c
+    , ( ( fiber-comp-fiber-sum c
+        , is-retract-fiber-sum-fiber-comp c)
+      , ( fiber-comp-fiber-sum c
+        , is-retract-fiber-comp-fiber-sum c)))
 
 #end fiber-composition
 ```

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -23,7 +23,7 @@ maps.
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( (a , c) : total-type A C)
+  ( ( a , c) : total-type A C)
   : fib (B a) (C a) (f a) (c)
   → fib (total-type A B) (total-type A C) (total-map A B C f) (a , c)
   := \ (b , p) → ((a , b) , eq-eq-fiber-Σ A C a (f a b) c p)
@@ -32,7 +32,7 @@ maps.
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  : ( (a , c) : total-type A C)
+  : ( ( a , c) : total-type A C)
   → fib (total-type A B) (total-type A C) (total-map A B C f) (a , c)
   → fib (B a) (C a) (f a) (c)
   :=
@@ -44,7 +44,7 @@ maps.
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( (a , c) : total-type A C)
+  ( ( a , c) : total-type A C)
   : has-retraction
     ( fib (B a) (C a) (f a) (c))
     ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
@@ -52,10 +52,10 @@ maps.
   :=
     ( ( fib-fiberwise-fib-total-map A B C f (a , c))
     , ( \ (b , p) →
-        ind-path ( C a) ( f a b)
+        ind-path (C a) (f a b)
         ( \ c' p' →
           ( ( fib-fiberwise-fib-total-map A B C f ((a , c')))
-            ( (fib-total-map-fib-fiberwise A B C f (a , c')) (b , p'))
+            ( ( fib-total-map-fib-fiberwise A B C f (a , c')) (b , p'))
           = ( b , p')))
         ( refl)
         ( c)
@@ -65,21 +65,21 @@ maps.
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( (a , c) : (Σ (x : A) , C x))
+  ( ( a , c) : (Σ (x : A) , C x))
   : has-section
     ( fib (B a) (C a) (f a) c)
     ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
     ( fib-total-map-fib-fiberwise A B C f (a , c))
   :=
     ( ( fib-fiberwise-fib-total-map A B C f (a , c))
-    , ( \ ((a', b') , p) →
+    , ( \ ((a' , b') , p) →
         ind-path
           ( total-type A C)
           ( a' , f a' b')
           ( \ w' p' →
             ( ( fib-total-map-fib-fiberwise A B C f w')
               ( ( fib-fiberwise-fib-total-map A B C f w') ((a' , b') , p'))
-            = ( (a' , b') , p')))
+            = ( ( a' , b') , p')))
           ( refl)
           ( a , c)
           ( p)))
@@ -88,10 +88,10 @@ maps.
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( (a , c) : total-type A C)
+  ( ( a , c) : total-type A C)
   : is-equiv
     ( fib (B a) (C a) (f a) c)
-    ( fib (total-type A B) (total-type A C) ( total-map A B C f) (a , c))
+    ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
     ( fib-total-map-fib-fiberwise A B C f (a , c))
   :=
     ( has-retraction-fib-total-map-fib-fiberwise A B C f (a , c)
@@ -101,13 +101,13 @@ maps.
   ( A : U)
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
-  ( (a , c) : total-type A C)
+  ( ( a , c) : total-type A C)
   : Equiv
     ( fib (B a) (C a) (f a) c)
-    ( fib (total-type A B) (total-type A C) ( total-map A B C f) (a , c))
+    ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
   :=
     ( fib-total-map-fib-fiberwise A B C f (a , c)
-    , is-equiv-fib-total-map-fib-fiberwise A B C f (a, c))
+    , is-equiv-fib-total-map-fib-fiberwise A B C f (a , c))
 ```
 
 ## Families of equivalences
@@ -121,10 +121,10 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
-  : (total-type A C) → (total-type A B)
+  : ( total-type A C) → (total-type A B)
   :=
     \ (a , c) →
-      (a , (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)
+      ( a , (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)
 
 #def has-retraction-total-has-inverse-fiberwise
   ( A : U)
@@ -133,11 +133,11 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-retraction (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily ,
-      \ (a , b) →
-        (eq-eq-fiber-Σ A B a
-          ( (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) (f a b)) b
-          ( (first (second (invfamily a))) b)))
+    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily
+    , \ (a , b) →
+        ( eq-eq-fiber-Σ A B a
+          ( ( map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) (f a b)) b
+          ( ( first (second (invfamily a))) b)))
 
 #def has-section-total-has-inverse-fiberwise
   ( A : U)
@@ -146,11 +146,11 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-section (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily ,
-      \ (a , c) →
+    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily
+    , \ (a , c) →
         ( eq-eq-fiber-Σ A C a
           ( f a ((map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)) c
-          ( (second (second (invfamily a))) c)))
+          ( ( second (second (invfamily a))) c)))
 
 #def has-inverse-total-has-inverse-fiberwise
   ( A : U)
@@ -159,9 +159,9 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
   ( invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-inverse (total-type A B) (total-type A C) (total-map A B C f)
   :=
-    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily ,
-      ( second (has-retraction-total-has-inverse-fiberwise A B C f invfamily) ,
-        second (has-section-total-has-inverse-fiberwise A B C f invfamily)))
+    ( map-inverse-total-has-inverse-fiberwise A B C f invfamily
+    , ( second (has-retraction-total-has-inverse-fiberwise A B C f invfamily)
+      , second (has-section-total-has-inverse-fiberwise A B C f invfamily)))
 ```
 
 The one-way result: that a family of equivalence gives an invertible map (and
@@ -173,7 +173,7 @@ thus an equivalence) on total spaces.
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
-  : has-inverse (total-type A B) ( total-type A C) ( total-map A B C f)
+  : has-inverse (total-type A B) (total-type A C) (total-map A B C f)
   :=
     has-inverse-total-has-inverse-fiberwise A B C f
     ( \ a → has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a))
@@ -183,10 +183,10 @@ thus an equivalence) on total spaces.
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
-  : is-equiv ( total-type A B) (total-type A C) (total-map A B C f)
+  : is-equiv (total-type A B) (total-type A C) (total-map A B C f)
   :=
     is-equiv-has-inverse
-    ( total-type A B) ( total-type A C) ( total-map A B C f)
+    ( total-type A B) (total-type A C) (total-map A B C f)
     ( has-inverse-total-is-equiv-fiberwise A B C f familyequiv)
 
 #def total-equiv-family-of-equiv
@@ -210,14 +210,14 @@ implication could be proven similarly.
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( totalcontrmap
-    : is-contr-map (total-type A B) ( total-type A C) ( total-map A B C f))
+ : is-contr-map (total-type A B) (total-type A C) (total-map A B C f))
   ( a : A)
   : is-contr-map (B a) (C a) (f a)
   :=
     \ c →
       is-contr-equiv-is-contr'
       ( fib (B a) (C a) (f a) c)
-      ( fib ( total-type A B) ( total-type A C) ( total-map A B C f) (a , c))
+      ( fib (total-type A B) (total-type A C) (total-map A B C f) (a , c))
       ( equiv-fib-total-map-fib-fiberwise A B C f (a , c))
       ( totalcontrmap (a , c))
 
@@ -226,8 +226,8 @@ implication could be proven similarly.
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( totalequiv
-    : is-equiv (total-type A B) (total-type A C) ( total-map A B C f))
-  (a : A)
+ : is-equiv (total-type A B) (total-type A C) (total-map A B C f))
+  ( a : A)
   : is-equiv (B a) (C a) (f a)
   :=
     is-equiv-is-contr-map (B a) (C a) (f a)
@@ -242,10 +242,10 @@ implication could be proven similarly.
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   ( totalequiv
-    : is-equiv (total-type A B) (total-type A C) ( total-map A B C f))
+ : is-equiv (total-type A B) (total-type A C) (total-map A B C f))
   ( a : A)
   : Equiv (B a) (C a)
-  := ( f a , is-equiv-fiberwise-is-equiv-total A B C f totalequiv a)
+  := (f a , is-equiv-fiberwise-is-equiv-total A B C f totalequiv a)
 ```
 
 In summary, a family of maps is an equivalence iff the map on total spaces is an
@@ -257,7 +257,7 @@ equivalence.
   ( B C : A → U)
   ( f : (a : A) → (B a) → (C a))
   : iff
-      ( (a : A) → is-equiv (B a) (C a) (f a))
+      ( ( a : A) → is-equiv (B a) (C a) (f a))
       ( is-equiv (Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map A B C f))
   :=
@@ -296,7 +296,7 @@ The canonical map from a type to its the free path type is an equivalence.
 #def free-paths
   ( A : U)
   : U
-  := Σ ( (x , y) : product A A) , (x = y)
+  := Σ ((x , y) : product A A) , (x = y)
 
 #def constant-free-path
   ( A : U)
@@ -306,13 +306,13 @@ The canonical map from a type to its the free path type is an equivalence.
 
 #def is-constant-free-path
   ( A : U)
-  ( ((a , y) , p) : free-paths A)
-  : constant-free-path A a = ((a , y), p)
+  ( ( ( a , y) , p) : free-paths A)
+  : constant-free-path A a = ((a , y) , p)
   :=
     ind-path A a
-    ( \ x p' →  constant-free-path A a = ((a , x) , p'))
+    ( \ x p' → constant-free-path A a = ((a , x) , p'))
     ( refl)
-    ( y) ( p)
+    ( y) (p)
 
 #def start-free-path
   ( A : U)
@@ -353,11 +353,11 @@ The pullback of a family along homotopic maps is equivalent.
 #variable a : A
 
 #def pullback-homotopy
-  : (pullback A B f C a) → (pullback A B g C a)
+  : ( pullback A B f C a) → (pullback A B g C a)
   := transport B C (f a) (g a) (α a)
 
 #def map-inverse-pullback-homotopy
-  : (pullback A B g C a) → (pullback A B f C a)
+  : ( pullback A B g C a) → (pullback A B f C a)
   := transport B C (g a) (f a) (rev B (f a) (g a) (α a))
 
 #def has-retraction-pullback-homotopy
@@ -407,7 +407,7 @@ The pullback of a family along homotopic maps is equivalent.
       ( pullback A B f C a)
       ( pullback A B g C a)
       ( pullback-homotopy)
-  := ( has-retraction-pullback-homotopy , has-section-pullback-homotopy)
+  := (has-retraction-pullback-homotopy , has-section-pullback-homotopy)
 
 #def equiv-pullback-homotopy uses (α)
   : Equiv (pullback A B f C a) (pullback A B g C a)
@@ -424,7 +424,7 @@ space.
   ( A B : U)
   ( f : A → B)
   ( C : B → U)
-  : (Σ (a : A) , (pullback A B f C) a) → (Σ (b : B) , C b)
+  : ( Σ ( a : A) , (pullback A B f C) a) → (Σ (b : B) , C b)
   := \ (a , c) → (f a , c)
 ```
 
@@ -442,8 +442,8 @@ map.
   : U
   :=
     fib
-      ( Σ (a : A) , (pullback A B f C) a)
-      ( Σ (b : B) , C b)
+      ( Σ ( a : A) , (pullback A B f C) a)
+      ( Σ ( b : B) , C b)
       ( pullback-comparison-map A B f C) z
 
 #def pullback-comparison-fiber-to-fiber
@@ -451,11 +451,11 @@ map.
   ( f : A → B)
   ( C : B → U)
   ( z : Σ (b : B) , C b)
-  : (pullback-comparison-fiber A B f C z) → (fib A B f (first z))
+  : ( pullback-comparison-fiber A B f C z) → (fib A B f (first z))
   :=
     \ (w , p) →
     ind-path
-      ( Σ (b : B) , C b)
+      ( Σ ( b : B) , C b)
       ( pullback-comparison-map A B f C w)
       ( \ z' p' →
         ( fib A B f (first z')))
@@ -468,14 +468,14 @@ map.
   ( f : A → B)
   ( C : B → U)
   ( b : B)
-  : (fib A B f b) → (c : C b) → (pullback-comparison-fiber A B f C (b , c))
+  : ( fib A B f b) → (c : C b) → (pullback-comparison-fiber A B f C (b , c))
   :=
     \ (a , p) →
     ind-path
       ( B)
       ( f a)
       ( \ b' p' →
-          (c : C b') → (pullback-comparison-fiber A B f C ((b' , c))))
+          ( c : C b') → (pullback-comparison-fiber A B f C ((b' , c))))
       ( \ c → ((a , c) , refl))
       ( b)
       ( p)
@@ -485,7 +485,7 @@ map.
   ( f : A → B)
   ( C : B → U)
   ( z : Σ (b : B) , C b)
-  : (fib A B f (first z)) → (pullback-comparison-fiber A B f C z)
+  : ( fib A B f (first z)) → (pullback-comparison-fiber A B f C z)
   :=
     \ (a , p) →
       from-base-fiber-to-pullback-comparison-fiber A B f C
@@ -496,17 +496,17 @@ map.
   ( f : A → B)
   ( C : B → U)
   ( z : Σ (b : B) , C b)
-  ( (w , p) : pullback-comparison-fiber A B f C z)
-  : ( (pullback-comparison-fiber-to-fiber-inv A B f C z)
-      ( (pullback-comparison-fiber-to-fiber A B f C z) (w , p))) = (w , p)
+  ( ( w , p) : pullback-comparison-fiber A B f C z)
+  : ( ( pullback-comparison-fiber-to-fiber-inv A B f C z)
+      ( ( pullback-comparison-fiber-to-fiber A B f C z) (w , p))) = (w , p)
   :=
     ind-path
-      ( Σ (b : B) , C b)
+      ( Σ ( b : B) , C b)
       ( pullback-comparison-map A B f C w)
       ( \ z' p' →
         ( ( pullback-comparison-fiber-to-fiber-inv A B f C z')
-          ( ( pullback-comparison-fiber-to-fiber A B f C z') (w , p'))) =
-        ( w , p'))
+          ( ( pullback-comparison-fiber-to-fiber A B f C z') (w , p')))
+      = ( w , p'))
       ( refl)
       ( z)
       ( p)
@@ -516,20 +516,20 @@ map.
   ( f : A → B)
   ( C : B → U)
   ( b : B)
-  ( (a , p) : fib A B f b)
-  : (c : C b) →
-      ((pullback-comparison-fiber-to-fiber A B f C (b , c))
-        ((pullback-comparison-fiber-to-fiber-inv A B f C (b , c)) (a , p))) =
-      (a , p)
+  ( ( a , p) : fib A B f b)
+  : ( c : C b)
+    → ( ( pullback-comparison-fiber-to-fiber A B f C (b , c))
+        ( ( pullback-comparison-fiber-to-fiber-inv A B f C (b , c)) (a , p)))
+    = ( a , p)
   :=
     ind-path
       ( B)
       ( f a)
       ( \ b' p' →
-        ( c : C b') →
-        ( ( pullback-comparison-fiber-to-fiber A B f C (b' , c))
-          ( (pullback-comparison-fiber-to-fiber-inv A B f C (b' , c)) (a , p'))) =
-        ( a , p'))
+        ( c : C b')
+      → ( ( pullback-comparison-fiber-to-fiber A B f C (b' , c))
+          ( ( pullback-comparison-fiber-to-fiber-inv A B f C (b' , c)) (a , p')))
+      = ( a , p'))
       ( \ c → refl)
       ( b)
       ( p)
@@ -539,7 +539,7 @@ map.
   ( f : A → B)
   ( C : B → U)
   ( z : Σ (b : B) , C b)
-  ( (a , p) : fib A B f (first z))
+  ( ( a , p) : fib A B f (first z))
   : ( pullback-comparison-fiber-to-fiber A B f C z
       ( pullback-comparison-fiber-to-fiber-inv A B f C z (a , p))) = (a , p)
   :=
@@ -553,11 +553,11 @@ map.
   ( z : Σ (b : B) , C b)
   : Equiv (pullback-comparison-fiber A B f C z) (fib A B f (first z))
   :=
-    ( pullback-comparison-fiber-to-fiber A B f C z ,
-      ( ( pullback-comparison-fiber-to-fiber-inv A B f C z ,
-          pullback-comparison-fiber-to-fiber-retracting-homotopy A B f C z) ,
-        ( pullback-comparison-fiber-to-fiber-inv A B f C z ,
-          pullback-comparison-fiber-to-fiber-section-homotopy A B f C z)))
+    ( pullback-comparison-fiber-to-fiber A B f C z
+    , ( ( pullback-comparison-fiber-to-fiber-inv A B f C z
+        , pullback-comparison-fiber-to-fiber-retracting-homotopy A B f C z)
+      , ( pullback-comparison-fiber-to-fiber-inv A B f C z
+        , pullback-comparison-fiber-to-fiber-section-homotopy A B f C z)))
 ```
 
 As a corollary, we show that pullback along an equivalence induces an
@@ -571,10 +571,10 @@ equivalence of total spaces.
   ( C : B → U)
   : Equiv (Σ (a : A) , (pullback A B f C) a) (Σ (b : B) , C b)
   :=
-    ( pullback-comparison-map A B f C ,
-      is-equiv-is-contr-map
-        ( Σ (a : A) , (pullback A B f C) a)
-        ( Σ (b : B) , C b)
+    ( pullback-comparison-map A B f C
+    , is-equiv-is-contr-map
+        ( Σ ( a : A) , (pullback A B f C) a)
+        ( Σ ( b : B) , C b)
         ( pullback-comparison-map A B f C)
         ( \ z →
           ( is-contr-equiv-is-contr'
@@ -602,22 +602,22 @@ We start by fixing `a : A` and investigating when a map of families
 #variable f : (x : A) → (a = x) → B x
 
 #def is-contr-total-are-equiv-from-paths
-  : ( (x : A) → (is-equiv (a = x) (B x) (f x)))
+  : ( ( x : A) → (is-equiv (a = x) (B x) (f x)))
   → ( is-contr (Σ (x : A) , B x))
   :=
     ( \ familyequiv →
       ( equiv-with-contractible-domain-implies-contractible-codomain
-        ( Σ (x : A) , a = x) (Σ (x : A) , B x)
-        ( ( total-map A ( \ x → (a = x)) B f)
+        ( Σ ( x : A) , a = x) (Σ (x : A) , B x)
+        ( ( total-map A (\ x → (a = x)) B f)
         , ( is-equiv-has-inverse (Σ (x : A) , a = x) (Σ (x : A) , B x)
-            ( total-map A ( \ x → (a = x)) B f)
+            ( total-map A (\ x → (a = x)) B f)
             ( has-inverse-total-is-equiv-fiberwise A
               ( \ x → (a = x)) B f familyequiv)))
         ( is-contr-based-paths A a)))
 
 #def are-equiv-from-paths-is-contr-total
   : ( is-contr (Σ (x : A) , B x))
-  → ( (x : A) → (is-equiv (a = x) (B x) (f x)))
+  → ( ( x : A) → (is-equiv (a = x) (B x) (f x)))
   :=
     ( \ is-contr-Σ-A-B x →
       is-equiv-fiberwise-is-equiv-total A
@@ -625,8 +625,8 @@ We start by fixing `a : A` and investigating when a map of families
         ( B)
         ( f)
         ( is-equiv-are-contr
-          ( Σ (x' : A) , (a = x'))
-          ( Σ (x' : A) , (B x'))
+          ( Σ ( x' : A) , (a = x'))
+          ( Σ ( x' : A) , (B x'))
           ( is-contr-based-paths A a)
           ( is-contr-Σ-A-B)
           ( total-map A (\ x' → (a = x')) B f))
@@ -647,11 +647,11 @@ fundamental theorem:
   : P u p
   :=
     ind-sing
-      ( Σ (v : A) , B v)
+      ( Σ ( v : A) , B v)
       ( a , f a refl)
       ( \ (u' , p') → P u' p')
       ( contr-implies-singleton-induction-pointed
-        ( Σ (z : A) , B z)
+        ( Σ ( z : A) , B z)
         ( is-contr-total-are-equiv-from-paths familyequiv)
         ( \ (x' , p') → P x' p'))
       ( p0)
@@ -668,17 +668,17 @@ contractible.
 #def map-from-paths-inhabited-total
   ( A : U)
   ( B : A → U)
-  ( (a , b) : total-type A B)
+  ( ( a , b) : total-type A B)
   ( x : A)
-  : (a = x) → B x
-  := ind-path A a ( \ y _ → B y) b x
+  : ( a = x) → B x
+  := ind-path A a (\ y _ → B y) b x
 
 #def fundamental-theorem-of-identity-types
   ( A : U)
   ( B : A → U)
   : iff
     ( is-contr (total-type A B))
-    ( Σ (a : A) , ((x : A) → Equiv (a = x) (B x)))
+    ( Σ ( a : A) , ((x : A) → Equiv (a = x) (B x)))
   :=
   ( ( \ ((a , b) , h) →
       ( a
@@ -686,7 +686,7 @@ contractible.
         ( map-from-paths-inhabited-total A B (a , b) x
         , are-equiv-from-paths-is-contr-total A a B
           ( map-from-paths-inhabited-total A B (a , b))
-          ( (a , b) , h)
+          ( ( a , b) , h)
           ( x))))
   , ( \ (a , familyequiv) →
       is-contr-total-are-equiv-from-paths A a B
@@ -710,26 +710,26 @@ types over a product type.
 #variable h : (a : A) → (b : B) → (C a b) → C' (f a) (g b)
 
 #def total-map-fibered-map-over-product
-  : ( Σ (a : A) , (Σ (b : B) , C a b))
-  → ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+  : ( Σ ( a : A) , (Σ (b : B) , C a b))
+  → ( Σ ( a' : A') , (Σ (b' : B') , C' a' b'))
   := \ (a , (b , c)) → (f a , (g b , h a b c))
 
 #def pullback-is-equiv-base-is-equiv-total-is-equiv
   ( is-equiv-total
-    : is-equiv
-      ( Σ (a : A) , (Σ (b : B) , C a b))
-      ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+ : is-equiv
+      ( Σ ( a : A) , (Σ (b : B) , C a b))
+      ( Σ ( a' : A') , (Σ (b' : B') , C' a' b'))
       ( total-map-fibered-map-over-product))
   ( is-equiv-f : is-equiv A A' f)
   : is-equiv
-    ( Σ (a : A) , (Σ (b : B) , C a b))
-    ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
+    ( Σ ( a : A) , (Σ (b : B) , C a b))
+    ( Σ ( a : A) , (Σ (b' : B') , C' (f a) b'))
     ( \ (a , (b , c)) → (a , (g b , h a b c)))
   :=
     is-equiv-right-factor
-    ( Σ (a : A) , (Σ (b : B) , C a b))
-    ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
-    ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+    ( Σ ( a : A) , (Σ (b : B) , C a b))
+    ( Σ ( a : A) , (Σ (b' : B') , C' (f a) b'))
+    ( Σ ( a' : A') , (Σ (b' : B') , C' a' b'))
     ( \ (a , (b , c)) → (a , (g b , h a b c)))
     ( \ (a , (b' , c')) → (f a , (b' , c')))
     ( second
@@ -741,21 +741,21 @@ types over a product type.
 
 #def pullback-is-equiv-bases-are-equiv-total-is-equiv
   ( is-equiv-total
-    : is-equiv
-      ( Σ (a : A) , (Σ (b : B) , C a b))
-      ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+ : is-equiv
+      ( Σ ( a : A) , (Σ (b : B) , C a b))
+      ( Σ ( a' : A') , (Σ (b' : B') , C' a' b'))
       ( total-map-fibered-map-over-product))
   ( is-equiv-f : is-equiv A A' f)
   ( is-equiv-g : is-equiv B B' g)
   : is-equiv
-    ( Σ (a : A) , (Σ (b : B) , C a b))
-    ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
+    ( Σ ( a : A) , (Σ (b : B) , C a b))
+    ( Σ ( a : A) , (Σ (b : B) , C' (f a) (g b)))
     ( \ (a , (b , c)) → (a , (b , h a b c)))
   :=
     is-equiv-right-factor
-    ( Σ (a : A) , (Σ (b : B) , C a b))
-    ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
-    ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
+    ( Σ ( a : A) , (Σ (b : B) , C a b))
+    ( Σ ( a : A) , (Σ (b : B) , C' (f a) (g b)))
+    ( Σ ( a : A) , (Σ (b' : B') , C' (f a) b'))
     ( \ (a , (b , c)) → (a , (b , h a b c)))
     ( \ (a , (b , c)) → (a , (g b , c)))
     ( is-equiv-total-is-equiv-fiberwise A
@@ -772,9 +772,9 @@ types over a product type.
 
 #def fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
   ( is-equiv-total
-    : is-equiv
-      ( Σ (a : A) , (Σ (b : B) , C a b))
-      ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+ : is-equiv
+      ( Σ ( a : A) , (Σ (b : B) , C a b))
+      ( Σ ( a' : A') , (Σ (b' : B') , C' a' b'))
       ( total-map-fibered-map-over-product))
   ( is-equiv-f : is-equiv A A' f)
   ( is-equiv-g : is-equiv B B' g)

--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -20,7 +20,7 @@ A type is a proposition when its identity types are contractible.
 
 ```rzk
 #def is-prop
-  (A : U)
+  ( A : U)
   : U
   := (a : A) → (b : A) → is-contr (a = b)
 ```
@@ -38,17 +38,17 @@ this is true for every contractible type.
 
 ```rzk
 #def all-elements-equal
-  (A : U)
+  ( A : U)
   : U
   := (a : A) → (b : A) → (a = b)
 
 #def is-contr-is-inhabited
-  (A : U)
+  ( A : U)
   : U
   := A → is-contr A
 
 #def is-emb-terminal-map
-  (A : U)
+  ( A : U)
   : U
   := is-emb A Unit (terminal-map A)
 ```
@@ -73,7 +73,7 @@ this is true for every contractible type.
   ( is-prop-A : is-prop A)
   : is-contr-is-inhabited A
   :=
-    \ a → (a, \ b → first (is-prop-A a b))
+    \ a → (a , \ b → first (is-prop-A a b))
 
 #def terminal-map-is-emb-is-inhabited-is-contr-is-inhabited
   ( A : U)
@@ -87,7 +87,7 @@ this is true for every contractible type.
 #def terminal-map-is-emb-is-contr-is-inhabited
   ( A : U)
   ( c : is-contr-is-inhabited A)
-  : (is-emb-terminal-map A)
+  : ( is-emb-terminal-map A)
   :=
     ( is-emb-is-inhabited-emb A Unit (terminal-map A)
       ( terminal-map-is-emb-is-inhabited-is-contr-is-inhabited A c))
@@ -99,7 +99,7 @@ this is true for every contractible type.
   :=
     \ x y →
       ( is-contr-equiv-is-contr' (x = y) (unit = unit)
-        ( (ap A Unit x y (terminal-map A)) , (f x y))
+        ( ( ap A Unit x y (terminal-map A)) , (f x y))
         ( is-contr-path-types-Unit unit unit))
 
 #def is-prop-is-contr-is-inhabited
@@ -116,7 +116,7 @@ this is true for every contractible type.
   : is-prop A
   :=
     is-prop-is-contr-is-inhabited A
-    (  is-contr-is-inhabited-all-elements-equal A all-elements-equal-A)
+    ( is-contr-is-inhabited-all-elements-equal A all-elements-equal-A)
 ```
 
 ## Properties of propositions
@@ -128,15 +128,15 @@ If two propositions are logically equivalent, then they are equivalent:
   ( A B : U)
   ( is-prop-A : is-prop A)
   ( is-prop-B : is-prop B)
-  ( (f , g) : iff A B)
+  ( ( f , g) : iff A B)
   : is-equiv A B f
   :=
-    ( ( g ,
-        \ a →
-          (all-elements-equal-is-prop A is-prop-A) ((comp A B A g f) a) a) ,
-      ( g ,
-        \ b →
-          (all-elements-equal-is-prop B is-prop-B) ((comp B A B f g) b) b))
+    ( ( g
+      , \ a →
+          ( all-elements-equal-is-prop A is-prop-A) ((comp A B A g f) a) a)
+    , ( g
+      , \ b →
+          ( all-elements-equal-is-prop B is-prop-B) ((comp B A B f g) b) b))
 
 #def equiv-iff-is-prop-is-prop
   ( A B : U)
@@ -144,7 +144,7 @@ If two propositions are logically equivalent, then they are equivalent:
   ( is-prop-B : is-prop B)
   ( e : iff A B)
   : Equiv A B
-  := (first e, is-equiv-iff-is-prop-is-prop A B is-prop-A is-prop-B e)
+  := (first e , is-equiv-iff-is-prop-is-prop A B is-prop-A is-prop-B e)
 ```
 
 Every contractible type is a proposition:
@@ -155,7 +155,7 @@ Every contractible type is a proposition:
   ( is-contr-A : is-contr A)
   : is-prop A
   :=
-    is-prop-is-contr-is-inhabited A ( \ _ → is-contr-A)
+    is-prop-is-contr-is-inhabited A (\ _ → is-contr-A)
 ```
 
 All parallel paths in a proposition are equal.
@@ -194,7 +194,7 @@ invoking `is-prop-is-contr`.
 #def ind-prop-is-contr
   ( A : U)
   ( is-contr-A : is-contr A)
-  : ( B : A → U) → ( a : A) → ( b : B a) → ( x : A) →  B x
+  : ( B : A → U) → (a : A) → (b : B a) → (x : A) → B x
   := ind-prop A (is-prop-is-contr A is-contr-A)
 ```
 
@@ -207,7 +207,7 @@ Retracts of propositions are propositions:
 ```rzk
 #def is-prop-is-retract-of-is-prop
   ( A B : U)
-  ( (f,(g,η)) : is-retract-of A B) -- f : A → B with retraction g
+  ( ( f , (g , η)) : is-retract-of A B) -- f : A → B with retraction g
   ( is-prop-B : is-prop B)
   : is-prop A
   :=
@@ -215,7 +215,7 @@ Retracts of propositions are propositions:
     ( \ a a' →
       triple-concat A a (g (f a)) (g (f a')) a'
       ( rev A (g (f a)) a (η a))
-      ( ap B A (f a) (f a') g ( first (is-prop-B (f a) (f a'))))
+      ( ap B A (f a) (f a') g (first (is-prop-B (f a) (f a'))))
       ( η a'))
 ```
 
@@ -224,9 +224,9 @@ In particular, propositions are closed under equivalences:
 ```rzk
 #def is-prop-Equiv-is-prop
   ( A B : U)
-  ( (f, (rec-f, _)) : Equiv A B)
+  ( ( f , (rec-f , _)) : Equiv A B)
   : is-prop B → is-prop A
-  := is-prop-is-retract-of-is-prop A B (f, rec-f)
+  := is-prop-is-retract-of-is-prop A B (f , rec-f)
 
 #def is-prop-Equiv-is-prop'
   ( A B : U)
@@ -250,7 +250,7 @@ dependent functions `#!rzk (x : A) → B x` is a proposition.
     \ f g →
     is-contr-equiv-is-contr'
       ( f = g)
-      ( (x : A) → f x = g x)
+      ( ( x : A) → f x = g x)
       ( equiv-FunExt funext A B f g)
       ( weakfunext A (\ x → f x = g x) (\ x → fiberwise-prop-B x (f x) (g x)))
 ```
@@ -274,9 +274,9 @@ If each `C a` is a proposition, then so is the total type `total-type A C`.
   : is-prop (total-type A C)
   :=
     is-prop-all-elements-equal (total-type A C)
-    ( \ (a, c) (a', c') →
-      eq-pair A C (a, c) (a', c')
-      ( first ( is-prop-A a a')
+    ( \ (a , c) (a' , c') →
+      eq-pair A C (a , c) (a' , c')
+      ( first (is-prop-A a a')
       , first
         ( is-fiberwise-prop-C a'
           ( transport A C a a' (first (is-prop-A a a')) c)
@@ -297,12 +297,12 @@ is every fiber `#!rzk C a`.
       transport
       ( a = a)
       ( \ p → transport A C a a p c = c')
-      ( first-path-Σ A C (a, c) (a, c') ( first (is-prop-ΣC (a, c) (a, c'))))
+      ( first-path-Σ A C (a , c) (a , c') (first (is-prop-ΣC (a , c) (a , c'))))
       ( refl)
       ( all-paths-equal-is-prop A is-prop-A a a
-        ( first-path-Σ A C (a, c) (a, c') ( first (is-prop-ΣC (a, c) (a, c'))))
+        ( first-path-Σ A C (a , c) (a , c') (first (is-prop-ΣC (a , c) (a , c'))))
         ( refl))
-      ( second-path-Σ A C (a, c) (a, c') ( first (is-prop-ΣC (a, c) (a, c')))))
+      ( second-path-Σ A C (a , c) (a , c') (first (is-prop-ΣC (a , c) (a , c')))))
 
 #end families-over-propositions
 ```
@@ -333,8 +333,8 @@ propositions.
   : is-contr (Σ (x : A) , f x = f y)
   :=
     is-contr-equiv-is-contr'
-    ( Σ (x : A) , f x = f y)
-    ( Σ (x : A) , f y = f x)
+    ( Σ ( x : A) , f x = f y)
+    ( Σ ( x : A) , f y = f x)
     ( total-equiv-family-of-equiv A (\ x → f x = f y) (\ x → f y = f x)
       ( \ x → equiv-rev B (f x) (f y)))
     ( is-contr-image-based-paths-is-emb A B f is-emb-f y)
@@ -375,11 +375,11 @@ propositions.
   : is-contr (Σ (y : A) , f x = f y)
   :=
   is-contr-equiv-is-contr'
-  ( Σ (y : A) , f x = f y)
-  ( Σ (y : A) , f y = f x)
+  ( Σ ( y : A) , f x = f y)
+  ( Σ ( y : A) , f y = f x)
   ( total-equiv-family-of-equiv A (\ y → f x = f y) (\ y → f y = f x)
     ( \ y → equiv-rev B (f x) (f y)))
-  ( is-contr-is-inhabited-fib-f (f x) ((x, refl)))
+  ( is-contr-is-inhabited-fib-f (f x) ((x , refl)))
 
 #def is-emb-is-contr-is-inhabited-fib
   ( A B : U)
@@ -404,7 +404,7 @@ propositions.
   ( A B : U)
   ( f : A → B)
   : iff (is-emb A B f) ((b : B) → is-prop (fib A B f b))
-  := (is-prop-fib-is-emb A B f, is-emb-is-prop-fib A B f)
+  := (is-prop-fib-is-emb A B f , is-emb-is-prop-fib A B f)
 ```
 
 ## Subtypes
@@ -433,7 +433,7 @@ referred to a subtype of `#!rzk A`.
   is-emb-is-prop-fib (total-type A P) A (projection-total-type A P)
   ( \ a →
     is-prop-Equiv-is-prop'
-    ( P a) ( fib (total-type A P) A (projection-total-type A P) a)
+    ( P a) (fib (total-type A P) A (projection-total-type A P) a)
     ( equiv-homotopy-fiber-strict-fiber A P a) (is-predicate-P a))
 ```
 
@@ -444,9 +444,9 @@ The subtype projection embedding reflects identifications.
   ( A : U)
   ( P : A → U)
   ( is-predicate-P : is-predicate A P)
-  : ( (a, p) : total-type A P)
-    → ( (b, q) : total-type A P)
-    → (a = b) → (a, p) =_{total-type A P} (b, q)
+  : ( ( a , p) : total-type A P)
+    → ( ( b , q) : total-type A P)
+    → ( a = b) → (a , p) =_{total-type A P} (b , q)
   :=
   inv-ap-is-emb (total-type A P) A (projection-total-type A P)
   ( is-emb-subtype-projection A P is-predicate-P)

--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -29,13 +29,13 @@ The following type asserts that the fibers of a type family are contractible.
 
 ```rzk title="The center of contraction in contractible fibers"
 #def contractible-fibers-section
-  : (x : A) → B x
+  : ( x : A) → B x
   := \ x → center-contraction (B x) (contractible-fibers-A-B x)
 ```
 
 ```rzk title="The section of the total space projection built from the contraction centers"
 #def contractible-fibers-actual-section uses (contractible-fibers-A-B)
-  : (a : A) → Σ (x : A) , B x
+  : ( a : A) → Σ (x : A) , B x
   := \ a → (a , contractible-fibers-section a)
 
 #def contractible-fibers-section-htpy uses (contractible-fibers-A-B)
@@ -55,13 +55,13 @@ projection, called `#!rzk first` here:
 
 ```rzk
 #def contractible-fibers-retraction-htpy
-  : (z : Σ (x : A) , B x) →
-      (contractible-fibers-actual-section) (first z) = z
+  : ( z : Σ (x : A) , B x)
+    → ( contractible-fibers-actual-section) (first z) = z
   :=
     \ z →
     eq-eq-fiber-Σ A B
       ( first z)
-      ( (contractible-fibers-section) (first z))
+      ( ( contractible-fibers-section) (first z))
       ( second z)
       ( homotopy-contraction (B (first z)) (contractible-fibers-A-B (first z)) (second z))
 
@@ -97,7 +97,7 @@ From a projection equivalence, it's not hard to inhabit fibers:
   : B a
   :=
     transport A B (first ((first (second proj-B-to-A-is-equiv)) a)) a
-      ( (second (second proj-B-to-A-is-equiv)) a)
+      ( ( second (second proj-B-to-A-is-equiv)) a)
       ( second ((first (second proj-B-to-A-is-equiv)) a))
 ```
 
@@ -130,17 +130,17 @@ We start over from a stronger hypothesis of a half adjoint equivalence.
 
 ```rzk
 #def projection-hae-inverse
-  (a : A)
-  : Σ (x : A) , B x
+  ( a : A)
+  : Σ ( x : A) , B x
   := (first (first proj-B-to-A-is-half-adjoint-equivalence)) a
 
 #def projection-hae-base-htpy uses (B)
-  (a : A)
-  : (first (projection-hae-inverse a)) = a
+  ( a : A)
+  : ( first (projection-hae-inverse a)) = a
   := (second (second (first proj-B-to-A-is-half-adjoint-equivalence))) a
 
 #def projection-hae-section uses (proj-B-to-A-is-half-adjoint-equivalence)
-  (a : A)
+  ( a : A)
   : B a
   :=
     transport A B (first (projection-hae-inverse a)) a
@@ -148,29 +148,29 @@ We start over from a stronger hypothesis of a half adjoint equivalence.
       ( second (projection-hae-inverse a))
 
 #def projection-hae-total-htpy
-  : (projection-hae-inverse (first w)) = w
+  : ( projection-hae-inverse (first w)) = w
   := (first (second (first proj-B-to-A-is-half-adjoint-equivalence))) w
 
 #def projection-hae-fibered-htpy
-  : (transport A B (first ((projection-hae-inverse (first w)))) (first w)
+  : ( transport A B (first ((projection-hae-inverse (first w)))) (first w)
     ( first-path-Σ A B
       ( projection-hae-inverse (first w)) w
       ( projection-hae-total-htpy))
-    ( second (projection-hae-inverse (first w)))) =
-    ( second w)
+    ( second (projection-hae-inverse (first w))))
+  = ( second w)
   :=
     second-path-Σ A B (projection-hae-inverse (first w)) w
       ( projection-hae-total-htpy)
 
 #def projection-hae-base-coherence
-  : ( projection-hae-base-htpy (first w)) =
-    ( first-path-Σ A B (projection-hae-inverse (first w)) w
+  : ( projection-hae-base-htpy (first w))
+  = ( first-path-Σ A B (projection-hae-inverse (first w)) w
       ( projection-hae-total-htpy))
   := (second proj-B-to-A-is-half-adjoint-equivalence) w
 
 #def projection-hae-transport-coherence
-  : ( projection-hae-section (first w)) =
-    ( transport A B (first ((projection-hae-inverse (first w)))) (first w)
+  : ( projection-hae-section (first w))
+  = ( transport A B (first ((projection-hae-inverse (first w)))) (first w)
       ( first-path-Σ A B
         ( projection-hae-inverse (first w)) w
         ( projection-hae-total-htpy))
@@ -184,7 +184,7 @@ We start over from a stronger hypothesis of a half adjoint equivalence.
     ( second (projection-hae-inverse (first w)))
 
 #def projection-hae-fibered-homotopy-contraction
-  : (projection-hae-section (first w)) =_{B (first w)} (second w)
+  : ( projection-hae-section (first w)) =_{B (first w)} (second w)
   :=
     concat (B (first w))
       ( projection-hae-section (first w))
@@ -208,12 +208,12 @@ Finally, we have:
   ( A : U)
   ( B : A → U)
   ( proj-B-to-A-is-half-adjoint-equivalence
-    : is-half-adjoint-equiv (Σ (x : A) , B x) A (projection-total-type A B))
+ : is-half-adjoint-equiv (Σ (x : A) , B x) A (projection-total-type A B))
   : contractible-fibers A B
   :=
     \ x →
-      ( (projection-hae-section A B proj-B-to-A-is-half-adjoint-equivalence x) ,
-        \ u →
+      ( ( projection-hae-section A B proj-B-to-A-is-half-adjoint-equivalence x)
+      , \ u →
           projection-hae-fibered-homotopy-contraction
           A B proj-B-to-A-is-half-adjoint-equivalence (x , u))
 ```
@@ -223,7 +223,7 @@ Finally, we have:
   ( A : U)
   ( B : A → U)
   ( proj-B-to-A-is-equiv
-    : is-equiv (Σ (x : A) , B x) A (projection-total-type A B))
+ : is-equiv (Σ (x : A) , B x) A (projection-total-type A B))
   : contractible-fibers A B
   :=
     contractible-fibers-is-half-adjoint-equiv-projection A B
@@ -240,8 +240,8 @@ Finally, we have:
     ( contractible-fibers A B)
   :=
     ( \ proj-B-to-A-is-equiv →
-      contractible-fibers-is-equiv-projection A B proj-B-to-A-is-equiv ,
-      \ contractible-fibers-A-B →
+      contractible-fibers-is-equiv-projection A B proj-B-to-A-is-equiv
+    , \ contractible-fibers-A-B →
       is-equiv-projection-contractible-fibers A B contractible-fibers-A-B)
 ```
 
@@ -254,15 +254,15 @@ the fibers.
 #def equiv-sum-of-fibers-domain
   ( A B : U)
   ( f : A → B)
-  : Equiv A (Σ (b : B), fib A B f b)
+  : Equiv A (Σ (b : B) , fib A B f b)
   :=
     equiv-left-cancel
-    ( Σ (a : A), Σ (b : B), f a = b)
+    ( Σ ( a : A) , Σ (b : B) , f a = b)
     ( A)
-    ( Σ (b : B), fib A B f b)
+    ( Σ ( b : B) , fib A B f b)
     ( equiv-projection-contractible-fibers
       A
-      ( \ a → Σ (b : B), f a = b)
+      ( \ a → Σ (b : B) , f a = b)
       ( \ a → is-contr-based-paths B (f a)))
     ( fubini-Σ A B (\ a b → f a = b))
 ```
@@ -273,7 +273,7 @@ The inverse map is just the canonical projection to `A`.
 #def is-equiv-domain-sum-of-fibers
   ( A B : U)
   ( f : A → B)
-  : is-equiv (Σ (b : B), fib A B f b) A ( \ (_ , (a , _)) → a)
+  : is-equiv (Σ (b : B) , fib A B f b) A (\ (_ , (a , _)) → a)
   :=
     second
     ( inv-equiv A (Σ (b : B) , fib A B f b)
@@ -295,12 +295,12 @@ equivalence preserves fibers up to equivalence.
   : Equiv (fib A C (comp A B C g f) c) (fib B C g c)
   :=
   equiv-comp
-  ( fib A C ( comp A B C g f) c)
-  ( Σ ((b, _) : fib B C g c), fib A B f b)
+  ( fib A C (comp A B C g f) c)
+  ( Σ ( ( b , _) : fib B C g c) , fib A B f b)
   ( fib B C g c)
   ( equiv-fiber-sum-fiber-comp A B C f g c)
-  ( ( projection-total-type (fib B C g c) (\ (b, _) → fib A B f b))
+  ( ( projection-total-type (fib B C g c) (\ (b , _) → fib A B f b))
     , second
-      ( projection-theorem (fib B C g c) (\ (b, _) → fib A B f b))
-      ( \ (b, _) → (is-contr-map-is-equiv A B f is-equiv-f) b))
+      ( projection-theorem (fib B C g c) (\ (b , _) → fib A B f b))
+      ( \ (b , _) → (is-contr-map-is-equiv A B f is-equiv-f) b))
 ```

--- a/src/hott/11-homotopy-pullbacks.rzk.md
+++ b/src/hott/11-homotopy-pullbacks.rzk.md
@@ -33,7 +33,7 @@ We start by fixing the data of a map between two type families `A' → U` and
 
 #def temp-uBDx-Σαγ
   : total-type A' C' → total-type A C
-  := \ (a', c') → (α a', γ a' c')
+  := \ (a' , c') → (α a' , γ a' c')
 ```
 
 We say that such a square is homotopy cartesian just if it induces an
@@ -56,40 +56,40 @@ cartesian square, then so is the upper one `Σαγ : Σ C' → Σ C`.
 
 ```rzk
 #def temp-uBDx-comp
-  : (total-type A' C') → (total-type A C)
+  : ( total-type A' C') → (total-type A C)
   := comp
       ( total-type A' C')
-      ( Σ (a' : A'), C (α a'))
+      ( Σ ( a' : A') , C (α a'))
       ( total-type A C)
-      ( \ (a', c) → (α a', c) )
+      ( \ (a' , c) → (α a' , c))
       ( total-map A' C' (\ a' → C (α a')) γ)
 
 
 #def pull-up-equiv-is-homotopy-cartesian
   ( is-hc-α-γ : is-homotopy-cartesian)
   ( is-equiv-α : is-equiv A' A α)
-  : is-equiv (total-type A' C') (total-type A C) (\ (a', c') → (α a', γ a' c'))
+  : is-equiv (total-type A' C') (total-type A C) (\ (a' , c') → (α a' , γ a' c'))
   :=
     is-equiv-homotopy
       ( total-type A' C')
       ( total-type A C)
-      ( temp-uBDx-Σαγ )
-      ( temp-uBDx-comp )
-      (\ _ → refl)
+      ( temp-uBDx-Σαγ)
+      ( temp-uBDx-comp)
+      ( \ _ → refl)
       ( is-equiv-comp
         ( total-type A' C')
-        ( Σ (a' : A'), C (α a'))
+        ( Σ ( a' : A') , C (α a'))
         ( total-type A C)
         ( total-map A' C' (\ a' → C (α a')) γ)
         ( is-equiv-total-is-equiv-fiberwise A' C'
-          ( \ a' → C (α a') )
+          ( \ a' → C (α a'))
           ( γ)
           ( \ a' → is-hc-α-γ a'))
-        ( \ (a', c) → (α a', c) )
+        ( \ (a' , c) → (α a' , c))
         ( second
           ( equiv-total-pullback-is-equiv A' A α
-            ( is-equiv-α )
-            ( C ))))
+            ( is-equiv-α)
+            ( C))))
 ```
 
 Conversely, if both the upper and the lower maps are equivalences, then the
@@ -99,24 +99,24 @@ square is homotopy-cartesian.
 #def is-homotopy-cartesian-is-horizontal-equiv
   ( is-equiv-α : is-equiv A' A α)
   ( is-equiv-Σαγ : is-equiv
-      (total-type A' C') (total-type A C) (\ (a', c') → (α a', γ a' c'))
+      ( total-type A' C') (total-type A C) (\ (a' , c') → (α a' , γ a' c'))
   )
   : is-homotopy-cartesian
   :=
     is-equiv-fiberwise-is-equiv-total
-        A' C' ( \ x → C (α x) ) γ
+        A' C' (\ x → C (α x)) γ
         ( is-equiv-right-factor
             ( total-type A' C')
-            ( Σ (x : A'), C (α x))
+            ( Σ ( x : A') , C (α x))
             ( total-type A C)
             ( total-map A' C' (\ x → C (α x)) γ)
-            ( \ (x, c) → (α x, c) )
-            ( second ( equiv-total-pullback-is-equiv A' A α is-equiv-α C))
+            ( \ (x , c) → (α x , c))
+            ( second (equiv-total-pullback-is-equiv A' A α is-equiv-α C))
             ( is-equiv-homotopy
                 ( total-type A' C')
-                ( total-type A C )
-                ( temp-uBDx-comp )
-                ( temp-uBDx-Σαγ )
+                ( total-type A C)
+                ( temp-uBDx-comp)
+                ( temp-uBDx-Σαγ)
                 ( \ _ → refl)
                 ( is-equiv-Σαγ)))
 ```
@@ -129,81 +129,81 @@ always do this (whether the square is homotopy-cartesian or not).
 #def has-section-family-over-map
   : U
   :=
-    Σ ( ( s', s) : product ((a' : A') → C' a') ((a : A) → C a) ),
-      ( (a' : A') → γ a' (s' a') = s (α a'))
+    Σ ( ( s' , s) : product ((a' : A') → C' a') ((a : A) → C a))
+    , ( ( a' : A') → γ a' (s' a') = s (α a'))
 
 #def induced-map-on-fibers-Σ uses (γ)
   ( ĉ : total-type A C)
-  ( (ĉ', q̂) : fib
-                (total-type A' C') (total-type A C)
-                (\ (a', c') → (α a', γ a' c'))
+  ( ( ĉ' , q̂) : fib
+                ( total-type A' C') (total-type A C)
+                ( \ (a' , c') → (α a' , γ a' c'))
                 ĉ)
   : fib A' A α (first ĉ)
   :=
-    (first ĉ', first-path-Σ A C (temp-uBDx-Σαγ ĉ') ĉ q̂)
+    ( first ĉ' , first-path-Σ A C (temp-uBDx-Σαγ ĉ') ĉ q̂)
 
 #def temp-uBDx-helper-type uses (γ C')
-  ( ((s', s) , η) : has-section-family-over-map)
-  ( a : A )
-  ( (a', p) : fib A' A α a )
+  ( ( ( s' , s) , η) : has-section-family-over-map)
+  ( a : A)
+  ( ( a' , p) : fib A' A α a)
   : U
   :=
-    Σ ( q̂ : temp-uBDx-Σαγ (a', s' a') = (a, s a)),
-        ( induced-map-on-fibers-Σ (a, s a) ((a', s' a'), q̂) = (a', p))
+    Σ ( q̂ : temp-uBDx-Σαγ (a' , s' a') = (a , s a))
+      , ( induced-map-on-fibers-Σ (a , s a) ((a' , s' a') , q̂) = (a' , p))
 
 #def temp-uBDx-helper uses (γ C')
-  ( ((s', s) , η) : has-section-family-over-map)
-  : ( a : A) →
-    ( (a', p) : fib A' A α a ) →
-    temp-uBDx-helper-type ((s',s), η) a (a', p)
+  ( ( ( s' , s) , η) : has-section-family-over-map)
+  : ( a : A)
+  → ( ( a' , p) : fib A' A α a)
+  → temp-uBDx-helper-type ((s' , s) , η) a (a' , p)
   :=
     ind-fib A' A α
-    ( temp-uBDx-helper-type ((s',s), η))
+    ( temp-uBDx-helper-type ((s' , s) , η))
     ( \ a' →
-      ( eq-pair A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ) ,
-        eq-pair
+      ( eq-pair A C (α a' , γ a' (s' a')) (α a' , s (α a')) (refl , η a')
+      , eq-pair
         ( A')
         ( \ x → α x = α a')
-        ( a' ,
-          first-path-Σ A C
-          ( α a', γ a' (s' a'))
-          ( α a', s (α a'))
-          ( eq-pair A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' )))
+        ( a'
+        , first-path-Σ A C
+          ( α a' , γ a' (s' a'))
+          ( α a' , s (α a'))
+          ( eq-pair A C (α a' , γ a' (s' a')) (α a' , s (α a')) (refl , η a')))
         ( a' , refl)
-        ( refl ,
-          first-path-Σ-eq-pair
-            A C (α a', γ a' (s' a')) (α a', s (α a')) ( refl, η a' ))))
+        ( refl
+        , first-path-Σ-eq-pair
+            A C (α a' , γ a' (s' a')) (α a' , s (α a')) (refl , η a'))))
 
 #def induced-retraction-on-fibers-with-section uses (γ)
-  ( ((s',s),η) : has-section-family-over-map)
-  ( a : A )
+  ( ( ( s' , s) , η) : has-section-family-over-map)
+  ( a : A)
   : ( is-retract-of
-      ( fib A' A α a )
+      ( fib A' A α a)
       ( fib
         ( total-type A' C') (total-type A C)
-        ( \ (a', c') → (α a', γ a' c'))
-        ( a, s a)))
+        ( \ (a' , c') → (α a' , γ a' c'))
+        ( a , s a)))
   :=
-    ( \ (a', p) → ( (a', s' a'), first (temp-uBDx-helper ((s',s),η) a (a',p))),
-      ( induced-map-on-fibers-Σ (a, s a) ,
-        \ (a', p) → second (temp-uBDx-helper ((s',s),η) a (a',p))))
+    ( \ (a' , p) → ((a' , s' a') , first (temp-uBDx-helper ((s' , s) , η) a (a' , p)))
+    , ( induced-map-on-fibers-Σ (a , s a)
+      , \ (a' , p) → second (temp-uBDx-helper ((s' , s) , η) a (a' , p))))
 
 #def push-down-equiv-with-section uses (γ)
-  ( ((s',s),η) : has-section-family-over-map)
+  ( ( ( s' , s) , η) : has-section-family-over-map)
   ( is-equiv-Σαγ : is-equiv
-      (total-type A' C') (total-type A C) temp-uBDx-Σαγ)
+      ( total-type A' C') (total-type A C) temp-uBDx-Σαγ)
   : is-equiv A' A α
   :=
     is-equiv-is-contr-map A' A α
     ( \ a →
       is-contr-is-retract-of-is-contr
       ( fib A' A α a)
-      ( fib (total-type A' C') (total-type A C) (temp-uBDx-Σαγ) (a, s a))
-      ( induced-retraction-on-fibers-with-section ((s',s),η) a)
+      ( fib (total-type A' C') (total-type A C) (temp-uBDx-Σαγ) (a , s a))
+      ( induced-retraction-on-fibers-with-section ((s' , s) , η) a)
       ( is-contr-map-is-equiv
         ( total-type A' C') (total-type A C)
         ( temp-uBDx-Σαγ)
-        ( is-equiv-Σαγ )
+        ( is-equiv-Σαγ)
         ( a , s a)))
 
 #end homotopy-cartesian
@@ -221,15 +221,15 @@ maps `β → α` and obtain another homotopy cartesian square.
   ( A : U)
   ( C : A → U)
   ( α : A' → A)
-  ( γ : ( a' : A') → C' a' → C (α a'))
+  ( γ : (a' : A') → C' a' → C (α a'))
   ( B' B : U)
   ( β : B' → B)
-  ( ((s', s), η) : map-of-maps B' B β A' A α)
+  ( ( ( s' , s) , η) : map-of-maps B' B β A' A α)
   ( is-hc-α : is-homotopy-cartesian A' C' A C α γ)
   : is-homotopy-cartesian
-      B' ( \ b' → C' (s' b'))
-      B  ( \ b → C (s b))
-      β  ( \ b' c' → transport A C (α (s' b')) (s (β b')) (η b') (γ (s' b') c'))
+      B' (\ b' → C' (s' b'))
+      B  (\ b → C (s b))
+      β  (\ b' c' → transport A C (α (s' b')) (s (β b')) (η b') (γ (s' b') c'))
   :=
     \ b' →
       is-equiv-comp (C' (s' b')) (C (α (s' b'))) (C (s (β b')))
@@ -256,7 +256,7 @@ corresponding statements about equivalences established above.
 
 #variable A' : U
 #variable C' : A' → U
-#variable D' : ( a' : A') → C' a' → U
+#variable D' : (a' : A') → C' a' → U
 #variable A : U
 #variable C : A → U
 #variable D : (a : A) → C a → U
@@ -266,28 +266,28 @@ corresponding statements about equivalences established above.
 
 #def is-homotopy-cartesian-upper
   : U
-  := ( is-homotopy-cartesian
+  := (is-homotopy-cartesian
        ( total-type A' C')
-       ( \ (a', c') → D' a' c')
+       ( \ (a' , c') → D' a' c')
        ( total-type A C)
-       ( \ (a, c) → D a c)
-       ( \ (a', c') → (α a', γ a' c'))
-       ( \ (a', c') → δ a' c'))
+       ( \ (a , c) → D a c)
+       ( \ (a' , c') → (α a' , γ a' c'))
+       ( \ (a' , c') → δ a' c'))
 
 #def is-homotopy-cartesian-upper-to-fibers uses (A)
   ( is-hc-γ-δ : is-homotopy-cartesian-upper)
   ( a' : A')
   : is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
   :=
-    \ c' → is-hc-γ-δ (a', c')
+    \ c' → is-hc-γ-δ (a' , c')
 
 #def is-homotopy-cartesian-upper-from-fibers uses (A)
   ( is-fiberwise-hc-γ-δ
-    : ( a' : A') →
-      is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
+ : ( a' : A')
+    → is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
   : is-homotopy-cartesian-upper
   :=
-    \ (a', c') → is-fiberwise-hc-γ-δ a' c'
+    \ (a' , c') → is-fiberwise-hc-γ-δ a' c'
 
 #def is-homotopy-cartesian-vertical-pasted
   : U
@@ -295,24 +295,24 @@ corresponding statements about equivalences established above.
     is-homotopy-cartesian
       A' (\ a' → total-type (C' a') (D' a'))
       A (\ a → total-type (C a) (D a))
-      α (\ a' (c', d') → (γ a' c', δ a' c' d'))
+      α (\ a' (c' , d') → (γ a' c' , δ a' c' d'))
 
 #def is-homotopy-cartesian-vertical-pasting
-  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ )
+  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ)
   ( is-hc-γ-δ : is-homotopy-cartesian-upper)
   : is-homotopy-cartesian-vertical-pasted
   :=
     \ a' →
       pull-up-equiv-is-homotopy-cartesian
-        (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
+        ( C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
         ( is-homotopy-cartesian-upper-to-fibers is-hc-γ-δ a')
-        ( is-hc-α-γ a' )
+        ( is-hc-α-γ a')
 
 #def is-homotopy-cartesian-vertical-pasting-from-fibers
-  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ )
+  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ)
   ( is-fiberwise-hc-γ-δ
-    : ( a' : A') →
-      is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
+ : ( a' : A')
+    → is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
   : is-homotopy-cartesian-vertical-pasted
   :=
     is-homotopy-cartesian-vertical-pasting
@@ -320,7 +320,7 @@ corresponding statements about equivalences established above.
       ( is-homotopy-cartesian-upper-from-fibers is-fiberwise-hc-γ-δ)
 
 #def is-homotopy-cartesian-lower-cancel-to-fibers
-  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ )
+  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ)
   ( is-hc-α-δ : is-homotopy-cartesian-vertical-pasted)
   ( a' : A')
   : is-homotopy-cartesian (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a')
@@ -331,18 +331,18 @@ corresponding statements about equivalences established above.
       ( is-hc-α-δ a')
 
 #def is-homotopy-cartesian-lower-cancel uses (D D' δ)
-  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ )
+  ( is-hc-α-γ : is-homotopy-cartesian A' C' A C α γ)
   ( is-hc-α-δ : is-homotopy-cartesian-vertical-pasted
   )
   : is-homotopy-cartesian-upper
   :=
     is-homotopy-cartesian-upper-from-fibers
-      (is-homotopy-cartesian-lower-cancel-to-fibers is-hc-α-γ is-hc-α-δ)
+      ( is-homotopy-cartesian-lower-cancel-to-fibers is-hc-α-γ is-hc-α-δ)
 
 #def is-homotopy-cartesian-upper-cancel-with-section
-  ( has-sec-γ-δ : (a' : A') →
-      has-section-family-over-map
-        (C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
+  ( has-sec-γ-δ : (a' : A')
+    → has-section-family-over-map
+        ( C' a') (D' a') (C (α a')) (D (α a')) (γ a') (δ a'))
   ( is-hc-α-δ : is-homotopy-cartesian-vertical-pasted)
   : is-homotopy-cartesian A' C' A C α γ
   :=
@@ -381,12 +381,12 @@ from composition and cancelling laws for equivalences.
     ( comp A'' A' A f f')
     ( \ a'' →
         comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-         (F (f' a'')) (F' a''))
+         ( F (f' a'')) (F' a''))
   :=
     \ a'' →
     is-equiv-comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-      (F' a'') (ihc' a'')
-      (F (f' a'')) (ihc (f' a''))
+      ( F' a'') (ihc' a'')
+      ( F (f' a'')) (ihc (f' a''))
 
 #def is-homotopy-cartesian-right-cancel
   ( ihc : is-homotopy-cartesian A' C' A C f F)
@@ -394,7 +394,7 @@ from composition and cancelling laws for equivalences.
               ( comp A'' A' A f f')
               ( \ a'' →
                 comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-                  (F (f' a'')) (F' a'')))
+                  ( F (f' a'')) (F' a'')))
   : is-homotopy-cartesian A'' C'' A' C' f' F'
   :=
     \ a'' →
@@ -416,7 +416,7 @@ We can cancel the left homotopy cartesian square if its lower map
               ( comp A'' A' A f f')
               ( \ a'' →
                 comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-                  (F (f' a'')) (F' a'')))
+                  ( F (f' a'')) (F' a'')))
   : is-homotopy-cartesian A' C' A C f F
   :=
     ind-has-section A'' A' f' has-section-f'
@@ -424,7 +424,7 @@ We can cancel the left homotopy cartesian square if its lower map
     ( \ a'' →
       is-equiv-left-factor (C'' a'') (C' (f' a'')) (C (f (f' a'')))
       ( F' a'') (ihc' a'')
-      ( F (f' a'')) ( ihc'' a''))
+      ( F (f' a'')) (ihc'' a''))
 ```
 
 In fact, it suffices to assume that the left square has horizontal sections.
@@ -437,36 +437,36 @@ In fact, it suffices to assume that the left square has horizontal sections.
               ( comp A'' A' A f f')
               ( \ a'' →
                 comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-                  (F (f' a'')) (F' a'')))
+                  ( F (f' a'')) (F' a'')))
   : is-homotopy-cartesian A' C' A C f F
   :=
     ind-has-section A'' A' f' has-section-f'
     ( \ a' → is-equiv (C' a') (C (f a')) (F a'))
     ( \ a'' →
       is-equiv-left-cancel (C'' a'') (C' (f' a'')) (C (f (f' a'')))
-      ( F' a'') ( has-sections-F' a'')
-      ( F (f' a'')) ( ihc'' a''))
+      ( F' a'') (has-sections-F' a'')
+      ( F (f' a'')) (ihc'' a''))
 
 #def is-homotopy-cartesian-left-cancel-with-section'
-  ( (sec-f' , ε-f') : has-section A'' A' f')
+  ( ( sec-f' , ε-f') : has-section A'' A' f')
   ( has-sections-F'
-    : (a' : A')
+ : ( a' : A')
     → has-section (C'' (sec-f' a')) (C' (f' (sec-f' a'))) (F' (sec-f' a')))
   ( ihc''
-    : is-homotopy-cartesian A'' C'' A C
+ : is-homotopy-cartesian A'' C'' A C
       ( comp A'' A' A f f')
       ( \ a'' →
         comp (C'' a'') (C' (f' a'')) (C (f (f' a'')))
         ( F (f' a'')) (F' a'')))
   : is-homotopy-cartesian A' C' A C f F
   :=
-    ind-has-section' A'' A' f' (sec-f', ε-f')
+    ind-has-section' A'' A' f' (sec-f' , ε-f')
     ( \ a' → is-equiv (C' a') (C (f a')) (F a'))
     ( \ a' →
       is-equiv-left-cancel
       ( C'' (sec-f' a')) (C' (f' (sec-f' a'))) (C (f (f' (sec-f' a'))))
-      ( F' (sec-f' a')) ( has-sections-F' a')
-      ( F (f' (sec-f' a'))) ( ihc'' (sec-f' a')))
+      ( F' (sec-f' a')) (has-sections-F' a')
+      ( F (f' (sec-f' a'))) (ihc'' (sec-f' a')))
 
 #end homotopy-cartesian-horizontal-calculus
 ```
@@ -503,8 +503,8 @@ and a map between them in the following strict sense
 #variable F' : (a' : A') → C' a' → D' (f' a')
 #variable F : (a : A) → C a → D (f a)
 #variable H
-  : (a' : A')
-  → (c' : C' a')
+ : ( a' : A')
+  → ( c' : C' a')
   → ( transport B D (β (f' a')) (f (α a')) (h a')
       ( δ (f' a') (F' a' c'))
     = F (α a') (γ a' c'))
@@ -543,8 +543,8 @@ If the square `B' D' B D` is homotopy cartesian, then so is `A' C' A C`.
     is-equiv-equiv-is-equiv
     ( C' a') (C (α a')) (γ a')
     ( D' (f' a')) (D (f (α a')))
-    (\ d' → transport B D (β (f' a')) (f (α a')) (h a') (δ (f' a') d'))
-    ( ( F' a' ,  F (α a')) , H a')
+    ( \ d' → transport B D (β (f' a')) (f (α a')) (h a') (δ (f' a') d'))
+    ( ( F' a' , F (α a')) , H a')
     ( is-hc-CD' a')
     ( is-hc-CD (α a'))
     ( is-equiv-comp
@@ -574,8 +574,8 @@ The converse holds provided that the map `f' : A' → B'` has a section.
         ( is-equiv-equiv-is-equiv'
           ( C' a') (C (α a')) (γ a')
           ( D' (f' a')) (D (f (α a')))
-          (\ d' → transport B D (β (f' a')) (f (α a')) (h a') (δ (f' a') d'))
-          ( ( F' a' ,  F (α a')) , H a')
+          ( \ d' → transport B D (β (f' a')) (f (α a')) (h a') (δ (f' a') d'))
+          ( ( F' a' , F (α a')) , H a')
           ( is-hc-CD' a')
           ( is-hc-CD (α a'))
           ( is-hc-AC a'))))
@@ -600,14 +600,14 @@ Given two type families `B C : A → U`, we can form their **fiberwise product**
   ( B C : A → U)
   ( a : A)
   : fiberwise-product A B C a → B a
-  := \ (b,_) → b
+  := \ (b , _) → b
 
 #def second-fiberwise-product
   ( A : U)
   ( B C : A → U)
   ( a : A)
   : fiberwise-product A B C a → C a
-  := \ (_,c) → c
+  := \ (_ , c) → c
 ```
 
 Given two maps `B → A` and `C → A`, we can form the **relative product** over
@@ -624,23 +624,23 @@ Given two maps `B → A` and `C → A`, we can form the **relative product** ove
 
 #def relative-product
   : U
-  := Σ ( (b, c) : product B C) , (β b = γ c)
+  := Σ ((b , c) : product B C) , (β b = γ c)
 
 #def first-relative-product uses (A B β C γ)
   : relative-product → B
-  := \ ((b , _), _) → b
+  := \ ((b , _) , _) → b
 
 #def second-relative-product uses (A B β C γ)
   : relative-product → C
-  := \ ((_ , c), _) → c
+  := \ ((_ , c) , _) → c
 
 #def projection-relative-product uses (A B β C)
   : relative-product → A
   := \ ((_ , c) , _) → γ c
 
 #def homotopy-relative-product uses (A B C)
-  ( (bc, p) : relative-product )
-  : β (first-relative-product (bc,p)) = γ (second-relative-product (bc,p))
+  ( ( bc , p) : relative-product)
+  : β (first-relative-product (bc , p)) = γ (second-relative-product (bc , p))
   := p
 ```
 
@@ -654,37 +654,37 @@ product of all fibers.
 
 #def unpack-fiber-product
   : fiber-product
-  = ( Σ (a : A), (product (fib B A β a) (fib C A γ a)))
+  = ( Σ ( a : A) , (product (fib B A β a) (fib C A γ a)))
   := refl
 
 #def first-fiber-product uses (A B β C γ)
   : fiber-product → B
-  := \ (_, ((b, _), _ )) → b
+  := \ (_ , ((b , _) , _)) → b
 
 #def second-fiber-product uses (A B β C γ)
   : fiber-product → C
-  := \ (_, (_, (c, _))) → c
+  := \ (_ , (_ , (c , _))) → c
 
 #def projection-fiber-product uses (A B β C γ)
   : fiber-product → A
-  := \ (a, (_, (_, _))) → a
+  := \ (a , (_ , (_ , _))) → a
 
 #def homotopy-fiber-product uses (A B C)
-  : ( abpcq : fiber-product )
+  : ( abpcq : fiber-product)
   → β (first-fiber-product abpcq) = γ (second-fiber-product abpcq)
   :=
-    \ ( a, ((b, p), (c,q))) →
+    \ (a , ((b , p) , (c , q))) →
       zig-zag-concat A (β b) a (γ c) p q
 
 #def relative-fiber-product uses (B C)
-  ( (a, ((b, p), (c,q))) : fiber-product )
+  ( ( a , ((b , p) , (c , q))) : fiber-product)
   : relative-product
-  := ( ( b , c) , zig-zag-concat A (β b) a (γ c) p q)
+  := ((b , c) , zig-zag-concat A (β b) a (γ c) p q)
 
-#def fiber-relative-product uses ( A B β C)
-  ( ((b,c), e) : relative-product)
+#def fiber-relative-product uses (A B β C)
+  ( ( ( b , c) , e) : relative-product)
   : fiber-product
-  := ( γ c , ( (b , e) , (c , refl)))
+  := (γ c , ((b , e) , (c , refl)))
 
 #def compatible-projection-fiber-relative-product uses (A B β C γ)
   ( x : relative-product)
@@ -706,12 +706,12 @@ product of all fibers.
   : ( abpcq : fiber-product)
   → ( fiber-relative-product (relative-fiber-product abpcq)) = abpcq
   :=
-  \ (a', (bq', cq')) →
+  \ (a' , (bq' , cq')) →
     ind-fib C A γ
     ( \ a cq →
       ( ( bq : fib B A β a)
-      → ( fiber-relative-product (relative-fiber-product (a, (bq, cq)))
-        = ( a, (bq, cq)))))
+      → ( fiber-relative-product (relative-fiber-product (a , (bq , cq)))
+        = ( a , (bq , cq)))))
     ( \ c bq → refl)
     ( a')
     ( cq')
@@ -747,9 +747,9 @@ The relative product of `f : B → A` with a map `Unit → A` corresponding to
   : Equiv (fib B A f a) (relative-product A B f Unit (\ unit → a))
   :=
     ( ( \ (b , p) → ((b , unit) , p))
-    , ( ( ( ( \ ((b , unit) , p) → (b, p))
+    , ( ( ( ( \ ((b , unit) , p) → (b , p))
           , ( \ _ → refl))
-        , ( ( \ ((b , unit) , p) → (b, p))
+        , ( ( \ ((b , unit) , p) → (b , p))
           , ( \ _ → refl)))))
 
 #def compute-map-pullback-to-Unit
@@ -759,7 +759,7 @@ The relative product of `f : B → A` with a map `Unit → A` corresponding to
   : Equiv-of-maps
     ( fib B A f a) (Unit) (\ _ → unit)
     ( relative-product A B f Unit (\ unit → a))
-    ( Unit) ( second-relative-product A B f Unit (\ unit → a))
+    ( Unit) (second-relative-product A B f Unit (\ unit → a))
   :=
     ( ( ( ( \ (b , p) → ((b , unit) , p))
         , ( identity Unit))
@@ -823,9 +823,9 @@ We define the induced maps on fibers the resulting fibers between fibers.
   ( c : C)
   : fib T C γ' c → fib B A β (γ c)
   := \ (t , q) →
-     ( (β' t)
+     ( ( β' t)
      , ( concat A (β (β' t)) (γ (γ' t)) (γ c)
-         (η t) (ap C A (γ' t) c γ q)))
+         ( η t) (ap C A (γ' t) c γ q)))
 
 #def fib-vertical-fibs-comm-square uses (β' γ' η)
   ( c : C)
@@ -845,29 +845,29 @@ the fiber fibers.
 -- that are only meant to be used locally in this section
 
 #def helper-IkCK uses (β' η)
-  ( ((b , c) , p) : relative-product A B β C γ)
+  ( ( ( b , c) , p) : relative-product A B β C γ)
   ( t : T)
   : U
-  := Σ ( q : γ' t = c) , map-vertical-fibs-comm-square c (t , q) = (b , p)
+  := Σ (q : γ' t = c) , map-vertical-fibs-comm-square c (t , q) = (b , p)
 
 #def fib-vertical-fibs-helper-IkCK uses (β' γ' η)
-  ( ((b , c) , p) : relative-product A B β C γ)
+  ( ( ( b , c) , p) : relative-product A B β C γ)
   ( t : T)
-  ( (q , e) : helper-IkCK ((b,c),p) t)
-  : fib-vertical-fibs-comm-square c (b,p)
+  ( ( q , e) : helper-IkCK ((b , c) , p) t)
+  : fib-vertical-fibs-comm-square c (b , p)
   := ((t , q) , e)
 
 #def fib-vertical-fibs-tot-fib-comm-square uses (η β' γ')
-  ( ((b,c),p) : relative-product A B β C γ)
-  ( (t , h) : tot-fib-comm-square ((b,c),p))
-  : fib-vertical-fibs-comm-square c (b,p)
+  ( ( ( b , c) , p) : relative-product A B β C γ)
+  ( ( t , h) : tot-fib-comm-square ((b , c) , p))
+  : fib-vertical-fibs-comm-square c (b , p)
   :=
-    ( fib-vertical-fibs-helper-IkCK ((b,c),p) t)
+    ( fib-vertical-fibs-helper-IkCK ((b , c) , p) t)
     ( ind-fib T (relative-product A B β C γ)
       ( gap-map-comm-square)
-      ( \ bcp' (t, h') → helper-IkCK bcp' t)
-      ( \ t → (refl, refl))
-      ( ((b,c),p))
+      ( \ bcp' (t , h') → helper-IkCK bcp' t)
+      ( \ t → (refl , refl))
+      ( ( ( b , c) , p))
       ( t , h))
 ```
 
@@ -878,7 +878,7 @@ canonical projection to `T`.
 ```rzk
 #def compute-fib-vertical-fibs-tot-fib-comm-square uses (η β' γ')
   ( bcp : relative-product A B β C γ)
-  ( (t , h) : tot-fib-comm-square bcp)
+  ( ( t , h) : tot-fib-comm-square bcp)
   :
   ( first (first (fib-vertical-fibs-tot-fib-comm-square bcp (t , h)))
   = t)
@@ -892,18 +892,18 @@ type on each side is just equivalent to `T`.
 ```rzk
 #def is-equiv-projection-fib-vertical-fibs-comm-square uses (η β')
   : is-equiv
-    ( Σ (((b,c),p) : relative-product A B β C γ)
-      , fib-vertical-fibs-comm-square c (b,p))
+    ( Σ ( ( ( b , c) , p) : relative-product A B β C γ)
+      , fib-vertical-fibs-comm-square c (b , p))
     ( T)
     ( \ (_ , ((t , _) , _)) → t)
   :=
     is-equiv-triple-comp
-    ( Σ (((b,c),p) : relative-product A B β C γ)
-      , fib-vertical-fibs-comm-square c (b,p))
+    ( Σ ( ( ( b , c) , p) : relative-product A B β C γ)
+      , fib-vertical-fibs-comm-square c (b , p))
     ( Σ ( c : C)
-      , ( Σ (bp : fib B A β (γ c))
+      , ( Σ ( bp : fib B A β (γ c))
           , fib-vertical-fibs-comm-square c bp))
-    ( Σ (c : C) , fib T C γ' c)
+    ( Σ ( c : C) , fib T C γ' c)
     ( T)
     ( \ (((b , c) , p) , tqe) → (c , ((b , p) , tqe)))
     ( ( \ (c , ((b , p) , tqe)) → (((b , c) , p) , tqe) , \ _ → refl)
@@ -921,32 +921,32 @@ type on each side is just equivalent to `T`.
     ( is-equiv-domain-sum-of-fibers T C γ')
 
 #def is-equiv-fib-vertical-fibs-tot-fib-comm-square uses (η β' γ')
-  : (((b,c),p) : relative-product A B β C γ)
+  : ( ( ( b , c) , p) : relative-product A B β C γ)
   → is-equiv
-    ( tot-fib-comm-square ((b,c),p))
-    ( fib-vertical-fibs-comm-square c (b,p))
-    ( fib-vertical-fibs-tot-fib-comm-square ((b,c),p))
+    ( tot-fib-comm-square ((b , c) , p))
+    ( fib-vertical-fibs-comm-square c (b , p))
+    ( fib-vertical-fibs-tot-fib-comm-square ((b , c) , p))
   :=
     is-equiv-fiberwise-is-equiv-total
     ( relative-product A B β C γ)
     ( \ bcp → tot-fib-comm-square bcp)
-    ( \ ((b,c),p) → fib-vertical-fibs-comm-square c (b,p))
+    ( \ ((b , c) , p) → fib-vertical-fibs-comm-square c (b , p))
     ( \ bcp → fib-vertical-fibs-tot-fib-comm-square bcp)
     ( is-equiv-right-factor
-      ( Σ (bcp : relative-product A B β C γ)
+      ( Σ ( bcp : relative-product A B β C γ)
         , tot-fib-comm-square bcp)
-      ( Σ (((b,c),p) : relative-product A B β C γ)
-        , fib-vertical-fibs-comm-square c (b,p))
+      ( Σ ( ( ( b , c) , p) : relative-product A B β C γ)
+        , fib-vertical-fibs-comm-square c (b , p))
       ( T)
       ( total-map
         ( relative-product A B β C γ)
         ( \ bcp → tot-fib-comm-square bcp)
-        ( \ ((b,c),p) → fib-vertical-fibs-comm-square c (b,p))
+        ( \ ((b , c) , p) → fib-vertical-fibs-comm-square c (b , p))
         ( \ bcp → fib-vertical-fibs-tot-fib-comm-square bcp))
       ( \ (_ , ((t , _) , _)) → t)
       ( is-equiv-projection-fib-vertical-fibs-comm-square)
       ( is-equiv-domain-sum-of-fibers
-        ( T) ( relative-product A B β C γ)
+        ( T) (relative-product A B β C γ)
         ( gap-map-comm-square)))
 ```
 
@@ -985,12 +985,16 @@ Every map of maps induces a map of fibers.
 
 -- To avoid polluting the global namespace, we add a random suffix to
 -- identifiers that are only supposed to be used in this section.
-#def s'-c4XT uses (A α B β) : A' → B' := first (first map-of-maps-α-β)
-#def s-c4XT uses (A' α B' β) : A → B := second (first map-of-maps-α-β)
+#def s'-c4XT uses (A α B β)
+  : A' → B'
+  := first (first map-of-maps-α-β)
+#def s-c4XT uses (A' α B' β)
+  : A → B
+  := second (first map-of-maps-α-β)
 
 #def map-of-fibers-map-of-maps
   ( a : A)
-  ( (a', p) : fib A' A α a)
+  ( ( a' , p) : fib A' A α a)
   : fib B' B β (s-c4XT a)
   :=
   ( s'-c4XT a'
@@ -1006,43 +1010,43 @@ that an equivalence of maps induces an equivalence of fibers at each base point.
 
 ```rzk
 #def map-of-sums-of-fibers-map-of-maps uses (map-of-maps-α-β)
-  ( (a, u) : Σ (a : A), fib A' A α a)
-  : Σ (b : B), fib B' B β b
-  := (s-c4XT a, map-of-fibers-map-of-maps a u)
+  ( ( a , u) : Σ (a : A) , fib A' A α a)
+  : Σ ( b : B) , fib B' B β b
+  := (s-c4XT a , map-of-fibers-map-of-maps a u)
 
 #def sums-of-fibers-to-domains-map-of-maps uses (map-of-maps-α-β)
   : map-of-maps
-    ( Σ (a : A), fib A' A α a)
-    ( Σ (b : B), fib B' B β b)
+    ( Σ ( a : A) , fib A' A α a)
+    ( Σ ( b : B) , fib B' B β b)
     ( map-of-sums-of-fibers-map-of-maps)
     ( A')
     ( B')
     ( s'-c4XT)
   :=
-  ((( \ (_, (a', _)) → a'), ( \ (_, (b', _)) → b')), \ (a, u) → refl)
+  ( ( ( \ (_ , (a' , _)) → a') , (\ (_ , (b' , _)) → b')) , \ (a , u) → refl)
 
 #variable is-equiv-s' : is-equiv A' B' s'-c4XT
 
 #def is-equiv-map-of-sums-of-fibers-is-equiv-map-of-domains
   uses (map-of-maps-α-β is-equiv-s')
   : is-equiv
-    ( Σ (a : A), fib A' A α a)
-    ( Σ (b : B), fib B' B β b)
+    ( Σ ( a : A) , fib A' A α a)
+    ( Σ ( b : B) , fib B' B β b)
     ( map-of-sums-of-fibers-map-of-maps)
   :=
   is-equiv-equiv-is-equiv
-  ( Σ (a : A), fib A' A α a)
-  ( Σ (b : B), fib B' B β b)
+  ( Σ ( a : A) , fib A' A α a)
+  ( Σ ( b : B) , fib B' B β b)
   ( map-of-sums-of-fibers-map-of-maps)
   ( A')
   ( B')
   ( s'-c4XT)
   ( sums-of-fibers-to-domains-map-of-maps)
   ( second
-    ( ( inv-equiv A' (Σ (a : A), fib A' A α a))
+    ( ( inv-equiv A' (Σ (a : A) , fib A' A α a))
       ( equiv-sum-of-fibers-domain A' A α)))
   ( second
-    ( ( inv-equiv B' (Σ (b : B), fib B' B β b))
+    ( ( inv-equiv B' (Σ (b : B) , fib B' B β b))
       ( equiv-sum-of-fibers-domain B' B β)))
   ( is-equiv-s')
 
@@ -1050,7 +1054,7 @@ that an equivalence of maps induces an equivalence of fibers at each base point.
 
 #def is-equiv-map-of-fibers-is-equiv-map-of-maps
   uses (map-of-maps-α-β  is-equiv-s is-equiv-s')
-  : (a : A)
+  : ( a : A)
   → is-equiv
     ( fib A' A α a)
     ( fib B' B β (s-c4XT a))
@@ -1073,12 +1077,12 @@ that an equivalence of maps induces an equivalence of fibers at each base point.
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
-  ( (((s', s), η), (is-equiv-s, is-equiv-s')) : Equiv-of-maps A' A α B' B β)
-  (a : A)
+  ( ( ( ( s' , s) , η) , (is-equiv-s , is-equiv-s')) : Equiv-of-maps A' A α B' B β)
+  ( a : A)
   : Equiv (fib A' A α a) (fib B' B β (s a))
   :=
-  ( map-of-fibers-map-of-maps A' A α B' B β ((s', s), η) a
-  , ( is-equiv-map-of-fibers-is-equiv-map-of-maps A' A α B' B β ((s', s), η))
+  ( map-of-fibers-map-of-maps A' A α B' B β ((s' , s) , η) a
+  , ( is-equiv-map-of-fibers-is-equiv-map-of-maps A' A α B' B β ((s' , s) , η))
     ( is-equiv-s)
     ( is-equiv-s')
     ( a))
@@ -1096,8 +1100,8 @@ The map induced on fibers respects composition up to homotopy.
   ( β : B' → B)
   ( C' C : U)
   ( γ : C' → C)
-  ( ((t',t),ηt) : map-of-maps B' B β C' C γ)
-  ( ((s',s),ηs) : map-of-maps A' A α B' B β)
+  ( ( ( t' , t) , ηt) : map-of-maps B' B β C' C γ)
+  ( ( ( s' , s) , ηs) : map-of-maps A' A α B' B β)
   : map-of-maps A' A α C' C γ
   :=
   ( ( comp A' B' C' t' s'
@@ -1114,27 +1118,27 @@ The map induced on fibers respects composition up to homotopy.
   ( β : B' → B)
   ( C' C : U)
   ( γ : C' → C)
-  ( ((t',t),ηt) : map-of-maps B' B β C' C γ)
-  ( ((s',s),ηs) : map-of-maps A' A α B' B β)
+  ( ( ( t' , t) , ηt) : map-of-maps B' B β C' C γ)
+  ( ( ( s' , s) , ηs) : map-of-maps A' A α B' B β)
   : ( a : A)
   → homotopy (fib A' A α a) (fib C' C γ (t (s a)))
-    ( comp ( fib A' A α a) (fib B' B β (s a)) (fib C' C γ (t (s a)))
-      ( map-of-fibers-map-of-maps B' B β C' C γ ((t',t),ηt) ( s a))
-      ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) ( a)))
+    ( comp (fib A' A α a) (fib B' B β (s a)) (fib C' C γ (t (s a)))
+      ( map-of-fibers-map-of-maps B' B β C' C γ ((t' , t) , ηt) (s a))
+      ( map-of-fibers-map-of-maps A' A α B' B β ((s' , s) , ηs) (a)))
     ( map-of-fibers-map-of-maps A' A α C' C γ
       ( comp-map-of-maps A' A α B' B β C' C γ
-        ((t',t),ηt) ((s',s),ηs))
-      (a))
+        ( ( t' , t) , ηt) ((s' , s) , ηs))
+      ( a))
   :=
     ind-fib A' A α
     ( \ a a'p →
-      ( ( map-of-fibers-map-of-maps B' B β C' C γ ((t',t),ηt) (s a))
-        ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) a
+      ( ( map-of-fibers-map-of-maps B' B β C' C γ ((t' , t) , ηt) (s a))
+        ( map-of-fibers-map-of-maps A' A α B' B β ((s' , s) , ηs) a
           ( a'p))
       =_{ fib C' C γ (t (s a))}
         ( map-of-fibers-map-of-maps A' A α C' C γ
           ( comp-map-of-maps A' A α B' B β C' C γ
-            ((t',t),ηt) ((s',s),ηs))
+            ( ( t' , t) , ηt) ((s' , s) , ηs))
           ( a) (a'p))))
     ( \ a' → refl)
 ```
@@ -1145,11 +1149,11 @@ Every retract of types induces a retract on fibers.
 
 ```rzk
 #def is-section-retraction-pair-Map
-  ( ((A',A),α) : Map)
-  ( ((B',B),β) : Map)
-  ( ((C',C),γ) : Map)
-  ( ((s',s),_) : map-Map ((A',A),α) ((B',B),β))
-  ( ((t',t),_) : map-Map ((B',B),β) ((C',C),γ))
+  ( ( ( A' , A) , α) : Map)
+  ( ( ( B' , B) , β) : Map)
+  ( ( ( C' , C) , γ) : Map)
+  ( ( ( s' , s) , _) : map-Map ((A' , A) , α) ((B' , B) , β))
+  ( ( ( t' , t) , _) : map-Map ((B' , B) , β) ((C' , C) , γ))
   : U
   :=
     product
@@ -1161,14 +1165,14 @@ Every retract of types induces a retract on fibers.
   ( S : map-Map α β)
   : U
   :=
-    Σ ((γ , T) : ( Σ (γ : Map) , (map-Map β γ)))
+    Σ ( ( γ , T) : (Σ (γ : Map) , (map-Map β γ)))
     , ( is-section-retraction-pair-Map α β γ S T)
 
 #def is-external-retract-of-Map
   ( α β : Map)
   : U
   :=
-    Σ (S : map-Map α β)
+    Σ ( S : map-Map α β)
     , has-external-retract-Map α β S
 
 #def is-retract-of-fibers-is-external-retract-of-Map
@@ -1176,30 +1180,30 @@ Every retract of types induces a retract on fibers.
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
-  ( ( ((s',s),ηs) , ( ( ((C',C),γ) , ((r',r),ηr)) , ( is-s-r' , is-s-r)))
-    : is-external-retract-of-Map ((A',A),α) ((B',B),β))
+  ( ( ( ( s' , s) , ηs) , ((((C' , C) , γ) , ((r' , r) , ηr)) , (is-s-r' , is-s-r)))
+ : is-external-retract-of-Map ((A' , A) , α) ((B' , B) , β))
   ( a : A)
   : is-retract-of (fib A' A α a) (fib B' B β (s a))
   :=
-    ( ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) a)
+    ( ( map-of-fibers-map-of-maps A' A α B' B β ((s' , s) , ηs) a)
     , ( has-retraction-internalize
         ( fib A' A α a) (fib B' B β (s a))
-        ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) a)
+        ( map-of-fibers-map-of-maps A' A α B' B β ((s' , s) , ηs) a)
         ( ( fib C' C γ (r (s a))
-          , map-of-fibers-map-of-maps B' B β C' C γ ((r',r),ηr) (s a))
+          , map-of-fibers-map-of-maps B' B β C' C γ ((r' , r) , ηr) (s a))
         , ( is-equiv-homotopy (fib A' A α a) (fib C' C γ (r (s a)))
-                ( comp ( fib A' A α a) (fib B' B β (s a)) (fib C' C γ (r (s a)))
-                  ( map-of-fibers-map-of-maps B' B β C' C γ ((r',r),ηr) ( s a))
-                  ( map-of-fibers-map-of-maps A' A α B' B β ((s',s),ηs) ( a)))
+                ( comp (fib A' A α a) (fib B' B β (s a)) (fib C' C γ (r (s a)))
+                  ( map-of-fibers-map-of-maps B' B β C' C γ ((r' , r) , ηr) (s a))
+                  ( map-of-fibers-map-of-maps A' A α B' B β ((s' , s) , ηs) (a)))
                 ( map-of-fibers-map-of-maps A' A α C' C γ
                   ( comp-map-of-maps A' A α B' B β C' C γ
-                    ( (r',r),ηr) ((s',s),ηs))
-                  (a))
+                    ( ( r' , r) , ηr) ((s' , s) , ηs))
+                  ( a))
             ( comp-map-of-fibers-comp-map-of-maps A' A α B' B β C' C γ
-              ( (r',r),ηr) ((s',s),ηs)
+              ( ( r' , r) , ηr) ((s' , s) , ηs)
               ( a))
             ( is-equiv-map-of-fibers-is-equiv-map-of-maps A' A α C' C γ
-              ( comp-map-of-maps A' A α B' B β C' C γ ((r',r),ηr) ((s',s),ηs))
+              ( comp-map-of-maps A' A α B' B β C' C γ ((r' , r) , ηr) ((s' , s) , ηs))
               ( is-s-r')
               ( is-s-r)
               ( a))))))
@@ -1215,8 +1219,8 @@ As an immediate corollary we obtain that equivalences are closed under retracts.
   ( α : A' → A)
   ( B' B : U)
   ( β : B' → B)
-  ( (((s',s),ηs) , has-ext-retr-S)
-    : is-external-retract-of-Map ((A',A),α) ((B',B),β))
+  ( ( ( ( s' , s) , ηs) , has-ext-retr-S)
+ : is-external-retract-of-Map ((A' , A) , α) ((B' , B) , β))
   ( is-equiv-β : is-equiv B' B β)
   : is-equiv A' A α
   :=
@@ -1225,7 +1229,7 @@ As an immediate corollary we obtain that equivalences are closed under retracts.
     is-contr-is-retract-of-is-contr
     ( fib A' A α a) (fib B' B β (s a))
     ( is-retract-of-fibers-is-external-retract-of-Map A' A α B' B β
-      ( ((s',s),ηs) , has-ext-retr-S)
+      ( ( ( s' , s) , ηs) , has-ext-retr-S)
       ( a))
     ( is-contr-map-is-equiv B' B β is-equiv-β (s a)))
 ```

--- a/src/simplicial-hott/02-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/02-simplicial-type-theory.rzk.md
@@ -13,29 +13,34 @@ This is a literate `rzk` file:
 ### Simplices
 
 ```rzk title="The 1-simplex"
-#def Δ¹ : 2 → TOPE
+#def Δ¹
+  : 2 → TOPE
   := \ t → TOP
 ```
 
 ```rzk title="The 2-simplex"
-#def Δ² : (2 × 2) → TOPE
+#def Δ²
+  : ( 2 × 2) → TOPE
   := \ (t , s) → s ≤ t
 ```
 
 ```rzk title="The 3-simplex"
-#def Δ³ : (2 × 2 × 2) → TOPE
+#def Δ³
+  : ( 2 × 2 × 2) → TOPE
   := \ ((t1 , t2) , t3) → t3 ≤ t2 ∧ t2 ≤ t1
 ```
 
 ### Boundaries of simplices
 
 ```rzk title="The boundary of a 1-simplex"
-#def ∂Δ¹ : Δ¹ → TOPE
+#def ∂Δ¹
+  : Δ¹ → TOPE
   := \ t → (t ≡ 0₂ ∨ t ≡ 1₂)
 ```
 
 ```rzk title="The boundary of a 2-simplex"
-#def ∂Δ² : Δ² → TOPE
+#def ∂Δ²
+  : Δ² → TOPE
   :=
     \ (t , s) → (s ≡ 0₂ ∨ t ≡ 1₂ ∨ s ≡ t)
 ```
@@ -43,21 +48,25 @@ This is a literate `rzk` file:
 ### The 2 dimensional inner horn
 
 ```rzk
-#def Λ : (2 × 2) → TOPE
+#def Λ
+  : ( 2 × 2) → TOPE
   := \ (t , s) → (s ≡ 0₂ ∨ t ≡ 1₂)
 
-#def Λ²₁ : Δ² → TOPE
-  := \ (s,t) → Λ (s,t)
+#def Λ²₁
+  : Δ² → TOPE
+  := \ (s , t) → Λ (s , t)
 ```
 
 ### The 3 dimensional inner horns
 
 ```rzk
-#def Λ³₁ : Δ³ → TOPE
-  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t2 ≡ t1 ∨ t1 ≡ 1₂
+#def Λ³₁
+  : Δ³ → TOPE
+  := \ ((t1 , t2) , t3) → t3 ≡ 0₂ ∨ t2 ≡ t1 ∨ t1 ≡ 1₂
 
-#def Λ³₂ : Δ³ → TOPE
-  := \ ((t1, t2), t3) → t3 ≡ 0₂ ∨ t3 ≡ t2 ∨ t1 ≡ 1₂
+#def Λ³₂
+  : Δ³ → TOPE
+  := \ ((t1 , t2) , t3) → t3 ≡ 0₂ ∨ t3 ≡ t2 ∨ t1 ≡ 1₂
 ```
 
 ### Products
@@ -69,37 +78,43 @@ The product of topes defines the product of shapes.
   ( I J : CUBE)
   ( ψ : I → TOPE)
   ( χ : J → TOPE)
-  : (I × J) → TOPE
+  : ( I × J) → TOPE
   := \ (t , s) → ψ t ∧ χ s
 ```
 
 ```rzk title="The square as a product"
-#def Δ¹×Δ¹ : (2 × 2) → TOPE
+#def Δ¹×Δ¹
+  : ( 2 × 2) → TOPE
   := shape-prod 2 2 Δ¹ Δ¹
 ```
 
 ```rzk title="The total boundary of the square"
-#def ∂□ : (2 × 2) → TOPE
-  := \ (t ,s) → ((∂Δ¹ t) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (∂Δ¹ s))
+#def ∂□
+  : ( 2 × 2) → TOPE
+  := \ (t , s) → ((∂Δ¹ t) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (∂Δ¹ s))
 ```
 
 ```rzk title="The vertical boundary of the square"
-#def ∂Δ¹×Δ¹ : (2 × 2) → TOPE
+#def ∂Δ¹×Δ¹
+  : ( 2 × 2) → TOPE
   := shape-prod 2 2 ∂Δ¹ Δ¹
 ```
 
 ```rzk title="The horizontal boundary of the square"
-#def Δ¹×∂Δ¹ : (2 × 2) → TOPE
+#def Δ¹×∂Δ¹
+  : ( 2 × 2) → TOPE
   := shape-prod 2 2 Δ¹ ∂Δ¹
 ```
 
 ```rzk title="The prism from a 2-simplex in an arrow type"
-#def Δ²×Δ¹ : (2 × 2 × 2) → TOPE
+#def Δ²×Δ¹
+  : ( 2 × 2 × 2) → TOPE
   := shape-prod (2 × 2) 2 Δ² Δ¹
 ```
 
 ```rzk
-#def Δ³×Δ² : ((2 × 2 × 2) × (2 × 2)) → TOPE
+#def Δ³×Δ²
+  : ( ( 2 × 2 × 2) × (2 × 2)) → TOPE
   := shape-prod (2 × 2 × 2) (2 × 2) Δ³ Δ²
 ```
 
@@ -107,14 +122,14 @@ Maps out of $Δ²$ are a retract of maps out of $Δ¹×Δ¹$.
 
 ```rzk title="RS17, Proposition 3.6"
 #def Δ²-is-retract-Δ¹×Δ¹
-  (A : U)
+  ( A : U)
   : is-retract-of (Δ² → A) (Δ¹×Δ¹ → A)
   :=
     ( ( \ f → \ (t , s) →
         recOR
-          ( t <= s |-> f (t , t) ,
-            s <= t |-> f (t , s))) ,
-      ( ( \ f → \ ts → f ts ) , \ _ → refl))
+          ( t ≤ s ↦ f (t , t)
+          , s ≤ t ↦ f (t , s)))
+    , ( ( \ f → \ ts → f ts) , \ _ → refl))
 ```
 
 Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
@@ -122,28 +137,28 @@ Maps out of $Δ³$ are a retract of maps out of $Δ²×Δ¹$.
 ```rzk title="RS17, Proposition 3.7"
 
 #def Δ³-is-retract-Δ²×Δ¹-retraction
-  (A : U)
-  : (Δ²×Δ¹ → A) → (Δ³ → A)
+  ( A : U)
+  : ( Δ²×Δ¹ → A) → (Δ³ → A)
   := \ f → \ ((t1 , t2) , t3) → f ((t1 , t3) , t2)
 
 #def Δ³-is-retract-Δ²×Δ¹-section
-  (A : U)
-  : (Δ³ → A) → (Δ²×Δ¹ → A)
+  ( A : U)
+  : ( Δ³ → A) → (Δ²×Δ¹ → A)
   :=
     \ f → \ ((t1 , t2) , t3) →
     recOR
-      ( t3 <= t2 |-> f ((t1 , t2) , t2) ,
-        t2 <= t3 |->
+      ( t3 ≤ t2 ↦ f ((t1 , t2) , t2)
+      , t2 ≤ t3 ↦
           recOR
-            ( t3 <= t1 |-> f ((t1 , t3) , t2) ,
-              t1 <= t3 |-> f ((t1 , t1) , t2)))
+            ( t3 ≤ t1 ↦ f ((t1 , t3) , t2)
+            , t1 ≤ t3 ↦ f ((t1 , t1) , t2)))
 
 #def Δ³-is-retract-Δ²×Δ¹
   ( A : U)
   : is-retract-of (Δ³ → A) (Δ²×Δ¹ → A)
   :=
-    ( Δ³-is-retract-Δ²×Δ¹-section A ,
-      ( Δ³-is-retract-Δ²×Δ¹-retraction A , \ _ → refl))
+    ( Δ³-is-retract-Δ²×Δ¹-section A
+    , ( Δ³-is-retract-Δ²×Δ¹-retraction A , \ _ → refl))
 ```
 
 ### Pushout product
@@ -157,8 +172,8 @@ Pushout product Φ×ζ ∪\_{Φ×χ} ψ×χ of Φ ↪ ψ and χ ↪ ζ, domain o
   ( Φ : ψ → TOPE)
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
-  : (shape-prod I J ψ ζ) → TOPE
-  := \ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s)
+  : ( shape-prod I J ψ ζ) → TOPE
+  := \ (t , s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s)
 ```
 
 ### Intersections
@@ -213,10 +228,10 @@ The union of shapes is defined by disjunction on topes.
 
 ```rzk title="RS17 Proposition 3.5(a)"
 #define join-square-arrow
-  (A : U)
-  (f : 2 → A)
-  : (2 × 2) → A
-  := \ (t, s) → recOR ( t ≤ s ↦ f s , s ≤ t ↦ f t )
+  ( A : U)
+  ( f : 2 → A)
+  : ( 2 × 2) → A
+  := \ (t , s) → recOR (t ≤ s ↦ f s , s ≤ t ↦ f t)
 ```
 
 <!-- This is manually adjusted diagram (hopefully fully supported in the future by rzk) -->
@@ -245,10 +260,10 @@ The union of shapes is defined by disjunction on topes.
 
 ```rzk title="RS17 Proposition 3.5(b)"
 #define meet-square-arrow
-  (A : U)
-  (f : 2 → A)
-  : (2 × 2) → A
-  := \ (t, s) → recOR ( t ≤ s ↦ f t , s ≤ t ↦ f s )
+  ( A : U)
+  ( f : 2 → A)
+  : ( 2 × 2) → A
+  := \ (t , s) → recOR (t ≤ s ↦ f t , s ≤ t ↦ f s)
 ```
 
 <!-- Definitions for the SVG images above -->
@@ -282,13 +297,13 @@ for a section of the family of extensions of a function `ϕ → A` to a function
 
 ```rzk
 #def is-functorial-shape-retract
-  ( I : CUBE )
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   : U
   :=
-    ( A' : U) → (A : U) → (α : A' → A) →
-    has-section-family-over-map
+    ( A' : U) → (A : U) → (α : A' → A)
+  → has-section-family-over-map
       ( ϕ → A') (\ f → (t : ψ) → A' [ϕ t ↦ f t])
       ( ϕ → A) (\ f → (t : ψ) → A [ϕ t ↦ f t])
       ( \ f t → α (f t))
@@ -302,8 +317,8 @@ For example, this applies to `Δ² ⊂ Δ¹×Δ¹`.
   : is-functorial-shape-retract (2 × 2) (Δ¹×Δ¹) (Δ²)
   :=
     \ A' A α →
-      ( ( first (Δ²-is-retract-Δ¹×Δ¹ A'), first (Δ²-is-retract-Δ¹×Δ¹ A) ) ,
-          \ a' → refl)
+      ( ( first (Δ²-is-retract-Δ¹×Δ¹ A') , first (Δ²-is-retract-Δ¹×Δ¹ A))
+        , \ a' → refl)
 ```
 
 Every functorial shape retract automatically induces a section when restricting
@@ -321,9 +336,9 @@ to diagrams extending a fixed diagram `σ': ϕ → A'` (or, respectively, its im
   ( α : A' → A)
   ( σ' : ϕ → A')
   : has-section-family-over-map
-      ( (t : χ) → A' [ϕ t ↦ σ' t])
+      ( ( t : χ) → A' [ϕ t ↦ σ' t])
       ( \ τ' → (t : ψ) → A' [χ t ↦ τ' t])
-      ( (t : χ) → A [ϕ t ↦ α (σ' t)])
+      ( ( t : χ) → A [ϕ t ↦ α (σ' t)])
       ( \ τ → (t : ψ) → A [χ t ↦ τ t])
       ( \ τ' t → α (τ' t))
       ( \ _ υ' t → α (υ' t))
@@ -356,8 +371,8 @@ describe this isomorphism on representables.
       , ( ( A : U)
         → ( σ : ζ → A)
         → ( Equiv
-            ( (t : χ) → A [ζ t ↦ σ t])
-            ( (t : ψ) → A [ϕ t ↦ first (f A) σ t]))))
+            ( ( t : χ) → A [ζ t ↦ σ t])
+            ( ( t : ψ) → A [ϕ t ↦ first (f A) σ t]))))
 
 #def functorial-isomorphism-shape-inclusions
   ( I : CUBE)
@@ -368,9 +383,9 @@ describe this isomorphism on representables.
   ( ζ : χ → TOPE)
   : U
   :=
-  Σ ( (f , F) : isomorphism-shape-inclusions I ψ ϕ J χ ζ)
+  Σ ( ( f , F) : isomorphism-shape-inclusions I ψ ϕ J χ ζ)
   , ( Σ ( e
-        : ( A' : U)
+ : ( A' : U)
         → ( A : U)
         → ( α : A' → A)
         → ( σ' : ζ → A')
@@ -385,7 +400,7 @@ describe this isomorphism on representables.
               ( \ (t : I | ϕ t) → α (first (f A') σ' t))
               ( first (f A) (\ t → α (σ' t)))
               ( e A' A α σ')
-              (\ (t : ψ) → α (first (F A' σ') τ' t)))
+              ( \ (t : ψ) → α (first (F A' σ') τ' t)))
             = ( first (F A (\ (t : ζ) → α (σ' t))) (\ (t : χ) → α (τ' t))))))
 ```
 
@@ -398,8 +413,9 @@ For example, consider the two shape inclusions `{0} ⊂ Δ¹` (subshapes of `2`)
 `{1} ⊂ right-leg-of-Λ` (subshapes of `2 × 2`), where
 
 ```rzk
-#def right-leg-of-Λ : Λ → TOPE
-  := \ (t, s) → t ≡ 1₂
+#def right-leg-of-Λ
+  : Λ → TOPE
+  := \ (t , s) → t ≡ 1₂
 ```
 
 These two shape inclusions are canonically isomorphic via the formulas
@@ -420,21 +436,21 @@ ugly boilerplate code.
 ```rzk
 #def isomorphism-0-Δ¹-1-right-leg-of-Λ
   : isomorphism-shape-inclusions
-    (2 × 2) (\ ts → right-leg-of-Λ ts) (\ (t , s) → t ≡ 1₂ ∧ s ≡ 0₂)
+    ( 2 × 2) (\ ts → right-leg-of-Λ ts) (\ (t , s) → t ≡ 1₂ ∧ s ≡ 0₂)
     2 Δ¹ (\ t → t ≡ 0₂)
   :=
     ( \ A →
-      ( \ τ (t,s) → τ s
-      , ( ( \ υ s → υ (1₂, s) , \ _ → refl)
-        , ( \ υ s → υ (1₂, s) , \ _ → refl)))
+      ( \ τ (t , s) → τ s
+      , ( ( \ υ s → υ (1₂ , s) , \ _ → refl)
+        , ( \ υ s → υ (1₂ , s) , \ _ → refl)))
     , \ A _ →
-      ( \ τ (t,s) → τ s
-      , ( ( \ υ s → υ (1₂, s) , \ _ → refl)
-        , ( \ υ s → υ (1₂, s) , \ _ → refl))))
+      ( \ τ (t , s) → τ s
+      , ( ( \ υ s → υ (1₂ , s) , \ _ → refl)
+        , ( \ υ s → υ (1₂ , s) , \ _ → refl))))
 
 #def functorial-isomorphism-0-Δ¹-1-right-leg-of-Λ
   : functorial-isomorphism-shape-inclusions
-    (2 × 2) (\ ts → right-leg-of-Λ ts) (\ (t , s) → t ≡ 1₂ ∧ s ≡ 0₂)
+    ( 2 × 2) (\ ts → right-leg-of-Λ ts) (\ (t , s) → t ≡ 1₂ ∧ s ≡ 0₂)
     2 Δ¹ (\ t → t ≡ 0₂)
   :=
     ( isomorphism-0-Δ¹-1-right-leg-of-Λ
@@ -476,7 +492,7 @@ We observe that we must have `ζ = χ ∧ ϕ`. Thus we have the following settin
   : U
   :=
   Σ ( s
-    : ( A : U)
+ : ( A : U)
     → ( σ : (t : I | χ t ∧ ϕ t) → A)
     → ( t : ϕ)
     → A [ χ t ∧ ϕ t ↦ σ t])
@@ -489,29 +505,29 @@ We observe that we must have `ζ = χ ∧ ϕ`. Thus we have the following settin
 #def functorial-retract-shape-inclusion
   : U
   :=
-  Σ ( (s, S) : retract-shape-inclusion)
+  Σ ( ( s , S) : retract-shape-inclusion)
   , Σ ( h
-      : ( A' : U)
+ : ( A' : U)
       → ( A : U)
       → ( α : A' → A)
       → ( σ' : (t : I | χ t ∧ ϕ t) → A')
       → ( ( \ (t : I | ϕ t) → α (s A' σ' t))
         =_{ ϕ → A}
-          ( s A ( \ t → α (σ' t)))))
+          ( s A (\ t → α (σ' t)))))
     , ( ( A' : U)
       → ( A : U)
       → ( α : A' → A)
       → ( σ' : (t : I | χ t ∧ ϕ t) → A')
       → ( τ' : (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
       → ( ( transport
-            ( (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
-            (\ σ → (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ σ t])
+            ( ( t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+            ( \ σ → (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ σ t])
             ( \ t → α (s A' σ' t))
-            ( \ t → s A ( \ t' → α (σ' t')) t)
+            ( \ t → s A (\ t' → α (σ' t')) t)
             ( h A' A α σ')
-            ( \ t → α ( S A' σ' τ' t)))
+            ( \ t → α (S A' σ' τ' t)))
         =_{ (t : ψ) → A [ϕ t ↦ s A (\ t' → α (τ' t')) t]}
-          ( S A (\ t → α (σ' t)) ( \ t → α (τ' t)))))
+          ( S A (\ t → α (σ' t)) (\ t → α (τ' t)))))
 
 #end retracts-shape-inclusions
 ```
@@ -521,11 +537,11 @@ For example the pair `{00} ⊂ Δ²` is a retract of `{0} × Δ¹ ⊂ Δ¹ × Δ
 ```rzk
 #def functorial-retract-00-Δ²-0Δ¹-Δ¹×Δ¹
   : functorial-retract-shape-inclusion (2 × 2)
-    ( Δ¹×Δ¹) ( \ (t , _) → t ≡ 0₂)
+    ( Δ¹×Δ¹) (\ (t , _) → t ≡ 0₂)
     ( \ ts → Δ² ts)
   :=
-  ( ( (\ _ f (t , s) → recOR ( t ≤ s ↦ f (t , t) , s ≤ t ↦ f (t , s)))
-    , (\ _ _ f (t , s) → recOR ( t ≤ s ↦ f (t , t) , s ≤ t ↦ f (t , s))))
+  ( ( ( \ _ f (t , s) → recOR (t ≤ s ↦ f (t , t) , s ≤ t ↦ f (t , s)))
+    , ( \ _ _ f (t , s) → recOR (t ≤ s ↦ f (t , t) , s ≤ t ↦ f (t , s))))
   , ( \ _ _ _ _ → refl , \ _ _ _ _ _ → refl))
 
 ```
@@ -536,6 +552,6 @@ For completeness we verify that the intesection `Δ² ∧ {0}×Δ¹` is indeed `
 #def verify-functorial-retract-0-Δ²-0Δ¹-Δ¹×Δ¹
   ( A : U)
   : ( ( shape-intersection (2 × 2) (\ ts → Δ² ts) (\ (t , _) → t ≡ 0₂) → A)
-    = ( ( (t, s) : 2 × 2 | t ≡ 0₂ ∧ s ≡ 0₂) → A))
+    = ( ( ( t , s) : 2 × 2 | t ≡ 0₂ ∧ s ≡ 0₂) → A))
   := refl
 ```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -32,7 +32,7 @@ restriction map `(ψ → A) → (ϕ → A)`, which we can view as the types of
 #def extension-type
   ( σ : (t : ϕ) → A t)
   : U
-  := ( t : ψ) → A t [ϕ t ↦ σ t]
+  := (t : ψ) → A t [ϕ t ↦ σ t]
 
 #def homotopy-extension-type
   ( σ : (t : ϕ) → A t)
@@ -42,46 +42,46 @@ restriction map `(ψ → A) → (ϕ → A)`, which we can view as the types of
 #def extension-type-weakening-map
   ( σ : (t : ϕ) → A t)
   : extension-type σ → homotopy-extension-type σ
-  := \ τ → ( τ, refl)
+  := \ τ → (τ , refl)
 
 #def section-extension-type-weakening'
   : ( σ : (t : ϕ) → A t)
   → ( th : homotopy-extension-type σ)
-  → Σ (τ : extension-type σ), (( τ, refl) =_{homotopy-extension-type σ} th)
+  → Σ ( τ : extension-type σ) , ((τ , refl) =_{homotopy-extension-type σ} th)
   :=
     ind-fib ((t : ψ) → A t) ((t : ϕ) → A t) (\ τ t → τ t)
       ( \ σ th →
-          Σ (τ : extension-type σ),
-            ( τ, refl) =_{homotopy-extension-type σ} th)
-      ( \ (τ : (t : ψ) → A t) → (τ, refl))
+          Σ ( τ : extension-type σ)
+          , ( τ , refl) =_{homotopy-extension-type σ} th)
+      ( \ (τ : (t : ψ) → A t) → (τ , refl))
 
 #def extension-strictification
   ( σ : (t : ϕ) → A t)
-  : (homotopy-extension-type σ) → (extension-type σ)
+  : ( homotopy-extension-type σ) → (extension-type σ)
   :=
     \ th → first (section-extension-type-weakening' σ th)
 
 #def has-section-extension-type-weakening
   ( σ : (t : ϕ) → A t)
   : has-section (extension-type σ) (homotopy-extension-type σ)
-      (extension-type-weakening-map σ)
+      ( extension-type-weakening-map σ)
   :=
     ( extension-strictification σ
-    , \ th → ( second (section-extension-type-weakening' σ th)))
+    , \ th → (second (section-extension-type-weakening' σ th)))
 
 
 #def is-equiv-extension-type-weakening
   ( σ : (t : ϕ) → A t)
   : is-equiv (extension-type σ) (homotopy-extension-type σ)
-      (extension-type-weakening-map σ)
+      ( extension-type-weakening-map σ)
   :=
-    ( ( extension-strictification σ, \ _ → refl)
+    ( ( extension-strictification σ , \ _ → refl)
     , has-section-extension-type-weakening σ)
 
 #def extension-type-weakening
   ( σ : (t : ϕ) → A t)
   : Equiv (extension-type σ) (homotopy-extension-type σ)
-  := ( extension-type-weakening-map σ , is-equiv-extension-type-weakening σ)
+  := (extension-type-weakening-map σ , is-equiv-extension-type-weakening σ)
 
 #end extensions-up-to-homotopy
 ```
@@ -102,11 +102,11 @@ This equivalence is functorial in the following sense:
     ( \ τ' t → α t (τ' t))
     ( homotopy-extension-type I ψ ϕ A' σ')
     ( homotopy-extension-type I ψ ϕ A (\ t → α t (σ' t)))
-    ( \ (τ', p) →
+    ( \ (τ' , p) →
       ( \ t → α t (τ' t)
       , ap
-        ( (t : ϕ) → A' t)
-        ( (t : ϕ) → A t)
+        ( ( t : ϕ) → A' t)
+        ( ( t : ϕ) → A t)
         ( \ (t : ϕ) → τ' t)
         ( \ (t : ϕ) → σ' t)
         ( \ σ'' t → α t (σ'' t))
@@ -130,8 +130,8 @@ This equivalence is functorial in the following sense:
   ( Y : ψ → X → U)
   ( f : (t : ϕ) → (x : X) → Y t x)
   : Equiv
-      ( (t : ψ) → ((x : X) → Y t x) [ϕ t ↦ f t])
-      ( (x : X) → (t : ψ) → Y t x [ϕ t ↦ f t x])
+      ( ( t : ψ) → ((x : X) → Y t x) [ϕ t ↦ f t])
+      ( ( x : X) → (t : ψ) → Y t x [ϕ t ↦ f t x])
   :=
     ( ( \ g x t → g t x)
     , ( ( \ h t x → (h x) t , \ g → refl)
@@ -145,8 +145,8 @@ This equivalence is functorial in the following sense:
   ( Y : ψ → X → U)
   ( f : (t : ϕ) → (x : X) → Y t x)
   : Equiv
-    ( (x : X) → (t : ψ) → Y t x [ϕ t ↦ f t x])
-    ( (t : ψ) → ((x : X) → Y t x) [ϕ t ↦ f t])
+    ( ( x : X) → (t : ψ) → Y t x [ϕ t ↦ f t x])
+    ( ( t : ψ) → ((x : X) → Y t x) [ϕ t ↦ f t])
   :=
     ( ( \ h t x → (h x) t)
     , ( ( \ g x t → g t x , \ h → refl)
@@ -164,9 +164,9 @@ This equivalence is functorial in the following sense:
   ( f : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → X t s)
   : Equiv
     ( ( t : ψ)
-    → ( (s : ζ) → X t s [χ s ↦ f (t , s)])
+    → ( ( s : ζ) → X t s [χ s ↦ f (t , s)])
       [ ϕ t ↦ \ s → f (t , s)])
-    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    ( ( ( t , s) : I × J | ψ t ∧ ζ s)
     → ( X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)]))
   :=
     ( ( \ g (t , s) → (g t) s)
@@ -182,10 +182,10 @@ This equivalence is functorial in the following sense:
   ( X : ψ → ζ → U)
   ( f : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → X t s)
   : Equiv
-    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    ( ( ( t , s) : I × J | ψ t ∧ ζ s)
     → ( X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)]))
     ( ( s : ζ)
-    → ( (t : ψ) → X t s [ϕ t ↦ f (t , s)])
+    → ( ( t : ψ) → X t s [ϕ t ↦ f (t , s)])
       [ χ s ↦ \ t → f (t , s)])
   :=
     ( ( \ h s t → h (t , s))
@@ -202,17 +202,17 @@ This equivalence is functorial in the following sense:
   ( f : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → X t s)
   : Equiv
     ( ( t : ψ)
-    → ( (s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
+    → ( ( s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
     ( ( s : ζ)
-    → ( (t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
+    → ( ( t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
   :=
     equiv-comp
       ( ( t : ψ)
-      → ( (s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
-      ( ( (t , s) : I × J | ψ t ∧ ζ s)
+      → ( ( s : ζ) → X t s [χ s ↦ f (t , s)]) [ϕ t ↦ \ s → f (t , s)])
+      ( ( ( t , s) : I × J | ψ t ∧ ζ s)
       → X t s [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
       ( ( s : ζ)
-      → ( (t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
+      → ( ( t : ψ) → X t s [ϕ t ↦ f (t , s)]) [χ s ↦ \ t → f (t , s)])
       ( curry-uncurry I J ψ ϕ ζ χ X f)
       ( uncurry-opcurry I J ψ ϕ ζ χ X f)
 ```
@@ -231,11 +231,11 @@ For each of these we provide a corresponding functorial instance
   ( α : (t : ψ) → (x : X) → A' t x → A t x)
   ( σ' : (t : ϕ) → (x : X) → A' t x)
   : Equiv-of-maps
-    ( (t : ψ) → ((x : X) → A' t x) [ϕ t ↦ σ' t])
-    ( (t : ψ) → ((x : X) → A t x) [ϕ t ↦ \ x → α t x (σ' t x)])
+    ( ( t : ψ) → ((x : X) → A' t x) [ϕ t ↦ σ' t])
+    ( ( t : ψ) → ((x : X) → A t x) [ϕ t ↦ \ x → α t x (σ' t x)])
     ( \ τ t x → α t x (τ t x))
-    ( (x : X) → (t : ψ) → A' t x [ϕ t ↦ σ' t x])
-    ( (x : X) → (t : ψ) → A t x [ϕ t ↦ α t x (σ' t x)])
+    ( ( x : X) → (t : ψ) → A' t x [ϕ t ↦ σ' t x])
+    ( ( x : X) → (t : ψ) → A t x [ϕ t ↦ α t x (σ' t x)])
     ( \ τ x t → α t x (τ x t))
   :=
     ( ( ( first (flip-ext-fun I ψ ϕ X A' σ')
@@ -256,23 +256,23 @@ For each of these we provide a corresponding functorial instance
   ( σ' : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → A' t s)
   : Equiv-of-maps
     ( ( t : ψ)
-    → ( (s : ζ) → A' t s [χ s ↦ σ' (t , s)])
+    → ( ( s : ζ) → A' t s [χ s ↦ σ' (t , s)])
       [ ϕ t ↦ \ s → σ' (t , s)])
     ( ( t : ψ)
-    → ( (s : ζ) → A t s [χ s ↦ α t s (σ' (t , s))])
+    → ( ( s : ζ) → A t s [χ s ↦ α t s (σ' (t , s))])
       [ ϕ t ↦ \ s → α t s (σ' (t , s))])
     ( \ τ' t s → α t s (τ' t s))
-    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    ( ( ( t , s) : I × J | ψ t ∧ ζ s)
     → ( A' t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ σ' (t , s)])
-    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    ( ( ( t , s) : I × J | ψ t ∧ ζ s)
     → ( A t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ α t s (σ' (t , s))])
     ( \ uτ' (t , s) → α t s (uτ' (t , s)))
   :=
   ( ( ( first (curry-uncurry I J ψ ϕ ζ χ A' σ')
-      , first (curry-uncurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s)))))
+      , first (curry-uncurry I J ψ ϕ ζ χ A (\ (t , s) → α t s (σ' (t , s)))))
     , ( \ _ → refl))
   , ( second (curry-uncurry I J ψ ϕ ζ χ A' σ')
-    , second (curry-uncurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s))))))
+    , second (curry-uncurry I J ψ ϕ ζ χ A (\ (t , s) → α t s (σ' (t , s))))))
 
 #def uncurry-opcurry-functorial
   ( I J : CUBE)
@@ -284,24 +284,24 @@ For each of these we provide a corresponding functorial instance
   ( α : (t : ψ) → (s : ζ) → A' t s → A t s)
   ( σ' : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → A' t s)
   : Equiv-of-maps
-    ( ( (t , s) : I × J | ψ t ∧ ζ s)
+    ( ( ( t , s) : I × J | ψ t ∧ ζ s)
     → ( A' t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ σ' (t , s)])
-    ( ( (t , s) : I × J | ψ t ∧ ζ s)
-    →  ( A t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ α t s (σ' (t , s))])
+    ( ( ( t , s) : I × J | ψ t ∧ ζ s)
+    → ( A t s) [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ α t s (σ' (t , s))])
     ( \ uτ' (t , s) → α t s (uτ' (t , s)))
     ( ( s : ζ)
-    → ( (t : ψ) → A' t s [ϕ t ↦ σ' (t , s)])
+    → ( ( t : ψ) → A' t s [ϕ t ↦ σ' (t , s)])
       [ χ s ↦ \ t → σ' (t , s)])
     ( ( s : ζ)
-    → ( (t : ψ) → A t s [ϕ t ↦ α t s ( σ' (t , s))])
+    → ( ( t : ψ) → A t s [ϕ t ↦ α t s (σ' (t , s))])
       [ χ s ↦ \ t → α t s (σ' (t , s))])
     ( \ τ' s t → α t s (τ' s t))
   :=
   ( ( ( first (uncurry-opcurry I J ψ ϕ ζ χ A' σ')
-      , first (uncurry-opcurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s)))))
+      , first (uncurry-opcurry I J ψ ϕ ζ χ A (\ (t , s) → α t s (σ' (t , s)))))
     , ( \ _ → refl))
   , ( second (uncurry-opcurry I J ψ ϕ ζ χ A' σ')
-    , second (uncurry-opcurry I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s))))))
+    , second (uncurry-opcurry I J ψ ϕ ζ χ A (\ (t , s) → α t s (σ' (t , s))))))
 
 #def fubini-functorial
   ( I J : CUBE)
@@ -314,25 +314,25 @@ For each of these we provide a corresponding functorial instance
   ( σ' : ((t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)) → A' t s)
   : Equiv-of-maps
     ( ( t : ψ)
-    → ( (s : ζ) → A' t s [χ s ↦ σ' (t , s)])
+    → ( ( s : ζ) → A' t s [χ s ↦ σ' (t , s)])
       [ ϕ t ↦ \ s → σ' (t , s)])
     ( ( t : ψ)
-    → ( (s : ζ) → A t s [χ s ↦ α t s (σ' (t , s))])
+    → ( ( s : ζ) → A t s [χ s ↦ α t s (σ' (t , s))])
       [ ϕ t ↦ \ s → α t s (σ' (t , s))])
     ( \ τ' t s → α t s (τ' t s))
     ( ( s : ζ)
-    → ( (t : ψ) → A' t s [ϕ t ↦ σ' (t , s)])
+    → ( ( t : ψ) → A' t s [ϕ t ↦ σ' (t , s)])
       [ χ s ↦ \ t → σ' (t , s)])
     ( ( s : ζ)
-    → ( (t : ψ) → A t s [ϕ t ↦ α t s( σ' (t , s))])
+    → ( ( t : ψ) → A t s [ϕ t ↦ α t s(σ' (t , s))])
       [ χ s ↦ \ t → α t s (σ' (t , s))])
     ( \ τ' s t → α t s (τ' s t))
   :=
   ( ( ( first (fubini I J ψ ϕ ζ χ A' σ')
-      , first (fubini I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s)))))
+      , first (fubini I J ψ ϕ ζ χ A (\ (t , s) → α t s (σ' (t , s)))))
     , ( \ _ → refl))
   , ( second (fubini I J ψ ϕ ζ χ A' σ')
-    , second (fubini I J ψ ϕ ζ χ A ( \ (t , s) → α t s (σ' (t , s))))))
+    , second (fubini I J ψ ϕ ζ χ A (\ (t , s) → α t s (σ' (t , s))))))
 ```
 
 ## Extending into Σ-types (the non-axiom of choice)
@@ -347,10 +347,10 @@ For each of these we provide a corresponding functorial instance
   ( a : (t : ϕ) → X t)
   ( b : (t : ϕ) → Y t (a t))
   : Equiv
-    ( (t : ψ) → (Σ (x : X t) , Y t x) [ϕ t ↦ (a t , b t)])
+    ( ( t : ψ) → (Σ (x : X t) , Y t x) [ϕ t ↦ (a t , b t)])
     ( Σ ( f : ((t : ψ) → X t [ϕ t ↦ a t]))
-      , ( (t : ψ) → Y t (f t) [ϕ t ↦ b t]))
-    :=
+      , ( ( t : ψ) → Y t (f t) [ϕ t ↦ b t]))
+  :=
       ( ( \ g → (\ t → (first (g t)) , \ t → second (g t)))
       , ( ( \ (f , h) t → (f t , h t) , \ _ → refl)
         , ( \ (f , h) t → (f t , h t) , \ _ → refl)))
@@ -365,13 +365,13 @@ For each of these we provide a corresponding functorial instance
   ( b : (t : ϕ) → Y t (a t))
   : Equiv
     ( Σ ( f : ((t : ψ) → X t [ϕ t ↦ a t]))
-      , ( (t : ψ) → Y t (f t) [ϕ t ↦ b t]))
-    ( (t : ψ) → (Σ (x : X t) , Y t x) [ϕ t ↦ (a t , b t)])
+      , ( ( t : ψ) → Y t (f t) [ϕ t ↦ b t]))
+    ( ( t : ψ) → (Σ (x : X t) , Y t x) [ϕ t ↦ (a t , b t)])
   :=
     inv-equiv
-    ( (t : ψ) → (Σ (x : X t) , Y t x) [ϕ t ↦ (a t , b t)])
+    ( ( t : ψ) → (Σ (x : X t) , Y t x) [ϕ t ↦ (a t , b t)])
     ( Σ ( f : ((t : ψ) → X t [ϕ t ↦ a t]))
-      , ( (t : ψ) → Y t (f t) [ϕ t ↦ b t]))
+      , ( ( t : ψ) → Y t (f t) [ϕ t ↦ b t]))
     ( axiom-choice I ψ ϕ X Y a b)
 ```
 
@@ -388,9 +388,9 @@ The original form.
   ( X : χ → U)
   ( a : (t : ϕ) → X t)
   : Equiv
-    ( (t : χ) → X t [ϕ t ↦ a t])
-    ( Σ ( f : (t : ψ) → X t [ϕ t ↦ a t]) ,
-        ( (t : χ) → X t [ψ t ↦ f t]))
+    ( ( t : χ) → X t [ϕ t ↦ a t])
+    ( Σ ( f : (t : ψ) → X t [ϕ t ↦ a t])
+      , ( ( t : χ) → X t [ψ t ↦ f t]))
   :=
     ( ( \ h → (\ t → h t , \ t → h t))
     , ( ( \ (_ , g) t → g t , \ _ → refl)
@@ -407,9 +407,9 @@ A reformulated version via tope disjunction instead of inclusion (see
   ( X : χ → U)
   ( a : (t : I | χ t ∧ ψ t ∧ ϕ t) → X t)
   : Equiv
-      ( (t : χ) → X t [χ t ∧ ψ t ∧ ϕ t ↦ a t])
+      ( ( t : χ) → X t [χ t ∧ ψ t ∧ ϕ t ↦ a t])
       ( Σ ( f : (t : I | χ t ∧ ψ t) → X t [χ t ∧ ψ t ∧ ϕ t ↦ a t])
-        , ( (t : χ) → X t [χ t ∧ ψ t ↦ f t]))
+        , ( ( t : χ) → X t [χ t ∧ ψ t ↦ f t]))
   :=
     ( ( \ h → (\ t → h t , \ t → h t))
     , ( ( \ (_ , g) t → g t , \ _ → refl)
@@ -426,9 +426,9 @@ Another variant is the following:
   ( A : ψ → U)
   ( a : (t : I | ϕ t) → A t)
   : Equiv
-    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
     ( Σ ( b : (t : I | χ t) → A t [χ t ∧ ϕ t ↦ a t])
-      , (t : ψ) → A t [χ t ↦ b t , ϕ t ↦ a t])
+      , ( t : ψ) → A t [χ t ↦ b t , ϕ t ↦ a t])
   :=
   ( \ c → (\ t → c t , \ t → c t)
   , ( ( \ (_ , c) t → c t
@@ -444,8 +444,8 @@ Another variant is the following:
   ( X : (t : I | ϕ t ∨ ψ t) → U)
   ( a : (t : ψ) → X t)
   : Equiv
-      ( (t : I | ϕ t ∨ ψ t) → X t [ψ t ↦ a t])
-      ( (t : ϕ) → X t [ϕ t ∧ ψ t ↦ a t])
+      ( ( t : I | ϕ t ∨ ψ t) → X t [ψ t ↦ a t])
+      ( ( t : ϕ) → X t [ϕ t ∧ ψ t ↦ a t])
   :=
     ( \ h t → h t
     , ( ( \ g t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ _ → refl)
@@ -464,14 +464,14 @@ Another variant is the following:
   ( α : (t : χ) → A' t → A t)
   ( σ' : (t : ϕ) → A' t)
   : Equiv-of-maps
-    ( (t : χ) → A' t [ϕ t ↦ σ' t])
-    ( (t : χ) → A t [ϕ t ↦ α t (σ' t)])
+    ( ( t : χ) → A' t [ϕ t ↦ σ' t])
+    ( ( t : χ) → A t [ϕ t ↦ α t (σ' t)])
     ( \ τ' t → α t (τ' t))
     ( Σ ( τ' : (t : ψ) → A' t [ϕ t ↦ σ' t])
-      , ( (t : χ) → A' t [ψ t ↦ τ' t]))
+      , ( ( t : χ) → A' t [ψ t ↦ τ' t]))
     ( Σ ( τ : (t : ψ) → A t [ϕ t ↦ α t (σ' t)])
-      , ( (t : χ) → A t [ψ t ↦ τ t]))
-    ( \ (τ', υ') → ( \ t → α t (τ' t), \t → α t (υ' t)))
+      , ( ( t : χ) → A t [ψ t ↦ τ t]))
+    ( \ (τ' , υ') → (\ t → α t (τ' t) , \ t → α t (υ' t)))
   :=
     ( ( ( \ h → (\ t → h t , \ t → h t) , \ h → (\ t → h t , \ t → h t))
       , ( \ _ → refl))
@@ -488,13 +488,13 @@ Another variant is the following:
   ( α : (t : I | ϕ t ∨ ψ t) → A' t → A t)
   ( a' : (t : I | ϕ t) → A' t)
   : Equiv-of-maps
-    ( (t : ψ) → A' t [ϕ t ↦ a' t])
-    ( (t : ψ) → A t [ϕ t ↦ α t (a' t)])
+    ( ( t : ψ) → A' t [ϕ t ↦ a' t])
+    ( ( t : ψ) → A t [ϕ t ↦ α t (a' t)])
     ( \ c t → α t (c t))
     ( Σ ( b' : (t : I | χ t) → A' t [χ t ∧ ϕ t ↦ a' t])
-      , (t : ψ) → A' t [χ t ↦ b' t , ϕ t ↦ a' t])
+      , ( t : ψ) → A' t [χ t ↦ b' t , ϕ t ↦ a' t])
     ( Σ ( b : (t : I | χ t) → A t [χ t ∧ ϕ t ↦ α t (a' t)])
-      , (t : ψ) → A t [χ t ↦ b t , ϕ t ↦ α t (a' t)])
+      , ( t : ψ) → A t [χ t ↦ b t , ϕ t ↦ α t (a' t)])
     ( \ (b , c) → (\ t → α t (b t) , \ t → α t (c t)))
   :=
   ( ( ( first (cofibration-composition'' I ψ ϕ χ A' a')
@@ -510,17 +510,17 @@ Another variant is the following:
   ( α : (t : I | ϕ t ∨ ψ t) → A' t → A t)
   ( τ' : (t : ψ) → A' t)
   : Equiv-of-maps
-      ( (t : I | ϕ t ∨ ψ t) → A' t [ψ t ↦ τ' t])
-      ( (t : I | ϕ t ∨ ψ t) → A t [ψ t ↦ α t (τ' t)])
+      ( ( t : I | ϕ t ∨ ψ t) → A' t [ψ t ↦ τ' t])
+      ( ( t : I | ϕ t ∨ ψ t) → A t [ψ t ↦ α t (τ' t)])
       ( \ υ' t → α t (υ' t))
-      ( (t : ϕ) → A' t [ϕ t ∧ ψ t ↦ τ' t])
-      ( (t : ϕ) → A t [ϕ t ∧ ψ t ↦ α t (τ' t)])
+      ( ( t : ϕ) → A' t [ϕ t ∧ ψ t ↦ τ' t])
+      ( ( t : ϕ) → A t [ϕ t ∧ ψ t ↦ α t (τ' t)])
       ( \ ν' t → α t (ν' t))
   :=
      ( ( ( \ υ' t → υ' t , \ υ t → υ t)
        , ( \ _ → refl))
      , ( ( second (cofibration-union I ϕ ψ A' τ'))
-       , ( second (cofibration-union I ϕ ψ A ( \ t → α t (τ' t))))))
+       , ( second (cofibration-union I ϕ ψ A (\ t → α t (τ' t))))))
 ```
 
 ## Extension extensionality
@@ -533,9 +533,9 @@ extension extensionality" axiom.
 ```rzk title="RS17, Axiom 4.6, Weak extension extensionality"
 #define WeakExtExt
   : U
-  := ( I : CUBE) → (ψ : I → TOPE) → (ϕ : ψ → TOPE) → (A : ψ → U) →
-     ( is-locally-contr-A : (t : ψ) → is-contr (A t)) →
-     ( a : (t : ϕ) → A t) → is-contr ((t : ψ) → A t [ϕ t ↦ a t])
+  := (I : CUBE) → (ψ : I → TOPE) → (ϕ : ψ → TOPE) → (A : ψ → U)
+   → ( is-locally-contr-A : (t : ψ) → is-contr (A t))
+   → ( a : (t : ϕ) → A t) → is-contr ((t : ψ) → A t [ϕ t ↦ a t])
 ```
 
 We refer to another form as an "extension extensionality" axiom.
@@ -549,10 +549,10 @@ We refer to another form as an "extension extensionality" axiom.
   ( a : (t : ϕ) → A t)
   ( f g : (t : ψ) → A t [ϕ t ↦ a t])
   ( p : f = g)
-  : (t : ψ) → (f t = g t) [ϕ t ↦ refl]
+  : ( t : ψ) → (f t = g t) [ϕ t ↦ refl]
   :=
     ind-path
-      ( (t : ψ) → A t [ϕ t ↦ a t])
+      ( ( t : ψ) → A t [ϕ t ↦ a t])
       ( f)
       ( \ g' p' → (t : ψ) → (f t = g' t) [ϕ t ↦ refl])
       ( \ _ → refl)
@@ -570,10 +570,10 @@ We refer to another form as an "extension extensionality" axiom.
     → ( A : ψ → U)
     → ( a : (t : ϕ) → A t)
     → ( f : (t : ψ) → A t [ϕ t ↦ a t])
-    → ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+    → ( g : (t : ψ) → A t [ϕ t ↦ a t])
     → is-equiv
       ( f = g)
-      ( (t : ψ) → (f t = g t) [ϕ t ↦ refl])
+      ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
       ( ext-htpy-eq I ψ ϕ A a f g))
 ```
 
@@ -607,13 +607,13 @@ fact, sometimes only this weaker form of the axiom is needed.
   → ( a : (t : ϕ) → A t)
   → ( f : (t : ψ) → A t [ϕ t ↦ a t])
   → ( g : (t : ψ) → A t [ϕ t ↦ a t])
-  → ( (t : ψ) → (f t = g t) [ϕ t ↦ refl])
+  → ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
   → ( f = g))
 
 #def naiveextext-extext
   ( extext : ExtExt)
   : NaiveExtExt
-  := \ I ψ ϕ A a f g → ( first (first (extext I ψ ϕ A a f g)))
+  := \ I ψ ϕ A a f g → (first (first (extext I ψ ϕ A a f g)))
 ```
 
 We show that naive extension extensionality implies weak extension
@@ -635,7 +635,7 @@ propositions.
     is-prop-all-elements-equal ((t : ϕ) → A t)
     ( \ a a' →
       naiveextext I (\ t → ϕ t) (\ _ → ⊥) (\ t → A t) (\ _ → recBOT) a a'
-      ( \ t → first ( is-locally-prop-A t (a t) (a' t))))
+      ( \ t → first (is-locally-prop-A t (a t) (a' t))))
 
 #def is-prop-extension-type-is-locally-prop uses (naiveextext)
   ( I : CUBE)
@@ -652,7 +652,7 @@ propositions.
     ( \ a → (t : ψ) → A t [ϕ t ↦ a t])
     ( is-prop-Equiv-is-prop'
       ( ( t : ψ) → A t)
-      ( Σ (a : (t : ϕ) → A t), (t : ψ) → A t [ϕ t ↦ a t])
+      ( Σ ( a : (t : ϕ) → A t) , (t : ψ) → A t [ϕ t ↦ a t])
       ( cofibration-composition I ψ ϕ (\ _ → BOT) (\ t → A t) (\ _ → recBOT))
       ( is-prop-shape-type-is-locally-prop I ψ A is-locally-prop-A))
 ```
@@ -668,14 +668,14 @@ type is always inhabited.
   ( A : ψ → U)
   ( is-locally-contr-A : (t : ψ) → is-contr (A t))
   ( a : (t : ϕ) → A t)
-  : (t : ψ) → A t [ϕ t ↦ a t]
+  : ( t : ψ) → A t [ϕ t ↦ a t]
   :=
     extension-strictification I ψ ϕ A a
     ( \ (t : ψ) → first (is-locally-contr-A t)
     , naiveextext I (\ t → ϕ t) (\ _ → BOT) (\ t → A t) (\ _ → recBOT)
-      ( \ ( t : ϕ) → first (is-locally-contr-A t) )
-      ( \ ( t : ϕ) → a t)
-      ( \ ( t : ϕ) → second (is-locally-contr-A t) (a t)))
+      ( \ (t : ϕ) → first (is-locally-contr-A t))
+      ( \ (t : ϕ) → a t)
+      ( \ (t : ϕ) → second (is-locally-contr-A t) (a t)))
 
 #end weakextext-naiveextext
 ```
@@ -689,13 +689,13 @@ extensionality.
   :=
     \ naiveextext I ψ ϕ A is-locally-contr-A a →
     ( is-contr-is-inhabited-is-prop
-      ( (t : ψ) → A t [ϕ t ↦ a t])
+      ( ( t : ψ) → A t [ϕ t ↦ a t])
       ( is-prop-extension-type-is-locally-prop naiveextext
-        ( I) ( ψ) ( ϕ) (A)
-        ( \ t → is-prop-is-contr (A t) ( is-locally-contr-A t))
+        ( I) (ψ) (ϕ) (A)
+        ( \ t → is-prop-is-contr (A t) (is-locally-contr-A t))
         ( a))
       ( is-inhabited-extension-type-is-locally-contr naiveextext I ψ ϕ A
-        ( is-locally-contr-A) ( a)))
+        ( is-locally-contr-A) (a)))
 ```
 
 For convenience we also provide the composite implication from extension
@@ -724,28 +724,28 @@ cases an extension type to a function type.
 #variable  ψ : I → TOPE
 #variable  ϕ : ψ → TOPE
 #variable  A : ψ → U
-#variable  a : (t : ϕ ) → A t
-#variable  f : (t : ψ ) → A t [ϕ t ↦ a t]
+#variable  a : (t : ϕ) → A t
+#variable  f : (t : ψ) → A t [ϕ t ↦ a t]
 
 #define ext-projection-temp uses (I ψ ϕ A a f)
-  : ((t : ψ ) → A t)
+  : ( ( t : ψ) → A t)
   := f
 
 #define is-contr-ext-based-paths uses (weakextext f)
   : is-contr
-    ( ( t : ψ )
-    → ( Σ (y : A t) , ((ext-projection-temp) t = y))
+    ( ( t : ψ)
+    → ( Σ ( y : A t) , ((ext-projection-temp) t = y))
       [ ϕ t ↦ (a t , refl)])
   :=
     weakextext I ψ ϕ
     ( \ t → (Σ (y : A t) , ((ext-projection-temp) t = y)))
-    ( \ t → is-contr-based-paths (A t ) ((ext-projection-temp) t))
-    ( \ t → (a t , refl) )
+    ( \ t → is-contr-based-paths (A t) ((ext-projection-temp) t))
+    ( \ t → (a t , refl))
 
 #define is-contr-ext-endpoint-based-paths uses (weakextext f)
   : is-contr
     ( ( t : ψ)
-    → ( Σ (y : A t) , (y = ext-projection-temp t))
+    → ( Σ ( y : A t) , (y = ext-projection-temp t))
       [ ϕ t ↦ (a t , refl)])
   :=
     weakextext I ψ ϕ
@@ -755,18 +755,18 @@ cases an extension type to a function type.
 
 #define is-contr-based-paths-ext uses (weakextext)
   : is-contr
-    ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t])
-      , ( (t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
+    ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
+      , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl]))
   :=
     is-contr-equiv-is-contr
-    ( (t : ψ ) → (Σ (y : A t),
-                     ((ext-projection-temp ) t = y)) [ϕ t ↦ (a t , refl)] )
-    ( Σ (g : (t : ψ ) → A t [ϕ t ↦ a t]) ,
-                (t : ψ ) → (f t = g t) [ϕ t ↦ refl] )
+    ( ( t : ψ) → (Σ (y : A t)
+                   , ( ( ext-projection-temp) t = y)) [ϕ t ↦ (a t , refl)])
+    ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
+              , ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
     ( axiom-choice I ψ ϕ A
       ( \ t y → (ext-projection-temp) t = y)
-      ( a )
-      ( \t → refl ))
+      ( a)
+      ( \ t → refl))
     ( is-contr-ext-based-paths)
 
 #end rs-4-8
@@ -780,16 +780,16 @@ The map that defines extension extensionality
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( a : (t : ϕ ) → A t)
-  ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  : ( ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t]), (f = g))
-    → ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+  ( a : (t : ϕ) → A t)
+  ( f : (t : ψ) → A t [ϕ t ↦ a t])
+  : ( ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]) , (f = g))
+    → ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
       , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])))
   :=
     total-map
-    ( (t : ψ ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
     ( \ g → (f = g))
-    ( \ g → (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
+    ( \ g → (t : ψ) → (f t = g t) [ϕ t ↦ refl])
     ( ext-htpy-eq I ψ ϕ A a f)
 ```
 
@@ -802,18 +802,18 @@ The total bundle version of extension extensionality
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( a : (t : ϕ ) → A t)
-  ( f : (t : ψ ) → A t [ϕ t ↦ a t])
+  ( a : (t : ϕ) → A t)
+  ( f : (t : ψ) → A t [ϕ t ↦ a t])
   : is-equiv
-    ( ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t]), (f = g)))
-    ( Σ ( g : (t : ψ ) → A t [ϕ t ↦ a t])
-      , ( ( t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
+    ( ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]) , (f = g)))
+    ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
+      , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl]))
     ( extext-weakextext-map I ψ ϕ A a f)
   :=
     is-equiv-are-contr
-    ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]), (f = g))
+    ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]) , (f = g))
     ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
-    , ( ( t : ψ ) → (f t = g t) [ϕ t ↦ refl]))
+    , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl]))
     ( is-contr-based-paths ((t : ψ) → A t [ϕ t ↦ a t]) (f))
     ( is-contr-based-paths-ext weakextext I ψ ϕ A a f)
     ( extext-weakextext-map I ψ ϕ A a f)
@@ -830,17 +830,17 @@ extensionality. The following is statement the as proved in RS17.
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( a : (t : ϕ ) → A t)
-  ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  : ( ( g : (t : ψ ) → A t [ϕ t ↦ a t])
+  ( a : (t : ϕ) → A t)
+  ( f : (t : ψ) → A t [ϕ t ↦ a t])
+  : ( ( g : (t : ψ) → A t [ϕ t ↦ a t])
     → is-equiv
         ( f = g)
-        ( (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
+        ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
         ( ext-htpy-eq I ψ ϕ A a f g))
   := is-equiv-fiberwise-is-equiv-total
-      ( (t : ψ ) → A t [ϕ t ↦ a t] )
-      ( \ g → (f = g) )
-      ( \ g → (t : ψ ) → (f t = g t) [ϕ t ↦ refl])
+      ( ( t : ψ) → A t [ϕ t ↦ a t])
+      ( \ g → (f = g))
+      ( \ g → (t : ψ) → (f t = g t) [ϕ t ↦ refl])
       ( ext-htpy-eq I ψ ϕ A a f)
       ( extext-weakextext-bundle-version weakextext I ψ ϕ A a f)
 ```
@@ -871,8 +871,8 @@ extensionality.
   ( e : (t : ϕ) → a t = b t)
   : U
   :=
-    Σ (a' : (t : ψ) → A t [ϕ t ↦ a t])
-    , ((t : ψ) → (a' t =_{ A t} b t) [ϕ t ↦ e t])
+    Σ ( a' : (t : ψ) → A t [ϕ t ↦ a t])
+    , ( ( t : ψ) → (a' t =_{ A t} b t) [ϕ t ↦ e t])
 
 #def HtpyExtProperty
   : U
@@ -905,8 +905,8 @@ the point of contraction for weak extension extensionality.
     ( first
       ( weakextext I ψ ϕ
         ( \ t → (Σ (y : A t) , y = b t))
-        ( \ t → is-contr-endpoint-based-paths ( A t) ( b t))
-        ( \ t → ( a t , e t) )))
+        ( \ t → is-contr-endpoint-based-paths (A t) (b t))
+        ( \ t → (a t , e t))))
 ```
 
 For completeness, we give a short direct proof that extension extensionality
@@ -925,12 +925,12 @@ extension extensionality.
   ( instance-HtpyExtProperty I ψ ϕ A b a)
   ( \ e' →
     ind-rev-fib
-    ( (t : ψ) → A t) ((t : ϕ) → A t) (\ b' t → b' t)
-    ( \ a' (b', p) →
+    ( ( t : ψ) → A t) ((t : ϕ) → A t) (\ b' t → b' t)
+    ( \ a' (b' , p) →
       instance-HtpyExtProperty I ψ ϕ A b' a'
       ( ext-htpy-eq I (\ t → ϕ t) (\ _ → BOT) (\ t → A t) (\ _ → recBOT)
-        ( a') (\ (t : ϕ) → b' t) ( p)))
-    ( \ b' → ( b' , \ _ → refl))
+        ( a') (\ (t : ϕ) → b' t) (p)))
+    ( \ b' → (b' , \ _ → refl))
     ( a) (b , e'))
 ```
 
@@ -952,24 +952,24 @@ Both directions of this statement will be needed.
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( a : (t : ϕ ) → A t)
-  ( is-contr-fiberwise-A : (t : ψ ) → is-contr ( A t))
-  : (t : ϕ ) → ((first (is-contr-fiberwise-A t)) = a t)
-  := \ t → ( second (is-contr-fiberwise-A t) (a t))
+  ( a : (t : ϕ) → A t)
+  ( is-contr-fiberwise-A : (t : ψ) → is-contr (A t))
+  : ( t : ϕ) → ((first (is-contr-fiberwise-A t)) = a t)
+  := \ t → (second (is-contr-fiberwise-A t) (a t))
 
 #def codomain-eq-ext-is-contr
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( a : (t : ϕ ) → A t)
-  ( is-contr-fiberwise-A : (t : ψ ) → is-contr ( A t))
-  : (t : ϕ ) → (a t = first (is-contr-fiberwise-A t))
+  ( a : (t : ϕ) → A t)
+  ( is-contr-fiberwise-A : (t : ψ) → is-contr (A t))
+  : ( t : ϕ) → (a t = first (is-contr-fiberwise-A t))
   :=
     \ t →
       rev
-      ( A t )
-      ( first (is-contr-fiberwise-A t) )
+      ( A t)
+      ( first (is-contr-fiberwise-A t))
       ( a t)
       ( second (is-contr-fiberwise-A t) (a t))
 ```
@@ -986,20 +986,20 @@ conclusion.
 
 ```rzk
 #define htpy-ext-prop-is-fiberwise-contr
-  (htpy-ext-property : HtpyExtProperty)
+  ( htpy-ext-property : HtpyExtProperty)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( a : (t : ϕ ) → A t)
-  (is-contr-fiberwise-A : (t : ψ ) → is-contr (A t))
-  : Σ ( a' : (t : ψ ) → A t [ϕ t ↦ a t])
-    , ( ( t : ψ )
+  ( a : (t : ϕ) → A t)
+  ( is-contr-fiberwise-A : (t : ψ) → is-contr (A t))
+  : Σ ( a' : (t : ψ) → A t [ϕ t ↦ a t])
+    , ( ( t : ψ)
       → ( ( a' t) =_{ A t} first (is-contr-fiberwise-A t))
-        [ ϕ t ↦ codomain-eq-ext-is-contr I ψ ϕ A a is-contr-fiberwise-A t] )
+        [ ϕ t ↦ codomain-eq-ext-is-contr I ψ ϕ A a is-contr-fiberwise-A t])
   :=
     htpy-ext-property I ψ ϕ A
-    (\ t →  first (is-contr-fiberwise-A t))
+    ( \ t → first (is-contr-fiberwise-A t))
     ( a)
     ( codomain-eq-ext-is-contr I ψ ϕ A a is-contr-fiberwise-A)
 ```
@@ -1011,15 +1011,15 @@ generality is needed.
 
 ```rzk
 #define RS-4-11-c
-  (htpy-ext-prop : HtpyExtProperty)
+  ( htpy-ext-prop : HtpyExtProperty)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( a : (t : ϕ ) → A t)
-  ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  (is-contr-fiberwise-A : (t : ψ ) → is-contr (A t))
-  : ( t : ψ )
+  ( a : (t : ϕ) → A t)
+  ( f : (t : ψ) → A t [ϕ t ↦ a t])
+  ( is-contr-fiberwise-A : (t : ψ) → is-contr (A t))
+  : ( t : ψ)
   → ( f t
     = first
       ( htpy-ext-prop-is-fiberwise-contr
@@ -1032,7 +1032,7 @@ generality is needed.
     all-elements-equal-is-contr
     ( A t)
     ( is-contr-fiberwise-A t)
-    ( f t )
+    ( f t)
     ( ( first
         ( htpy-ext-prop-is-fiberwise-contr
           htpy-ext-prop
@@ -1050,16 +1050,16 @@ slightly more general statement.
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( is-fiberwise-contr : (t : ψ ) → is-contr (A t))
-  ( a : (t : ϕ ) → A t)
-  ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  ( a' : (t : ψ ) → A t [ϕ t ↦ a t])
-  ( c : (t : ψ ) → (f t = a' t))
-  : (t : ϕ ) → (refl =_{f t = a' t} c t)
-  :=  \ t →
+  ( is-fiberwise-contr : (t : ψ) → is-contr (A t))
+  ( a : (t : ϕ) → A t)
+  ( f : (t : ψ) → A t [ϕ t ↦ a t])
+  ( a' : (t : ψ) → A t [ϕ t ↦ a t])
+  ( c : (t : ψ) → (f t = a' t))
+  : ( t : ϕ) → (refl =_{f t = a' t} c t)
+  := \ t →
     all-paths-equal-is-contr
-    (A t) ( is-fiberwise-contr t)
-    ( f t) ( a' t) ( refl ) ( c t )
+    ( A t) (is-fiberwise-contr t)
+    ( f t) (a' t) (refl) (c t)
 ```
 
 Given the `#!rzk a'` produced above, the following gives an inhabitant of
@@ -1068,17 +1068,17 @@ f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
 
 ```rzk
 #define is-fiberwise-contr-ext-is-fiberwise-contr
-  (htpy-ext-prop : HtpyExtProperty)
+  ( htpy-ext-prop : HtpyExtProperty)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   ( A : ψ → U)
-  ( is-contr-fiberwise-A : (t : ψ ) → is-contr (A t))
+  ( is-contr-fiberwise-A : (t : ψ) → is-contr (A t))
   ( a : (t : ϕ) → A t)
-  ( f : (t : ψ ) → A t [ϕ t ↦ a t])
-  : (t : ψ ) →
-      (f t = (first
-              (htpy-ext-prop-is-fiberwise-contr
+  ( f : (t : ψ) → A t [ϕ t ↦ a t])
+  : ( t : ψ)
+    → ( f t = (first
+              ( htpy-ext-prop-is-fiberwise-contr
                 htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A)) t)[ϕ t ↦ refl]
   :=
   first(
@@ -1093,11 +1093,11 @@ f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
         ( t)))
     ( RS-4-11-c
       htpy-ext-prop I ψ ϕ A a f is-contr-fiberwise-A)
-    ( \ t → refl )
+    ( \ t → refl)
     ( RS-4-11-c-is-refl I ψ ϕ A
       ( is-contr-fiberwise-A)
-      ( a )
-      ( f )
+      ( a)
+      ( f)
       ( first
         ( htpy-ext-prop-is-fiberwise-contr
           htpy-ext-prop
@@ -1105,21 +1105,21 @@ f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
           is-contr-fiberwise-A))
       ( RS-4-11-c
         ( htpy-ext-prop)
-        ( I) ( ψ) ( ϕ) ( A) ( a) ( f)
-        ( is-contr-fiberwise-A ))))
+        ( I) (ψ) (ϕ) (A) (a) (f)
+        ( is-contr-fiberwise-A))))
 ```
 
 ```rzk title="RS17, Proposition 4.11"
 #define weak-extext-naiveextext-htpy-ext-property
  ( naiveextext : NaiveExtExt)
  ( htpy-ext-prop : HtpyExtProperty)
- : WeakExtExt
+  : WeakExtExt
   := \ I ψ ϕ A is-contr-fiberwise-A a →
-    (first (htpy-ext-prop-is-fiberwise-contr htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A),
-     \ f →
+    ( first (htpy-ext-prop-is-fiberwise-contr htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A)
+   , \ f →
       rev
-      ( (t : ψ ) → A t [ϕ t ↦ a t])
-      ( f )
+      ( ( t : ψ) → A t [ϕ t ↦ a t])
+      ( f)
       ( first (htpy-ext-prop-is-fiberwise-contr
                 htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A))
       ( naiveextext I ψ ϕ A a f
@@ -1127,7 +1127,7 @@ f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
                 htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A))
       ( is-fiberwise-contr-ext-is-fiberwise-contr
         ( htpy-ext-prop)
-        ( I) ( ψ ) ( ϕ ) ( A)
+        ( I) (ψ) (ϕ) (A)
         ( is-contr-fiberwise-A)
         ( a)
         ( f))))
@@ -1159,7 +1159,7 @@ pointwise.
   : U
   :=
     Σ ( τ : (t : ψ) → A t)
-    , ( (t : ϕ) → (τ t =_{ A t} σ t))
+    , ( ( t : ϕ) → (τ t =_{ A t} σ t))
 
 #def equiv-pointwise-homotopy-extension-type uses (extext)
   ( σ : (t : ϕ) → A t)
@@ -1168,7 +1168,7 @@ pointwise.
     ( pointwise-homotopy-extension-type σ)
   :=
     total-equiv-family-of-equiv
-    ( (t : ψ) → A t)
+    ( ( t : ψ) → A t)
     ( \ τ → (\ t → τ t) =_{ (t : ϕ) → A t} σ)
     ( \ τ → (t : ϕ) → (τ t = σ t))
     ( \ τ →
@@ -1218,16 +1218,16 @@ This is equivalently expressed as the fibers of postcomposition by $f$.
 
 ```rzk
 #def postcomp-Π-ext
-  : ((t : ψ) → A t [ϕ t ↦ a t]) →
-    ((t : ψ) → B t [ϕ t ↦ f t (a t)])
-  := ( \ τ' t → f t (τ' t))
+  : ( ( t : ψ) → A t [ϕ t ↦ a t])
+  → ( ( t : ψ) → B t [ϕ t ↦ f t (a t)])
+  := (\ τ' t → f t (τ' t))
 
 #def fiber-postcomp-Π-ext
   : U
   :=
     fib
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ f t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ f t (a t)])
     ( postcomp-Π-ext)
     ( τ)
 
@@ -1237,13 +1237,13 @@ This is equivalently expressed as the fibers of postcomposition by $f$.
     ( relative-extension-type)
   :=
     total-equiv-family-of-equiv
-    ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
     ( \ τ' → (\ t → f t (τ' t)) =_{ (t : ψ) → B t [ϕ t ↦ f t (a t)]} τ)
     ( \ τ' → (t : ψ) → (f t (τ' t) = τ t) [ϕ t ↦ refl])
     ( \ τ' →
       equiv-ExtExt extext I ψ ϕ B
       ( \ t → f t (a t))
-      ( \ t → f t (τ' t)) ( τ))
+      ( \ t → f t (τ' t)) (τ))
 ```
 
 The fiber of postcomposition by a map $f: \prod_{t : I|\psi} A (t) \to B (t)$ is
@@ -1252,7 +1252,7 @@ equivalent to the family of fibers of $f\_t$.
 ```rzk
 #def fiber-family-ext
   : U
-  := (t : ψ) → fib (A t) (B t) (f t) (τ t) [ϕ t ↦ (a t, refl)]
+  := (t : ψ) → fib (A t) (B t) (f t) (τ t) [ϕ t ↦ (a t , refl)]
 
 #def equiv-fiber-postcomp-Π-ext-fiber-family-ext uses (extext)
   : Equiv
@@ -1310,7 +1310,7 @@ extension types are also contractible.
     ( ( σ' : (t : ϕ) → A' t)
     → ( τ : (t : ψ) → A t)
     → ( h : (t : ϕ) → α t (σ' t) = τ t)
-    → ( is-contr ( general-relative-extension-type σ' τ h)))
+    → ( is-contr (general-relative-extension-type σ' τ h)))
 
 #def has-contr-relative-extension-types-generalize' uses (extext)
   ( has-contr-relext-α : has-contr-relative-extension-types)
@@ -1339,12 +1339,12 @@ extension types are also contractible.
   :=
   \ σ' τ h →
     transport
-    ( (t : ϕ) → α t (σ' t) = τ t)
-    ( \ ĥ → is-contr ( general-relative-extension-type σ' τ ĥ))
+    ( ( t : ϕ) → α t (σ' t) = τ t)
+    ( \ ĥ → is-contr (general-relative-extension-type σ' τ ĥ))
     ( \ t → rev (A t) (τ t) (α t (σ' t)) (rev (A t) (α t (σ' t)) (τ t) (h t)))
     ( h)
     ( naiveextext-extext extext
-      ( I) (\ t → ϕ t) (\ _ → BOT) (\ t → α t (σ' t ) = τ t) (\ _ → recBOT)
+      ( I) (\ t → ϕ t) (\ _ → BOT) (\ t → α t (σ' t) = τ t) (\ _ → recBOT)
       ( \ t → rev (A t) (τ t) (α t (σ' t)) (rev (A t) (α t (σ' t)) (τ t) (h t)))
       ( h)
       ( \ t → rev-rev (A t) (α t (σ' t)) (τ t) (h t)))
@@ -1390,10 +1390,10 @@ We can view it as a map of maps either vertically or horizontally.
   ( A B : ψ → U)
   ( f : (t : ψ) → A t → B t)
   : map-of-maps
-    ( (t : ψ) → A t) ( (t : ϕ) → A t)  (\ a t → a t)
-    ( (t : ψ) → B t) ( (t : ϕ) → B t)  (\ b t → b t)
+    ( ( t : ψ) → A t) ((t : ϕ) → A t)  (\ a t → a t)
+    ( ( t : ψ) → B t) ((t : ϕ) → B t)  (\ b t → b t)
   :=
-    ( ( (\ a t → f t (a t)), (\ a t → f t (a t))), \ _ → refl)
+    ( ( ( \ a t → f t (a t)) , (\ a t → f t (a t))) , \ _ → refl)
 
 #def map-of-map-extension-type
   ( I : CUBE)
@@ -1402,10 +1402,10 @@ We can view it as a map of maps either vertically or horizontally.
   ( A B : ψ → U)
   ( f : (t : ψ) → A t → B t)
   : map-of-maps
-    ( (t : ψ) → A t) ( (t : ψ) → B t) (\ a t → f t (a t))
-    ( (t : ϕ) → A t) ( (t : ϕ) → B t) (\ a t → f t (a t))
+    ( ( t : ψ) → A t) ((t : ψ) → B t) (\ a t → f t (a t))
+    ( ( t : ϕ) → A t) ((t : ϕ) → B t) (\ a t → f t (a t))
   :=
-    ( ( (\ a t → a t), (\ b t → b t)), \ _ → refl)
+    ( ( ( \ a t → a t) , (\ b t → b t)) , \ _ → refl)
 ```
 
 ### Equivalences induce equivalences of extension types
@@ -1426,10 +1426,10 @@ fibers of postcomposition by $f$ are contractible.
   ( family-equiv-f : (t : ψ) → is-equiv (A t) (B t) (f t))
   : is-contr (fiber-family-ext I ψ ϕ A B f a τ)
   :=
-    (weakextext-extext extext) I ψ ϕ
+    ( weakextext-extext extext) I ψ ϕ
     ( \ t → fib (A t) (B t) (f t) (τ t))
     ( \ t → is-contr-map-is-equiv (A t) (B t) (f t) (family-equiv-f t) (τ t))
-    ( \ t → (a t, refl))
+    ( \ t → (a t , refl))
 
 #def is-contr-fiber-postcomp-Π-ext-is-equiv-fam uses (extext)
   ( I : CUBE)
@@ -1462,13 +1462,13 @@ types.
   ( a : (t : ϕ) → A t)
   ( family-equiv-f : (t : ψ) → is-equiv (A t) (B t) (f t))
   : is-equiv
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ f t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ f t (a t)])
     ( postcomp-Π-ext I ψ ϕ A B f a)
   :=
     is-equiv-is-contr-map
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ f t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ f t (a t)])
     ( postcomp-Π-ext I ψ ϕ A B f a)
     ( \ τ →
       is-contr-fiber-postcomp-Π-ext-is-equiv-fam I ψ ϕ A B f a τ family-equiv-f)
@@ -1481,8 +1481,8 @@ types.
   ( equivs-A-B : (t : ψ) → Equiv (A t) (B t))
   ( a : (t : ϕ) → A t)
   : Equiv
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ first (equivs-A-B t) (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ first (equivs-A-B t) (a t)])
   :=
     ( postcomp-Π-ext I ψ ϕ A B (\ t → (first (equivs-A-B t))) a
     , is-equiv-extensions-is-equiv I ψ ϕ A B
@@ -1497,16 +1497,16 @@ types.
   ( A B : ψ → U)
   ( famequiv : (t : ψ) → (Equiv (A t) (B t)))
   : Equiv-of-maps
-    ( (t : ψ) → A t) ( (t : ϕ) → A t)  (\ a t → a t)
-    ( (t : ψ) → B t) ( (t : ϕ) → B t)  (\ b t → b t)
+    ( ( t : ψ) → A t) ((t : ϕ) → A t)  (\ a t → a t)
+    ( ( t : ψ) → B t) ((t : ϕ) → B t)  (\ b t → b t)
   :=
     ( map-of-restriction-maps I ψ ϕ A B (\ t → first (famequiv t))
-    , ( second (equiv-extensions-equiv I ψ ( \ _ → BOT)
-      ( A) ( B)
+    , ( second (equiv-extensions-equiv I ψ (\ _ → BOT)
+      ( A) (B)
       ( famequiv)
       ( \ _ → recBOT))
-      , second ( equiv-extensions-equiv I ( \ t → ϕ t) ( \ _ → BOT)
-        ( \ t → A t) ( \ t → B t)
+      , second (equiv-extensions-equiv I (\ t → ϕ t) (\ _ → BOT)
+        ( \ t → A t) (\ t → B t)
         ( \ t → famequiv t)
         ( \ _ → recBOT))))
 ```
@@ -1532,9 +1532,9 @@ working with external retractions.
 #def is-sec-rec-extensions-sec-rec uses (extext)
   ( a : (t : ϕ) → A t)
   : is-section-retraction-pair
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
-    ( (t : ψ) → A t [ϕ t ↦ r t(s t(a t))])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ r t(s t(a t))])
     ( \ a' t → s t (a' t))
     ( \ b' t → r t (b' t))
   :=
@@ -1547,30 +1547,30 @@ working with external retractions.
 #def has-retraction-extensions-has-retraction' uses (extext η)
   ( a : (t : ϕ) → A t)
   : has-retraction
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ s t (a t)])
     ( \ a' t → s t (a' t))
   :=
     has-retraction-internalize
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ s t (a t)])
     ( \ a' t → s t (a' t))
-    ( ( (t : ψ) → A t [ϕ t ↦ r t (s t (a t))]
+    ( ( ( t : ψ) → A t [ϕ t ↦ r t (s t (a t))]
       , \ b' t → r t (b' t))
     , is-sec-rec-extensions-sec-rec a)
 
 #def has-section-extensions-has-section' uses (extext η)
   ( a : (t : ϕ) → A t)
   : has-section
-    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
-    ( (t : ψ) → A t [ϕ t ↦ r t (s t (a t))])
+    ( ( t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ r t (s t (a t))])
     ( \ b t → r t (b t))
   :=
     has-section-internalize
-    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
-    ( (t : ψ) → A t [ϕ t ↦ r t (s t (a t))])
+    ( ( t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ r t (s t (a t))])
     ( \ b' t → r t (b' t))
-    ( ( ( (t : ψ) → A t [ϕ t ↦ a t])
+    ( ( ( ( t : ψ) → A t [ϕ t ↦ a t])
       , ( \ a' t → s t (a' t)))
     , is-sec-rec-extensions-sec-rec a)
 
@@ -1589,8 +1589,8 @@ It is convenient to have uncurried versions.
   ( has-retraction-s : (t : ψ) → has-retraction (A t) (B t) (s t))
   ( a : (t : ϕ) → A t)
   : has-retraction
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ s t (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ s t (a t)])
     ( \ a' t → s t (a' t))
   :=
     has-retraction-extensions-has-retraction' I ψ ϕ A B s
@@ -1607,8 +1607,8 @@ It is convenient to have uncurried versions.
   ( has-section-r : (t : ψ) → has-section (B t) (A t) (r t))
   ( a : (t : ϕ) → A t)
   : has-section
-    ( (t : ψ) → B t [ϕ t ↦ (first (has-section-r t)) (a t)])
-    ( (t : ψ) → A t [ϕ t ↦ r t (first (has-section-r t) (a t))])
+    ( ( t : ψ) → B t [ϕ t ↦ (first (has-section-r t)) (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ r t (first (has-section-r t) (a t))])
     ( \ b t → r t (b t))
   :=
     has-section-extensions-has-section' I ψ ϕ A B
@@ -1630,8 +1630,8 @@ types.
   ( are-retract-A-of-B : (t : ψ) → is-retract-of (A t) (B t))
   ( a : (t : ϕ) → A t)
   : is-retract-of
-    ( (t : ψ) → A t [ϕ t ↦ a t])
-    ( (t : ψ) → B t [ϕ t ↦ first (are-retract-A-of-B t) (a t)])
+    ( ( t : ψ) → A t [ϕ t ↦ a t])
+    ( ( t : ψ) → B t [ϕ t ↦ first (are-retract-A-of-B t) (a t)])
   :=
   ( ( \ a' t → first (are-retract-A-of-B t) (a' t))
   , ( has-retraction-extensions-has-retraction I ψ ϕ A B
@@ -1647,9 +1647,9 @@ The following special case of extensions from `BOT` is also useful.
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A B : ψ → U)
-  ( f : ( t : ψ) → A t → B t)
+  ( f : (t : ψ) → A t → B t)
   ( has-section-f : (t : ψ) → has-section (A t) (B t) (f t))
-  : has-section ((t : ψ) → A t) ((t : ψ) → B t) ( \ a t → f t (a t))
+  : has-section ((t : ψ) → A t) ((t : ψ) → B t) (\ a t → f t (a t))
   :=
     ( ( \ b t → first (has-section-f t) (b t))
     , \ b →

--- a/src/simplicial-hott/04-right-orthogonal.rzk.md
+++ b/src/simplicial-hott/04-right-orthogonal.rzk.md
@@ -49,9 +49,9 @@ orthogonal** to the map `α`, if `α : A' → A` is right orthogonal to `ϕ ⊂ 
   : U
   :=
     is-homotopy-cartesian
-      ( ϕ → A' ) ( \ σ' → (t : ψ) → A' [ϕ t ↦ σ' t])
-      ( ϕ → A ) ( \ σ → (t : ψ) → A [ϕ t ↦ σ t])
-      ( \ σ' t → α (σ' t)) ( \ _ τ' x → α (τ' x) )
+      ( ϕ → A') (\ σ' → (t : ψ) → A' [ϕ t ↦ σ' t])
+      ( ϕ → A) (\ σ → (t : ψ) → A [ϕ t ↦ σ t])
+      ( \ σ' t → α (σ' t)) (\ _ τ' x → α (τ' x))
 ```
 
 ## Contractible relative extension types
@@ -71,20 +71,20 @@ extension types.
 
 #def is-right-orthogonal-to-shape-has-contr-relative-extension-types uses (extext)
   ( are-contr-relext-α
-    : has-contr-relative-extension-types I ψ ϕ
+ : has-contr-relative-extension-types I ψ ϕ
       ( \ _ → A') (\ _ → A) (\ _ → α))
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=
     \ σ' →
     is-equiv-is-contr-map
-    ( (t : ψ) → A' [ϕ t ↦ σ' t])
-    ( (t : ψ) → A [ϕ t ↦ α (σ' t)])
+    ( ( t : ψ) → A' [ϕ t ↦ σ' t])
+    ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
     ( \ τ' t → α (τ' t))
     ( \ τ →
       is-contr-equiv-is-contr'
       ( fib
-        ( (t : ψ) → A' [ϕ t ↦ σ' t])
-        ( (t : ψ) → A [ϕ t ↦ α (σ' t)])
+        ( ( t : ψ) → A' [ϕ t ↦ σ' t])
+        ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
         ( \ τ' t → α (τ' t))
         ( τ))
       ( relative-extension-type I ψ ϕ
@@ -100,8 +100,8 @@ extension types.
     \ σ' τ →
       is-contr-equiv-is-contr
       ( fib
-        ( (t : ψ) → A' [ϕ t ↦ σ' t])
-        ( (t : ψ) → A [ϕ t ↦ α (σ' t)])
+        ( ( t : ψ) → A' [ϕ t ↦ σ' t])
+        ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
         ( \ τ' t → α (τ' t))
         ( τ))
       ( relative-extension-type I ψ ϕ
@@ -109,8 +109,8 @@ extension types.
       ( equiv-relative-extension-type-fib extext I ψ ϕ
         ( \ _ → A') (\ _ → A) (\ _ → α) σ' τ)
       ( is-contr-map-is-equiv
-        ( (t : ψ) → A' [ϕ t ↦ σ' t])
-        ( (t : ψ) → A [ϕ t ↦ α (σ' t)])
+        ( ( t : ψ) → A' [ϕ t ↦ σ' t])
+        ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
         ( \ τ' t → α (τ' t))
         ( is-orth-α σ')
         ( τ))
@@ -149,8 +149,8 @@ conditions.
 #variable ϕ : χ → TOPE
 #variable is-orth-ψ-χ : is-right-orthogonal-to-shape I ψ χ A' A α
 #variable is-orth-χ-ϕ : is-right-orthogonal-to-shape
-                          I ( \ t → χ t) ( \ t → ϕ t) A' A α
-#variable is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ ( \ t → ϕ t) A' A α
+                          I (\ t → χ t) (\ t → ϕ t) A' A α
+#variable is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ (\ t → ϕ t) A' A α
 ```
 
 Using the vertical pasting calculus for homotopy cartesian squares, it is not
@@ -178,20 +178,20 @@ occasionally go back or forth along the functorial equivalence
       Σ ( τ : (t : χ) → A [ϕ t ↦ σ t])
       , ( t : ψ) → A [χ t ↦ τ t])
     ( \ σ' t → α (σ' t))
-    ( \ _ (τ', υ') → ( \ t → α (τ' t), \ t → α (υ' t) ))
+    ( \ _ (τ' , υ') → (\ t → α (τ' t) , \ t → α (υ' t)))
   :=
-    ( \ (σ' : ϕ → A') →
-    is-equiv-Equiv-is-equiv'
+    ( \ (σ' : ϕ → A')
+  → is-equiv-Equiv-is-equiv'
       ( ( t : ψ) → A' [ϕ t ↦ σ' t])
       ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
-      ( \ υ' t → α ( υ' t))
+      ( \ υ' t → α (υ' t))
       ( Σ ( τ' : (t : χ) → A' [ϕ t ↦ σ' t])
         , ( ( t : ψ) → A' [χ t ↦ τ' t]))
-      ( Σ ( τ : ( t : χ) → A [ϕ t ↦ α (σ' t)])
+      ( Σ ( τ : (t : χ) → A [ϕ t ↦ α (σ' t)])
         , ( ( t : ψ) → A [χ t ↦ τ t]))
-      ( \ (τ', υ') → ( \ t → α (τ' t), \t → α (υ' t)))
+      ( \ (τ' , υ') → (\ t → α (τ' t) , \ t → α (υ' t)))
       ( cofibration-composition-functorial I ψ χ ϕ
-        ( \ _ → A') ( \ _ → A) ( \ _ → α) σ')
+        ( \ _ → A') (\ _ → A) (\ _ → α) σ')
       ( is-orth-ψ-ϕ σ'))
 ```
 
@@ -202,30 +202,30 @@ Left orthogonal shape inclusions are preserved under composition.
 ```rzk title="right-orthogonality for composition of shape inclusions"
 
 #def is-right-orthogonal-to-shape-comp uses (is-orth-ψ-χ is-orth-χ-ϕ)
-  : is-right-orthogonal-to-shape I ψ ( \ t → ϕ t) A' A α
+  : is-right-orthogonal-to-shape I ψ (\ t → ϕ t) A' A α
   :=
     \ σ' →
       is-equiv-Equiv-is-equiv
         ( ( t : ψ) → A' [ϕ t ↦ σ' t])
         ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
-        ( \ υ' t → α ( υ' t))
+        ( \ υ' t → α (υ' t))
         ( Σ ( τ' : (t : χ) → A' [ϕ t ↦ σ' t])
           , ( ( t : ψ) → A' [χ t ↦ τ' t]))
-        ( Σ ( τ : ( t : χ) → A [ϕ t ↦ α (σ' t)])
+        ( Σ ( τ : (t : χ) → A [ϕ t ↦ α (σ' t)])
           , ( ( t : ψ) → A [χ t ↦ τ t]))
-        ( \ (τ', υ') → ( \ t → α (τ' t), \t → α (υ' t)))
+        ( \ (τ' , υ') → (\ t → α (τ' t) , \ t → α (υ' t)))
         ( cofibration-composition-functorial I ψ χ ϕ
-          ( \ _ → A') ( \ _ → A) ( \ _ → α) σ')
+          ( \ _ → A') (\ _ → A) (\ _ → α) σ')
         ( is-homotopy-cartesian-vertical-pasting-from-fibers
-          ( ϕ → A' )
+          ( ϕ → A')
           ( \ σ' → (t : χ) → A' [ϕ t ↦ σ' t])
           ( \ _ τ' → (t : ψ) → A' [χ t ↦ τ' t])
-          ( ϕ → A )
+          ( ϕ → A)
           ( \ σ → (t : χ) → A [ϕ t ↦ σ t])
           ( \ _ τ → (t : ψ) → A [χ t ↦ τ t])
           ( \ σ' t → α (σ' t))
-          ( \ _ τ' x → α (τ' x) )
-          ( \ _ _ υ' x → α (υ' x) )
+          ( \ _ τ' x → α (τ' x))
+          ( \ _ _ υ' x → α (υ' x))
           is-orth-χ-ϕ
           ( \ _ τ' → is-orth-ψ-χ τ')
           σ')
@@ -241,18 +241,18 @@ If `ϕ ⊂ χ` and `ϕ ⊂ ψ` are left orthogonal to `α : A' → A`, then so i
   :=
     \ τ' →
         is-homotopy-cartesian-lower-cancel-to-fibers
-          ( ϕ → A' )
+          ( ϕ → A')
           ( \ σ' → (t : χ) → A' [ϕ t ↦ σ' t])
           ( \ _ τ' → (t : ψ) → A' [χ t ↦ τ' t])
-          ( ϕ → A )
+          ( ϕ → A)
           ( \ σ → (t : χ) → A [ϕ t ↦ σ t])
           ( \ _ τ → (t : ψ) → A [χ t ↦ τ t])
           ( \ σ' t → α (σ' t))
-          ( \ _ τ' x → α (τ' x) )
-          ( \ _ _ υ' x → α (υ' x) )
-          ( is-orth-χ-ϕ )
-          (is-homotopy-cartesian-Σ-is-right-orthogonal-to-shape)
-          ( \ ( t : ϕ) → τ' t)
+          ( \ _ τ' x → α (τ' x))
+          ( \ _ _ υ' x → α (υ' x))
+          ( is-orth-χ-ϕ)
+          ( is-homotopy-cartesian-Σ-is-right-orthogonal-to-shape)
+          ( \ (t : ϕ) → τ' t)
           ( τ')
 ```
 
@@ -262,18 +262,18 @@ shape retract, then `ϕ ⊂ ψ` is left orthogonal to `α : A' → A`.
 ```rzk
 #def is-right-orthogonal-to-shape-right-cancel-retract uses (is-orth-ψ-ϕ)
   ( is-fretract-ψ-χ : is-functorial-shape-retract I ψ χ)
-  : is-right-orthogonal-to-shape I ( \ t → χ t) ( \ t → ϕ t) A' A α
+  : is-right-orthogonal-to-shape I (\ t → χ t) (\ t → ϕ t) A' A α
   :=
     is-homotopy-cartesian-upper-cancel-with-section
-      ( ϕ → A' )
+      ( ϕ → A')
       ( \ σ' → (t : χ) → A' [ϕ t ↦ σ' t])
       ( \ _ τ' → (t : ψ) → A' [χ t ↦ τ' t])
-      ( ϕ → A )
+      ( ϕ → A)
       ( \ σ → (t : χ) → A [ϕ t ↦ σ t])
       ( \ _ τ → (t : ψ) → A [χ t ↦ τ t])
       ( \ σ' t → α (σ' t))
-      ( \ _ τ' x → α (τ' x) )
-      ( \ _ _ υ' x → α (υ' x) )
+      ( \ _ τ' x → α (τ' x))
+      ( \ _ _ υ' x → α (υ' x))
       ( relativize-is-functorial-shape-retract I ψ χ is-fretract-ψ-χ ϕ A' A α)
       ( is-homotopy-cartesian-Σ-is-right-orthogonal-to-shape)
 
@@ -295,7 +295,7 @@ affecting left orthogonality.
   ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape (I × J)
     ( \ (s , t) → ψ (s , t))
     ( \ (s , t) → ϕ (s , t))
-    ( A') ( A) ( α))
+    ( A') (A) (α))
   : is-right-orthogonal-to-shape (J × I)
     ( \ (t , s) → ψ (s , t))
     ( \ (t , s) → ϕ (s , t))
@@ -303,21 +303,21 @@ affecting left orthogonality.
   :=
     \ σ' →
     is-equiv-Equiv-is-equiv
-    ( ( (t , s) : J × I | ψ (s , t)) → A' [ϕ (s , t) ↦ σ' (t , s)])
-    ( ( (t , s) : J × I | ψ (s , t)) → A [ϕ (s , t) ↦ α (σ' (t , s))])
+    ( ( ( t , s) : J × I | ψ (s , t)) → A' [ϕ (s , t) ↦ σ' (t , s)])
+    ( ( ( t , s) : J × I | ψ (s , t)) → A [ϕ (s , t) ↦ α (σ' (t , s))])
     ( \ τ' ts → α (τ' ts))
-    ( ((s , t) : I × J | ψ (s , t)) → A' [ϕ (s , t) ↦ σ' (t , s)])
-    ( ((s , t) : I × J | ψ (s , t)) → A [ϕ (s , t) ↦ α (σ' (t , s))])
+    ( ( ( s , t) : I × J | ψ (s , t)) → A' [ϕ (s , t) ↦ σ' (t , s)])
+    ( ( ( s , t) : I × J | ψ (s , t)) → A [ϕ (s , t) ↦ α (σ' (t , s))])
     ( \ τ' st → α (τ' st))
     ( ( ( ( \ v (x , y) → v (y , x))
         , ( \ v (x , y) → v (y , x))
         )
       , ( \ _ → refl)
       )
-    , ( ( ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl))
-        , ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl)))
-      , ( ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl))
-        , ( ( \ v (x , y) → v (y , x)) , ( \ _ → refl)))))
+    , ( ( ( ( \ v (x , y) → v (y , x)) , (\ _ → refl))
+        , ( ( \ v (x , y) → v (y , x)) , (\ _ → refl)))
+      , ( ( ( \ v (x , y) → v (y , x)) , (\ _ → refl))
+        , ( ( \ v (x , y) → v (y , x)) , (\ _ → refl)))))
     ( is-orth-ψ-ϕ (\ (s , t) → σ' (t , s)))
 ```
 
@@ -336,67 +336,67 @@ extensionality.
   ( J : CUBE)
   ( χ : J → TOPE)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ ϕ A' A α)
   : is-right-orthogonal-to-shape
-      ( J × I) ( \ (t , s) → χ t ∧ ψ s) ( \ (t , s) → χ t ∧ ϕ s) A' A α
+      ( J × I) (\ (t , s) → χ t ∧ ψ s) (\ (t , s) → χ t ∧ ϕ s) A' A α
   :=
-    \ ( σ' : ( (t , s) : J × I | χ t ∧ ϕ s) → A') →
-      ( ( \ ( τ : ( (t , s) : J × I | χ t ∧ ψ s) → A[ϕ s ↦ α (σ' (t , s))])
-            ( t, s) →
-          ( first (first (is-orth-ψ-ϕ (\ s' → σ' (t, s'))))) ( \ s' → τ (t, s')) s
-        , \ ( τ' : ( (t , s) : J × I | χ t ∧ ψ s) → A' [ϕ s ↦ σ' (t , s)]) →
-            naiveextext-extext extext
-              ( J × I) ( \ (t , s) → χ t ∧ ψ s) ( \ (t , s) → χ t ∧ ϕ s)
+    \ (σ' : ((t , s) : J × I | χ t ∧ ϕ s) → A')
+    → ( ( \ (τ : ((t , s) : J × I | χ t ∧ ψ s) → A[ϕ s ↦ α (σ' (t , s))])
+            ( t , s)
+        → ( first (first (is-orth-ψ-ϕ (\ s' → σ' (t , s'))))) (\ s' → τ (t , s')) s
+        , \ (τ' : ((t , s) : J × I | χ t ∧ ψ s) → A' [ϕ s ↦ σ' (t , s)])
+          → naiveextext-extext extext
+              ( J × I) (\ (t , s) → χ t ∧ ψ s) (\ (t , s) → χ t ∧ ϕ s)
               ( \ _ → A')
-              ( \ ( t,s) → σ' (t , s))
-              ( \ ( t,s) →
-                ( first (first (is-orth-ψ-ϕ (\ s' → σ' (t, s')))))
-                  ( \ s' → α (τ' (t, s'))) s)
+              ( \ (t , s) → σ' (t , s))
+              ( \ (t , s) →
+                ( first (first (is-orth-ψ-ϕ (\ s' → σ' (t , s')))))
+                  ( \ s' → α (τ' (t , s'))) s)
               ( τ')
-              ( \ ( t,s) →
-                ext-htpy-eq I ψ ϕ (\ _ → A') ( \ s' → σ' (t, s'))
-                  ( ( first (first (is-orth-ψ-ϕ (\ s' → σ' (t, s')))))
-                    ( \ s' → α (τ' (t, s'))))
-                  ( \ s' → τ' (t, s') )
-                  ( ( second (first (is-orth-ψ-ϕ (\ s' → σ' (t, s')))))
-                    ( \ s' → τ' (t, s')))
+              ( \ (t , s) →
+                ext-htpy-eq I ψ ϕ (\ _ → A') (\ s' → σ' (t , s'))
+                  ( ( first (first (is-orth-ψ-ϕ (\ s' → σ' (t , s')))))
+                    ( \ s' → α (τ' (t , s'))))
+                  ( \ s' → τ' (t , s'))
+                  ( ( second (first (is-orth-ψ-ϕ (\ s' → σ' (t , s')))))
+                    ( \ s' → τ' (t , s')))
                   ( s)))
-      , ( \ ( τ : ( (t , s) : J × I | χ t ∧ ψ s) → A [ϕ s ↦ α (σ' (t , s))])
-            ( t, s) →
-          ( first (second (is-orth-ψ-ϕ (\ s' → σ' (t, s'))))) ( \ s' → τ (t, s')) s
-        , \ ( τ : ( (t , s) : J × I | χ t ∧ ψ s) → A [ϕ s ↦ α (σ' (t , s))]) →
-            naiveextext-extext extext
-              ( J × I) ( \ (t , s) → χ t ∧ ψ s) ( \ (t , s) → χ t ∧ ϕ s)
+      , ( \ (τ : ((t , s) : J × I | χ t ∧ ψ s) → A [ϕ s ↦ α (σ' (t , s))])
+            ( t , s)
+        → ( first (second (is-orth-ψ-ϕ (\ s' → σ' (t , s'))))) (\ s' → τ (t , s')) s
+        , \ (τ : ((t , s) : J × I | χ t ∧ ψ s) → A [ϕ s ↦ α (σ' (t , s))])
+          → naiveextext-extext extext
+              ( J × I) (\ (t , s) → χ t ∧ ψ s) (\ (t , s) → χ t ∧ ϕ s)
               ( \ _ → A)
               ( \ (t , s) → α (σ' (t , s)))
               ( \ (t , s) →
-                α ( ( first ( second ( is-orth-ψ-ϕ (\ s' → σ' (t, s')))))
-                      ( \ s' → τ (t, s')) s))
+                α ((first (second (is-orth-ψ-ϕ (\ s' → σ' (t , s')))))
+                      ( \ s' → τ (t , s')) s))
               ( τ)
-              ( \ ( t,s) →
-                ext-htpy-eq I ψ ϕ (\ _ → A) ( \ s' → α (σ' (t, s')))
+              ( \ (t , s) →
+                ext-htpy-eq I ψ ϕ (\ _ → A) (\ s' → α (σ' (t , s')))
                   ( \ s'' →
-                      α ( ( first (second (is-orth-ψ-ϕ (\ s' → σ' (t, s')))))
-                          ( \ s' → τ (t, s'))
+                      α ((first (second (is-orth-ψ-ϕ (\ s' → σ' (t , s')))))
+                          ( \ s' → τ (t , s'))
                           ( s'')))
-                  ( \ s' → τ (t, s') )
-                  ( ( second ( second (is-orth-ψ-ϕ (\ s' → σ' (t, s')))))
-                    ( \ s' → τ (t, s')))
+                  ( \ s' → τ (t , s'))
+                  ( ( second (second (is-orth-ψ-ϕ (\ s' → σ' (t , s')))))
+                    ( \ s' → τ (t , s')))
                   ( s))))
 
 #def is-right-orthogonal-to-shape-product' uses (extext)
   ( A' A : U)
   ( α : A' → A)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ ϕ A' A α)
   : is-right-orthogonal-to-shape
-      ( I × J) ( \ (s , t) → ψ s ∧ χ t) ( \ (s , t) → ϕ s ∧ χ t) A' A α
+      ( I × J) (\ (s , t) → ψ s ∧ χ t) (\ (s , t) → ϕ s ∧ χ t) A' A α
   :=
     is-right-orthogonal-to-shape-transpose A' A α J I
     ( \ (t , s) → χ t ∧ ψ s)
@@ -415,18 +415,18 @@ For any two shapes `ϕ, ψ ⊂ I`, if `ϕ ∩ ψ ⊂ ϕ` is left orthogonal to
   ( α : A' → A)
   ( I : CUBE)
   ( ϕ ψ : I → TOPE)
-  ( is-orth-ϕ-ψ∧ϕ : is-right-orthogonal-to-shape I ϕ ( \ t → ϕ t ∧ ψ t) A' A α)
-  : is-right-orthogonal-to-shape I ( \ t → ϕ t ∨ ψ t) ( \ t → ψ t) A' A α
-  := \ ( τ' : ψ → A') →
-       is-equiv-Equiv-is-equiv
-         ( (t : I | ϕ t ∨ ψ t) → A' [ψ t ↦ τ' t])
-         ( (t : I | ϕ t ∨ ψ t) → A [ψ t ↦ α (τ' t)])
+  ( is-orth-ϕ-ψ∧ϕ : is-right-orthogonal-to-shape I ϕ (\ t → ϕ t ∧ ψ t) A' A α)
+  : is-right-orthogonal-to-shape I (\ t → ϕ t ∨ ψ t) (\ t → ψ t) A' A α
+  := \ (τ' : ψ → A')
+     → is-equiv-Equiv-is-equiv
+         ( ( t : I | ϕ t ∨ ψ t) → A' [ψ t ↦ τ' t])
+         ( ( t : I | ϕ t ∨ ψ t) → A [ψ t ↦ α (τ' t)])
          ( \ υ' t → α (υ' t))
-         ( (t : ϕ) → A' [ϕ t ∧ ψ t ↦ τ' t])
-         ( (t : ϕ) → A [ϕ t ∧ ψ t ↦ α (τ' t)])
+         ( ( t : ϕ) → A' [ϕ t ∧ ψ t ↦ τ' t])
+         ( ( t : ϕ) → A [ϕ t ∧ ψ t ↦ α (τ' t)])
          ( \ ν' t → α (ν' t))
          ( cofibration-union-functorial I ϕ ψ (\ _ → A') (\ _ → A) (\ _ → α) τ')
-         ( is-orth-ϕ-ψ∧ϕ ( \ t → τ' t))
+         ( is-orth-ϕ-ψ∧ϕ (\ t → τ' t))
 ```
 
 ### Pushout products
@@ -442,13 +442,13 @@ stability under pushout products.
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( is-orth-ψ-ϕ : is-right-orthogonal-to-shape I ψ ϕ A' A α)
   : is-right-orthogonal-to-shape (J × I)
     ( \ (t , s) → χ t ∧ ψ s)
     ( \ (t , s) → (ζ t ∧ ψ s) ∨ (χ t ∧ ϕ s))
-    ( A') ( A) ( α)
+    ( A') (A) (α)
   :=
     is-right-orthogonal-to-shape-left-cancel A' A α (J × I)
     ( \ (t , s) → χ t ∧ ψ s)
@@ -457,8 +457,8 @@ stability under pushout products.
     ( is-right-orthogonal-to-shape-pushout A' A α (J × I)
       ( \ (t , s) → ζ t ∧ ψ s)
       ( \ (t , s) → χ t ∧ ϕ s)
-      ( is-right-orthogonal-to-shape-product A' A α J ( \ t → ζ t) I ψ ϕ
-        (is-orth-ψ-ϕ)))
+      ( is-right-orthogonal-to-shape-product A' A α J (\ t → ζ t) I ψ ϕ
+        ( is-orth-ψ-ϕ)))
     ( is-right-orthogonal-to-shape-product A' A α J χ I ψ ϕ
       ( is-orth-ψ-ϕ))
 
@@ -466,8 +466,8 @@ stability under pushout products.
   ( A' A : U)
   ( α : A' → A)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
@@ -475,7 +475,7 @@ stability under pushout products.
   : is-right-orthogonal-to-shape (I × J)
     ( \ (s , t) → ψ s ∧ χ t)
     ( \ (s , t) → (ϕ s ∧ χ t) ∨ (ψ s ∧ ζ t))
-    ( A') ( A) ( α)
+    ( A') (A) (α)
   :=
     is-right-orthogonal-to-shape-transpose A' A α J I
     ( \ (t , s) → χ t ∧ ψ s)
@@ -495,14 +495,14 @@ orthogonal.
   ( A' A : U)
   ( α : A' → A)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
-  ( ((f , F) , (e , E)) : functorial-isomorphism-shape-inclusions I ψ ϕ J χ ζ)
+  ( ( ( f , F) , (e , E)) : functorial-isomorphism-shape-inclusions I ψ ϕ J χ ζ)
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
-  →  is-right-orthogonal-to-shape J χ ζ A' A α
+  → is-right-orthogonal-to-shape J χ ζ A' A α
   :=
   is-homotopy-cartesian-in-cube
   ( ζ → A') (\ σ' → (t : χ) → A' [ζ t ↦ σ' t])
@@ -513,7 +513,7 @@ orthogonal.
   ( ϕ → A) (\ σ' → (t : ψ) → A [ϕ t ↦ σ' t])
   ( \ σ' t → α (σ' t))
   ( \ _ τ' t → α (τ' t))
-  ( first (f A')) ( first (f A))
+  ( first (f A')) (first (f A))
   ( e A' A α)
   ( \ σ' → first (F A' σ')) (\ σ → first (F A σ))
   ( E A' A α)
@@ -523,12 +523,12 @@ orthogonal.
   ( A' A : U)
   ( α : A' → A)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
-  ( ((f , F) , (e , E)) : functorial-isomorphism-shape-inclusions I ψ ϕ J χ ζ)
+  ( ( ( f , F) , (e , E)) : functorial-isomorphism-shape-inclusions I ψ ϕ J χ ζ)
   : is-right-orthogonal-to-shape J χ ζ A' A α
   → is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=
@@ -541,7 +541,7 @@ orthogonal.
   ( ϕ → A) (\ σ' → (t : ψ) → A [ϕ t ↦ σ' t])
   ( \ σ' t → α (σ' t))
   ( \ _ τ' t → α (τ' t))
-  ( first (f A')) ( first (f A))
+  ( first (f A')) (first (f A))
   ( e A' A α)
   ( \ σ' → first (F A' σ')) (\ σ → first (F A σ))
   ( E A' A α)
@@ -559,60 +559,60 @@ retract of it, then `ζ ⊂ χ` is also left orthogonal.
   ( A' A : U)
   ( α : A' → A)
   ( I : CUBE)
-  ( ψ : I → TOPE )
+  ( ψ : I → TOPE)
   ( ϕ χ : ψ → TOPE)
   -- ζ := χ ∧ ϕ
-  ( ((s , S) , (h , H)) : functorial-retract-shape-inclusion I ψ ϕ χ)
+  ( ( ( s , S) , (h , H)) : functorial-retract-shape-inclusion I ψ ϕ χ)
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   → is-right-orthogonal-to-shape I (\ t → χ t) (\ t → χ t ∧ ϕ t) A' A α
   :=
-  \ is-orth-ψ-ϕ (σ' : (t : I | χ t ∧ ϕ t) → A') →
-    push-down-equiv-with-section
-    ( (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
+  \ is-orth-ψ-ϕ (σ' : (t : I | χ t ∧ ϕ t) → A')
+  → push-down-equiv-with-section
+    ( ( t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
     ( \ τ' → (t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
-    ( (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+    ( ( t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
     ( \ τ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ s A (\ t' → α (σ' t')) t])
     ( \ τ' t → α (τ' t))
     ( \ τ' υ →
       ( transport
-        ( (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+        ( ( t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
         ( \ σ → (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ σ t])
         ( \ t → α (s A' σ' t))
-        ( s A ( \ t → α (σ' t)))
+        ( s A (\ t → α (σ' t)))
         ( h A' A α σ')
-        ( \ t → α ( υ t))))
+        ( \ t → α (υ t))))
     ( ( S A' σ' , S A (\ t → α (σ' t)))
     , H A' A α σ')
     ( second
       ( equiv-comp
       ( Σ ( τ' : (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
-      , (t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
+      , ( t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
       ( Σ ( τ : (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
-          , (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
+          , ( t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
         ( Σ ( τ : (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
-          , (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ s A (\ t' → α (σ' t')) t])
+          , ( t : ψ) → A [χ t ↦ τ t , ϕ t ↦ s A (\ t' → α (σ' t')) t])
         ( ( \ (τ' , υ') →
-            ( (\ t → α (τ' t))
-            , (\ t → α (υ' t))))
+            ( ( \ t → α (τ' t))
+            , ( \ t → α (υ' t))))
         , ( is-equiv-Equiv-is-equiv'
-            ( (t : ψ) → A' [ϕ t ↦ s A' σ' t])
-            ( (t : ψ) → A [ϕ t ↦ α (s A' σ' t)])
+            ( ( t : ψ) → A' [ϕ t ↦ s A' σ' t])
+            ( ( t : ψ) → A [ϕ t ↦ α (s A' σ' t)])
             ( \ υ' t → α (υ' t))
             ( Σ ( τ' : (t : χ) → A' [χ t ∧ ϕ t ↦ σ' t])
-              , (t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
+              , ( t : ψ) → A' [χ t ↦ τ' t , ϕ t ↦ s A' σ' t])
             ( Σ ( τ : (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
-              , (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
-              ( \ (τ' , υ') → ( (\ t → α (τ' t)) , (\ t → α (υ' t))))
+              , ( t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
+              ( \ (τ' , υ') → ((\ t → α (τ' t)) , (\ t → α (υ' t))))
               ( cofibration-composition-functorial'' I ψ ϕ χ
-                (\ _ → A') (\ _ → A) (\ _ → α) (s A' σ'))
+                ( \ _ → A') (\ _ → A) (\ _ → α) (s A' σ'))
             ( is-orth-ψ-ϕ (s A' σ'))))
         ( total-equiv-family-of-equiv
-          ( (t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+          ( ( t : χ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
           ( \ τ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ α (s A' σ' t)])
           ( \ τ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ s A (\ t' → α (σ' t')) t])
           ( \ τ →
             equiv-transport
-            ( (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
+            ( ( t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)])
             ( \ σ → (t : ψ) → A [χ t ↦ τ t , ϕ t ↦ σ t])
             ( \ t → α (s A' σ' t))
             ( s A (\ t → α (σ' t)))
@@ -643,7 +643,7 @@ Every equivalence `α : A' → A` is right orthogonal to `ϕ ⊂ ψ`.
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=
     ( \ a → is-equiv-extensions-is-equiv extext I ψ ϕ
-      ( \ _ → A') ( \  _ → A) ( \ _ → α) ( a) ( \ _ → is-equiv-α))
+      ( \ _ → A') (\ _ → A) (\ _ → α) (a) (\ _ → is-equiv-α))
 ```
 
 Right orthogonality is closed under homotopy.
@@ -656,7 +656,7 @@ Right orthogonality is closed under homotopy.
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   → is-right-orthogonal-to-shape I ψ ϕ A' A β
   :=
-    transport (A' → A) ( is-right-orthogonal-to-shape I ψ ϕ A' A) α β
+    transport (A' → A) (is-right-orthogonal-to-shape I ψ ϕ A' A) α β
     ( first (first (funext A' (\ _ → A) α β)) h)
 ```
 
@@ -719,11 +719,11 @@ right (whether it is right orthogonal or not.)
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=
     is-homotopy-cartesian-left-cancel-with-section'
-        ( ϕ → A'' ) ( \ σ'' → (t : ψ) → A'' [ϕ t ↦ σ'' t])
-        ( ϕ → A' ) ( \ σ' → (t : ψ) → A' [ϕ t ↦ σ' t])
-        ( ϕ → A ) ( \ σ → (t : ψ) → A [ϕ t ↦ σ t])
-        ( \ σ'' t → α' (σ'' t)) ( \ _ τ'' x → α' (τ'' x) )
-        ( \ σ' t → α (σ' t)) ( \ _ τ' x → α (τ' x) )
+        ( ϕ → A'') (\ σ'' → (t : ψ) → A'' [ϕ t ↦ σ'' t])
+        ( ϕ → A') (\ σ' → (t : ψ) → A' [ϕ t ↦ σ' t])
+        ( ϕ → A) (\ σ → (t : ψ) → A [ϕ t ↦ σ t])
+        ( \ σ'' t → α' (σ'' t)) (\ _ τ'' x → α' (τ'' x))
+        ( \ σ' t → α (σ' t)) (\ _ τ' x → α (τ' x))
     ( has-section-extensions-BOT-has-section extext I (\ t → ϕ t)
           ( \ _ → A'') (\ _ → A') (\ _ → α')
       ( \ _ → has-section-α'))
@@ -751,27 +751,27 @@ follows for the former.
 #def relative-extension-type-pullback-general-relative-extension-type
   ( σB' : ϕ → relative-product A A' α B f)
   ( τB : (t : ψ) → B [ϕ t ↦ second-relative-product A A' α B f (σB' t)])
-  ( (τA', hA)
-    : general-relative-extension-type I ψ ϕ (\ _ → A') (\ _ → A) (\ _ → α)
+  ( ( τA' , hA)
+ : general-relative-extension-type I ψ ϕ (\ _ → A') (\ _ → A) (\ _ → α)
       ( \ t → first-relative-product A A' α B f (σB' t))
       ( \ t → f (τB t))
       ( \ t → homotopy-relative-product A A' α B f (σB' t)))
   : relative-extension-type I ψ ϕ
-    ( \ _ → relative-product A A' α B f) ( \ _ → B)
+    ( \ _ → relative-product A A' α B f) (\ _ → B)
     ( \ _ → second-relative-product A A' α B f)
-    ( σB') ( τB)
+    ( σB') (τB)
   :=
-    ( \ t → ( (τA' t, τB t) , hA t)
+    ( \ t → ((τA' t , τB t) , hA t)
     , \ t → refl)
 
 #def general-relative-extension-type-relative-extension-type-pullback
   ( σB' : ϕ → relative-product A A' α B f)
   ( τB : (t : ψ) → B [ϕ t ↦ second-relative-product A A' α B f (σB' t)])
-  ( (τB', hB)
-    : relative-extension-type I ψ ϕ
-      ( \ _ → relative-product A A' α B f) ( \ _ → B)
+  ( ( τB' , hB)
+ : relative-extension-type I ψ ϕ
+      ( \ _ → relative-product A A' α B f) (\ _ → B)
       ( \ _ → second-relative-product A A' α B f)
-      ( σB') ( τB))
+      ( σB') (τB))
   : general-relative-extension-type I ψ ϕ (\ _ → A') (\ _ → A) (\ _ → α)
     ( \ t → first-relative-product A A' α B f (σB' t))
     ( \ t → f (τB t))
@@ -787,54 +787,54 @@ follows for the former.
       ( ap B A
         ( second-relative-product A A' α B f (τB' t))
         ( τB t)
-        ( f) ( hB t)))
+        ( f) (hB t)))
 
 #def is-id-rel-ext-type-pb-gen-rel-ext-type-rel-ext-type-pb uses (extext)
   ( σB' : ϕ → relative-product A A' α B f)
   ( τB : (t : ψ) → B [ϕ t ↦ second-relative-product A A' α B f (σB' t)])
   : ( τhB
-      : relative-extension-type I ψ ϕ
-        ( \ _ → relative-product A A' α B f) ( \ _ → B)
+ : relative-extension-type I ψ ϕ
+        ( \ _ → relative-product A A' α B f) (\ _ → B)
         ( \ _ → second-relative-product A A' α B f)
-        ( σB') ( τB))
+        ( σB') (τB))
   → ( relative-extension-type-pullback-general-relative-extension-type σB' τB
       ( general-relative-extension-type-relative-extension-type-pullback σB' τB τhB)
     = τhB)
   :=
     ind-has-section-equiv
     ( fiber-postcomp-Π-ext I ψ ϕ
-      ( \ _ → relative-product A A' α B f) ( \ _ → B)
+      ( \ _ → relative-product A A' α B f) (\ _ → B)
       ( \ _ → second-relative-product A A' α B f)
-      ( σB') ( τB))
+      ( σB') (τB))
     ( relative-extension-type I ψ ϕ
-      ( \ _ → relative-product A A' α B f) ( \ _ → B)
+      ( \ _ → relative-product A A' α B f) (\ _ → B)
       ( \ _ → second-relative-product A A' α B f)
-      ( σB') ( τB))
+      ( σB') (τB))
     ( equiv-relative-extension-type-fib extext I ψ ϕ
-      ( \ _ → relative-product A A' α B f) ( \ _ → B)
+      ( \ _ → relative-product A A' α B f) (\ _ → B)
       ( \ _ → second-relative-product A A' α B f)
-      ( σB') ( τB))
+      ( σB') (τB))
     ( \ τhB →
       ( relative-extension-type-pullback-general-relative-extension-type σB' τB
         ( general-relative-extension-type-relative-extension-type-pullback σB' τB τhB)
       = τhB))
     ( ind-fib
-      ( (t : ψ) → relative-product A A' α B f [ϕ t ↦ σB' t])
-      ( (t : ψ) → B [ϕ t ↦ second-relative-product A A' α B f (σB' t)])
+      ( ( t : ψ) → relative-product A A' α B f [ϕ t ↦ σB' t])
+      ( ( t : ψ) → B [ϕ t ↦ second-relative-product A A' α B f (σB' t)])
       ( \ τB' t → second-relative-product A A' α B f (τB' t))
-      ( \ τB₁ (τB'₁, h₁) →
+      ( \ τB₁ (τB'₁ , h₁) →
         ( relative-extension-type-pullback-general-relative-extension-type σB' τB₁
           ( general-relative-extension-type-relative-extension-type-pullback σB' τB₁
             ( τB'₁
             , ext-htpy-eq I ψ ϕ (\ _ → B)
               ( \ t → second-relative-product A A' α B f (σB' t))
               ( \ t → second-relative-product A A' α B f (τB'₁ t))
-              ( τB₁) ( h₁)))
+              ( τB₁) (h₁)))
         = ( τB'₁
           , ext-htpy-eq I ψ ϕ (\ _ → B)
             ( \ t → second-relative-product A A' α B f (σB' t))
             ( \ t → second-relative-product A A' α B f (τB'₁ t))
-            ( τB₁) ( h₁))))
+            ( τB₁) (h₁))))
       ( \ τB' → refl)
       ( τB))
 
@@ -843,9 +843,9 @@ follows for the former.
   ( τB : (t : ψ) → B [ϕ t ↦ second-relative-product A A' α B f (σB' t)])
   : is-retract-of
     ( relative-extension-type I ψ ϕ
-      ( \ _ → relative-product A A' α B f) ( \ _ → B)
+      ( \ _ → relative-product A A' α B f) (\ _ → B)
       ( \ _ → second-relative-product A A' α B f)
-      ( σB') ( τB))
+      ( σB') (τB))
     ( general-relative-extension-type I ψ ϕ (\ _ → A') (\ _ → A) (\ _ → α)
       ( \ t → first-relative-product A A' α B f (σB' t))
       ( \ t → f (τB t))
@@ -861,18 +861,18 @@ Then we can deduce that right orthogonal maps are preserved under pullback:
 ```rzk
 #def is-right-orthogonal-pullback-to-shape uses (extext is-orth-ψ-ϕ-α B f)
   : is-right-orthogonal-to-shape I ψ ϕ
-    ( relative-product A A' α B f) ( B)
+    ( relative-product A A' α B f) (B)
     ( second-relative-product A A' α B f)
   :=
     is-right-orthogonal-to-shape-has-contr-relative-extension-types I ψ ϕ
-    ( relative-product A A' α B f) ( B)
+    ( relative-product A A' α B f) (B)
     ( second-relative-product A A' α B f)
     ( \ σB' τB →
       is-contr-is-retract-of-is-contr
       ( relative-extension-type I ψ ϕ
-        ( \ _ → relative-product A A' α B f) ( \ _ → B)
+        ( \ _ → relative-product A A' α B f) (\ _ → B)
         ( \ _ → second-relative-product A A' α B f)
-        ( σB') ( τB))
+        ( σB') (τB))
       ( general-relative-extension-type I ψ ϕ (\ _ → A') (\ _ → A) (\ _ → α)
         ( \ t → first-relative-product A A' α B f (σB' t))
         ( \ t → f (τB t))
@@ -905,29 +905,29 @@ orthogonal to `ϕ ⊂ ψ`, then so is the other.
 #variable β : B' → B
 
 #def is-right-orthogonal-equiv-to-shape uses (funext extext)
-  ( (((s', s), η), (is-equiv-s', is-equiv-s)) : Equiv-of-maps A' A α B' B β)
+  ( ( ( ( s' , s) , η) , (is-equiv-s' , is-equiv-s)) : Equiv-of-maps A' A α B' B β)
   ( is-orth-ψ-ϕ-β : is-right-orthogonal-to-shape I ψ ϕ B' B β)
   : is-right-orthogonal-to-shape I ψ ϕ A' A α
   :=
     is-right-orthogonal-right-cancel-to-shape I ψ ϕ A' A B α s
     ( is-right-orthogonal-is-equiv-to-shape I ψ ϕ A B s is-equiv-s)
     ( is-right-orthogonal-homotopy-to-shape I ψ ϕ A' B
-      ( \ a' → β (s' a')) ( \ a' → s (α a')) ( η)
+      ( \ a' → β (s' a')) (\ a' → s (α a')) (η)
       ( is-right-orthogonal-comp-to-shape I ψ ϕ A' B' B s' β
         ( is-right-orthogonal-is-equiv-to-shape I ψ ϕ A' B' s' is-equiv-s')
         ( is-orth-ψ-ϕ-β)))
 
 #def is-right-orthogonal-equiv-to-shape'
   uses (funext extext)
-  ( (((s', s), η), (is-equiv-s', is-equiv-s)) : Equiv-of-maps A' A α B' B β)
+  ( ( ( ( s' , s) , η) , (is-equiv-s' , is-equiv-s)) : Equiv-of-maps A' A α B' B β)
   ( is-orth-ψ-ϕ-α : is-right-orthogonal-to-shape I ψ ϕ A' A α)
   : is-right-orthogonal-to-shape I ψ ϕ B' B β
   :=
     is-right-orthogonal-left-cancel-with-section-to-shape
           I ψ ϕ A' B' B s' β
     ( is-right-orthogonal-homotopy-to-shape I ψ ϕ A' B
-      ( \ a' → s (α a')) ( \ a' → β (s' a'))
-      ( rev-homotopy A' B ( \ a' → β (s' a')) ( \ a' → s (α a')) ( η))
+      ( \ a' → s (α a')) (\ a' → β (s' a'))
+      ( rev-homotopy A' B (\ a' → β (s' a')) (\ a' → s (α a')) (η))
       ( is-right-orthogonal-comp-to-shape I ψ ϕ A' A B α s
         ( is-orth-ψ-ϕ-α)
         ( is-right-orthogonal-is-equiv-to-shape I ψ ϕ A B s is-equiv-s)))
@@ -952,28 +952,28 @@ map on dependent products `Π α : Π A' → Π A`.
   ( A' A : X → U)
   ( α : (x : X) → (A' x) → (A x))
   ( are-right-orth-ψ-ϕ-α
-    : (x : X) → is-right-orthogonal-to-shape I ψ ϕ (A' x) (A x) (α x))
+ : ( x : X) → is-right-orthogonal-to-shape I ψ ϕ (A' x) (A x) (α x))
   : is-right-orthogonal-to-shape I ψ ϕ
-    ( (x : X) → A' x)
-    ( (x : X) → A x)
+    ( ( x : X) → A' x)
+    ( ( x : X) → A x)
     ( \ a' x → α x (a' x))
   :=
   \ σ' →
     is-equiv-Equiv-is-equiv
-    ( (t : ψ) → ((x : X) → A' x) [ϕ t ↦ σ' t])
-    ( (t : ψ) → ((x : X) → A x) [ϕ t ↦ \ x → α x (σ' t x)])
+    ( ( t : ψ) → ((x : X) → A' x) [ϕ t ↦ σ' t])
+    ( ( t : ψ) → ((x : X) → A x) [ϕ t ↦ \ x → α x (σ' t x)])
     ( \ τ' t x → α x (τ' t x))
-    ( (x : X) → (t : ψ) → A' x [ϕ t ↦ σ' t x])
-    ( (x : X) → (t : ψ) → A x [ϕ t ↦ α x (σ' t x)])
+    ( ( x : X) → (t : ψ) → A' x [ϕ t ↦ σ' t x])
+    ( ( x : X) → (t : ψ) → A x [ϕ t ↦ α x (σ' t x)])
     ( \ τ' x t → α x (τ' x t))
     ( flip-ext-fun-functorial I ψ ϕ X
-      (\ _ → A') (\ _ → A) (\ _ → α)
+      ( \ _ → A') (\ _ → A) (\ _ → α)
       ( σ'))
     ( is-equiv-function-is-equiv-family funext X
       ( \ x → (t : ψ) → A' x [ϕ t ↦ σ' t x])
       ( \ x → (t : ψ) → A x [ϕ t ↦ α x (σ' t x)])
       ( \ x τ' t → α x (τ' t))
-      ( \ x → are-right-orth-ψ-ϕ-α x ( \ t → σ' t x)))
+      ( \ x → are-right-orth-ψ-ϕ-α x (\ t → σ' t x)))
 ```
 
 ### Sigma types
@@ -1001,7 +1001,7 @@ for each `σ : ϕ → A` the type of `ψ`-extensions is contractible.
 
 #def has-unique-extensions
   : U
-  := ( σ : ϕ → A) → is-contr ( (t : ψ) → A [ϕ t ↦ σ t])
+  := (σ : ϕ → A) → is-contr ((t : ψ) → A [ϕ t ↦ σ t])
 ```
 
 There are other equivalent characterizations which we shall prove below:
@@ -1012,7 +1012,7 @@ equivalence.
 ```rzk
 #def is-local-type
   : U
-  := is-equiv (ψ → A) (ϕ → A) ( \ τ t → τ t)
+  := is-equiv (ψ → A) (ϕ → A) (\ τ t → τ t)
 ```
 
 We can ask that the terminal map `A → Unit` is right orthogonal to `ϕ ⊂ ψ`.
@@ -1035,12 +1035,12 @@ of the restriction map `(ψ → A) → (ϕ → A)`.
   ( has-ue-ψ-ϕ-A : has-unique-extensions)
   : is-local-type
   :=
-    is-equiv-is-contr-map (ψ → A) (ϕ → A) ( \ τ t → τ t)
-      ( \ ( σ : ϕ → A) →
-        is-contr-equiv-is-contr
-          ( extension-type I ψ ϕ ( \ t → A) σ)
-          ( homotopy-extension-type I ψ ϕ ( \ t → A) σ)
-          ( extension-type-weakening I ψ ϕ ( \ t → A) σ)
+    is-equiv-is-contr-map (ψ → A) (ϕ → A) (\ τ t → τ t)
+      ( \ (σ : ϕ → A)
+      → is-contr-equiv-is-contr
+          ( extension-type I ψ ϕ (\ t → A) σ)
+          ( homotopy-extension-type I ψ ϕ (\ t → A) σ)
+          ( extension-type-weakening I ψ ϕ (\ t → A) σ)
           ( has-ue-ψ-ϕ-A σ))
 
 #def has-unique-extensions-is-local-type
@@ -1049,11 +1049,11 @@ of the restriction map `(ψ → A) → (ϕ → A)`.
   :=
     \ σ →
       is-contr-equiv-is-contr'
-        ( extension-type I ψ ϕ ( \ t → A) σ)
-        ( homotopy-extension-type I ψ ϕ ( \ t → A) σ)
-        ( extension-type-weakening I ψ ϕ ( \ t → A) σ)
+        ( extension-type I ψ ϕ (\ t → A) σ)
+        ( homotopy-extension-type I ψ ϕ (\ t → A) σ)
+        ( extension-type-weakening I ψ ϕ (\ t → A) σ)
         ( is-contr-map-is-equiv
-            ( ψ → A) (ϕ → A) ( \ τ t → τ t)
+            ( ψ → A) (ϕ → A) (\ τ t → τ t)
             ( is-lt-ψ-ϕ-A)
             ( σ))
 
@@ -1112,8 +1112,8 @@ right orthogonal map.
   ( is-orth-ψ-ϕ-α : is-right-orthogonal-to-shape I ψ ϕ A' A α)
   : has-unique-extensions I ψ ϕ A → has-unique-extensions I ψ ϕ A'
   :=
-    \ has-ue-A ( σ' : ϕ → A') →
-      is-contr-equiv-is-contr'
+    \ has-ue-A (σ' : ϕ → A')
+    → is-contr-equiv-is-contr'
         ( ( t : ψ) → A' [ϕ t ↦ σ' t])
         ( ( t : ψ) → A [ϕ t ↦ α (σ' t)])
         ( \ τ' t → α (τ' t) , is-orth-ψ-ϕ-α σ')
@@ -1128,7 +1128,7 @@ right orthogonal map.
   :=
     is-local-type-has-unique-extensions I ψ ϕ A'
       ( has-unique-extensions-right-orthogonal-has-unique-extensions
-          ( A') ( A) ( α) ( is-orth-α)
+          ( A') (A) (α) (is-orth-α)
           ( has-unique-extensions-is-local-type I ψ ϕ A is-local-A))
 ```
 
@@ -1142,7 +1142,7 @@ extensions for every shape inclusion `ϕ ⊂ ψ`.
   : has-unique-extensions I ψ ϕ C
   :=
     weakextext-extext extext I ψ ϕ
-    ( \ _ → C) ( \ _ → is-contr-C)
+    ( \ _ → C) (\ _ → is-contr-C)
 
 #def is-local-type-is-contr uses (extext)
   ( C : U)
@@ -1166,14 +1166,14 @@ Unique extension types are closed under equivalence.
   : is-local-type I ψ ϕ A → is-local-type I ψ ϕ A'
   :=
     is-equiv-Equiv-is-equiv
-      ( ψ → A') ( ϕ → A') ( \ τ' t → τ' t)
-      ( ψ → A)  ( ϕ → A)  ( \ τ t → τ t)
+      ( ψ → A') (ϕ → A') (\ τ' t → τ' t)
+      ( ψ → A)  (ϕ → A)  (\ τ t → τ t)
       ( equiv-of-restriction-maps-equiv extext I ψ ϕ
-        ( \ _ → A') ( \ _ → A) ( \ _ → A'≃A))
+        ( \ _ → A') (\ _ → A) (\ _ → A'≃A))
 
 #def has-unique-extensions-equiv-has-unique-extensions uses (extext)
   ( A' A : U)
-  ( (α , is-equiv-α) : Equiv A' A)
+  ( ( α , is-equiv-α) : Equiv A' A)
   : has-unique-extensions I ψ ϕ A → has-unique-extensions I ψ ϕ A'
   :=
     has-unique-extensions-right-orthogonal-has-unique-extensions A' A α
@@ -1222,7 +1222,7 @@ Next we prove the logical equivalence between `has-unique-extensions` and
   : is-right-orthogonal-terminal-map I ψ ϕ A
   :=
     is-right-orthogonal-have-unique-extensions I ψ ϕ A Unit
-    ( has-ue-ψ-ϕ-A) ( has-unique-extensions-Unit I ψ ϕ)
+    ( has-ue-ψ-ϕ-A) (has-unique-extensions-Unit I ψ ϕ)
     ( terminal-map A)
 
 #def is-right-orthogonal-terminal-map-is-local-type
@@ -1271,7 +1271,7 @@ from the unit type.
     ( has-unique-extensions-is-right-orthogonal-terminal-map I ψ ϕ
       ( relative-product A A' α Unit (\ unit → a))
       ( is-right-orthogonal-pullback-to-shape I ψ ϕ A' A α
-        ( is-orth-ψ-ϕ-α) ( Unit) (\ unit → a)))
+        ( is-orth-ψ-ϕ-α) (Unit) (\ unit → a)))
 ```
 
 Corollary: Given two types `A'` and `A` with unique extensions w.r.t. `ϕ ⊂ ψ`,
@@ -1287,11 +1287,11 @@ every fiber of every map `α : A' → A` also has unique extensions.
   ( α : A' → A)
   ( has-ue-ψ-ϕ-A' : has-unique-extensions I ψ ϕ A')
   ( has-ue-ψ-ϕ-A : has-unique-extensions I ψ ϕ A)
-  : (a : A) → has-unique-extensions I ψ ϕ (fib A' A α a)
+  : ( a : A) → has-unique-extensions I ψ ϕ (fib A' A α a)
   :=
     has-fiberwise-unique-extensions-is-right-orthogonal-to-shape I ψ ϕ A' A α
     ( is-right-orthogonal-have-unique-extensions I ψ ϕ A' A
-      ( has-ue-ψ-ϕ-A') ( has-ue-ψ-ϕ-A) ( α))
+      ( has-ue-ψ-ϕ-A') (has-ue-ψ-ϕ-A) (α))
 ```
 
 ## Anodyne shape inclusions
@@ -1370,15 +1370,15 @@ conditions of being anodyne.
   :=
     \ r f A' A α is-orth₀ →
     ( is-right-orthogonal-to-shape-right-cancel-retract A' A α I ψ χ ϕ
-      ( f A' A α is-orth₀) ( r))
+      ( f A' A α is-orth₀) (r))
 
 #def is-anodyne-pushout-product-for-shape uses (extext)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   : is-anodyne-for-shape I ψ ϕ
   → is-anodyne-for-shape (J × I)
     ( \ (t , s) → χ t ∧ ψ s)
@@ -1390,8 +1390,8 @@ conditions of being anodyne.
 
 #def is-anodyne-pushout-product-for-shape' uses (extext)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
@@ -1413,11 +1413,11 @@ implication with respect to types with unique extensions.
 ```rzk
 #def is-weak-anodyne-for-shape
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   : U
   :=
-    ( (A : U)
+    ( ( A : U)
     → has-unique-extensions I₀ ψ₀ ϕ₀ A
     → has-unique-extensions I ψ ϕ A)
 ```
@@ -1427,8 +1427,8 @@ Every anodyne shape inclusion is weak anodyne.
 ```rzk
 #def is-weak-anodyne-is-anodyne-for-shape uses (extext)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   : is-anodyne-for-shape I ψ ϕ
   → is-weak-anodyne-for-shape I ψ ϕ
   :=
@@ -1452,13 +1452,13 @@ analog fo weak anodyne shape inclusions.
 #def implication-has-unique-extension-implication-right-orthogonal
   uses (extext)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
   ( impl
-    : (A' : U) → (A : U) → (α : A' → A)
+ : ( A' : U) → (A : U) → (α : A' → A)
     → is-right-orthogonal-to-shape I ψ ϕ A' A α
     → is-right-orthogonal-to-shape J χ ζ A' A α)
   ( A : U)
@@ -1473,8 +1473,8 @@ analog fo weak anodyne shape inclusions.
 
 #def is-weak-anodyne-pushout-product-for-shape uses (extext)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
@@ -1486,15 +1486,15 @@ analog fo weak anodyne shape inclusions.
   :=
     \ f A has-ue₀ →
     implication-has-unique-extension-implication-right-orthogonal I ψ ϕ
-    ( J × I) ( \ (t , s) → χ t ∧ ψ s) ( \ (t , s) → (ζ t ∧ ψ s) ∨ (χ t ∧ ϕ s))
+    ( J × I) (\ (t , s) → χ t ∧ ψ s) (\ (t , s) → (ζ t ∧ ψ s) ∨ (χ t ∧ ϕ s))
     ( \ A'₁ A₁ α₁ →
       is-right-orthogonal-to-shape-pushout-product A'₁ A₁ α₁ J χ ζ I ψ ϕ)
     ( A) (f A has-ue₀)
 
 #def is-weak-anodyne-pushout-product-for-shape' uses (extext)
   ( I : CUBE)
-  ( ψ : I → TOPE )
-  ( ϕ : ψ → TOPE )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( J : CUBE)
   ( χ : J → TOPE)
   ( ζ : χ → TOPE)
@@ -1505,7 +1505,7 @@ analog fo weak anodyne shape inclusions.
   :=
     \ f A has-ue₀ →
     implication-has-unique-extension-implication-right-orthogonal I ψ ϕ
-    ( I × J) ( \ (s , t) → ψ s ∧ χ t) ( \ (s , t) → (ϕ s ∧ χ t) ∨ (ψ s ∧ ζ t))
+    ( I × J) (\ (s , t) → ψ s ∧ χ t) (\ (s , t) → (ϕ s ∧ χ t) ∨ (ψ s ∧ ζ t))
     ( \ A'₁ A₁ α₁ →
       is-right-orthogonal-to-shape-pushout-product' A'₁ A₁ α₁ I ψ ϕ J χ ζ)
     ( A) (f A has-ue₀)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -46,8 +46,8 @@ Extension types are used to define the type of arrows between fixed terms:
   ( x y : A)
   : U
   :=
-    ( t : Δ¹) →
-    A [ t ≡ 0₂ ↦ x ,  -- the left endpoint is exactly x
+    ( t : Δ¹)
+  → A [ t ≡ 0₂ ↦ x , -- the left endpoint is exactly x
         t ≡ 1₂ ↦ y]   -- the right endpoint is exactly y
 
 ```
@@ -60,7 +60,7 @@ For each `a : A`, the total types of the representables `\ z → hom A a z` and
   ( A : U)
   ( a : A)
   : U
-  := Σ ( z : A) , (hom A a z)
+  := Σ (z : A) , (hom A a z)
 
 #def slice
   ( A : U)
@@ -74,20 +74,20 @@ sense:
 
 ```rzk
 #def coslice-fun
-  (A B : U)
-  (f : A → B)
-  (a : A)
+  ( A B : U)
+  ( f : A → B)
+  ( a : A)
   : coslice A a → coslice B (f a)
   :=
-    \ (a', g) → (f a', \ t → f (g t))
+    \ (a' , g) → (f a' , \ t → f (g t))
 
 #def slice-fun
-  (A B : U)
-  (f : A → B)
-  (a : A)
+  ( A B : U)
+  ( f : A → B)
+  ( a : A)
   : slice A a → slice B (f a)
   :=
-    \ (a', g) → (f a', \ t → f (g t))
+    \ (a' , g) → (f a' , \ t → f (g t))
 ```
 
 Slices and coslices can also be defined directly as extension types:
@@ -99,42 +99,42 @@ Slices and coslices can also be defined directly as extension types:
 
 #def coslice'
   : U
-  := ( t : Δ¹) → A [t ≡ 0₂ ↦ a]
+  := (t : Δ¹) → A [t ≡ 0₂ ↦ a]
 
 #def coslice'-coslice
   : coslice A a → coslice'
-  := \ (_, f) → f
+  := \ (_ , f) → f
 
 #def coslice-coslice'
   : coslice' → coslice A a
-  := \ f → ( f 1₂ , \ t → f t) -- does not typecheck after η-reduction
+  := \ f → (f 1₂ , \ t → f t) -- does not typecheck after η-reduction
 
 #def is-id-coslice-coslice'-coslice
-  ( (a', f) : coslice A a)
-  : ( coslice-coslice' ( coslice'-coslice (a', f)) = (a', f))
+  ( ( a' , f) : coslice A a)
+  : ( coslice-coslice' (coslice'-coslice (a' , f)) = (a' , f))
   :=
     eq-pair A (hom A a)
-      ( coslice-coslice' ( coslice'-coslice (a', f))) (a', f)
-      (refl, refl)
+      ( coslice-coslice' (coslice'-coslice (a' , f))) (a' , f)
+      ( refl , refl)
 
 #def is-id-coslice'-coslice-coslice'
   ( f : coslice')
-  : ( coslice'-coslice ( coslice-coslice' f) = f)
+  : ( coslice'-coslice (coslice-coslice' f) = f)
   :=
     refl
 
 #def is-equiv-coslice'-coslice
   : is-equiv (coslice A a) coslice' coslice'-coslice
   :=
-    ( ( coslice-coslice', is-id-coslice-coslice'-coslice),
-      ( coslice-coslice', is-id-coslice'-coslice-coslice')
+    ( ( coslice-coslice' , is-id-coslice-coslice'-coslice)
+    , ( coslice-coslice' , is-id-coslice'-coslice-coslice')
     )
 
 #def is-equiv-coslice-coslice'
   : is-equiv coslice' (coslice A a)  coslice-coslice'
   :=
-    ( ( coslice'-coslice, is-id-coslice'-coslice-coslice'),
-      ( coslice'-coslice, is-id-coslice-coslice'-coslice)
+    ( ( coslice'-coslice , is-id-coslice'-coslice-coslice')
+    , ( coslice'-coslice , is-id-coslice-coslice'-coslice)
     )
 
 #end coslice-as-extension-type
@@ -145,42 +145,42 @@ Slices and coslices can also be defined directly as extension types:
 
 #def slice'
   : U
-  := ( t : Δ¹) → A[t ≡ 1₂ ↦ a]
+  := (t : Δ¹) → A[t ≡ 1₂ ↦ a]
 
 #def slice'-slice
   : slice A a → slice'
-  := \ (_, f) → f
+  := \ (_ , f) → f
 
 #def slice-slice'
   : slice' → slice A a
-  := \ f → ( f 0₂ , \ t → f t) -- does not typecheck after η-reduction
+  := \ f → (f 0₂ , \ t → f t) -- does not typecheck after η-reduction
 
 #def is-id-slice-slice'-slice
-  ( (a', f) : slice A a)
-  : ( slice-slice' ( slice'-slice (a', f)) = (a', f))
+  ( ( a' , f) : slice A a)
+  : ( slice-slice' (slice'-slice (a' , f)) = (a' , f))
   :=
     eq-pair A (\ a' → hom A a' a)
-      ( slice-slice' ( slice'-slice (a', f))) (a', f)
-      (refl, refl)
+      ( slice-slice' (slice'-slice (a' , f))) (a' , f)
+      ( refl , refl)
 
 #def is-id-slice'-slice-slice'
   ( f : slice')
-  : ( slice'-slice ( slice-slice' f) = f)
+  : ( slice'-slice (slice-slice' f) = f)
   :=
     refl
 
 #def is-equiv-slice'-slice
   : is-equiv (slice A a) slice' slice'-slice
   :=
-    ( ( slice-slice', is-id-slice-slice'-slice),
-      ( slice-slice', is-id-slice'-slice-slice')
+    ( ( slice-slice' , is-id-slice-slice'-slice)
+    , ( slice-slice' , is-id-slice'-slice-slice')
     )
 
 #def is-equiv-slice-slice'
   : is-equiv slice' (slice A a)  slice-slice'
   :=
-    ( ( slice'-slice, is-id-slice'-slice-slice'),
-      ( slice'-slice, is-id-slice-slice'-slice)
+    ( ( slice'-slice , is-id-slice'-slice-slice')
+    , ( slice'-slice , is-id-slice-slice'-slice)
     )
 
 #end slice-as-extension-type
@@ -210,9 +210,9 @@ Extension types are also used to define the type of commutative triangles:
   ( h : hom A x z)
   : U
   :=
-    ( (t₁ , t₂) : Δ²) →
-    A [ t₂ ≡ 0₂ ↦ f t₁ ,  -- the top edge is exactly `f`,
-        t₁ ≡ 1₂ ↦ g t₂ ,  -- the right edge is exactly `g`, and
+    ( ( t₁ , t₂) : Δ²)
+  → A [ t₂ ≡ 0₂ ↦ f t₁ , -- the top edge is exactly `f`,
+        t₁ ≡ 1₂ ↦ g t₂ , -- the right edge is exactly `g`, and
         t₂ ≡ t₁ ↦ h t₂]   -- the diagonal is exactly `h`
 ```
 
@@ -245,8 +245,8 @@ type.
   ( A : U)
   : is-equiv (arr A) (fibered-arr A) (fibered-arr-free-arr A)
   :=
-    ( ( (\ (_ , (_ , f)) → f) , (\ _ → refl))
-    , ( (\ (_ , (_ , f)) → f) , (\ _ → refl)))
+    ( ( ( \ (_ , (_ , f)) → f) , (\ _ → refl))
+    , ( ( \ (_ , (_ , f)) → f) , (\ _ → refl)))
 
 #def equiv-fibered-arr-free-arr
   ( A : U)
@@ -261,7 +261,7 @@ And the corresponding uncurried version.
   ( A : U)
   : U
   :=
-    Σ ((a,b) : product A A), hom A a b
+    Σ ( ( a , b) : product A A) , hom A a b
 
 #def fibered-arr-free-arr'
   ( A : U)
@@ -272,8 +272,8 @@ And the corresponding uncurried version.
   ( A : U)
   : is-equiv (arr A) (fibered-arr' A) (fibered-arr-free-arr' A)
   :=
-    ( ( (\ ((_ , _) , σ) → σ) , (\ _ → refl))
-    , ( (\ ((_ , _) , σ) → σ) , (\ _ → refl)))
+    ( ( ( \ ((_ , _) , σ) → σ) , (\ _ → refl))
+    , ( ( \ ((_ , _) , σ) → σ) , (\ _ → refl)))
 ```
 
 ## The Segal condition
@@ -287,9 +287,9 @@ also requires homotopical uniqueness of higher-order composites.
   ( A : U)
   : U
   :=
-    (x : A) → (y : A) → (z : A) →
-    (f : hom A x y) → (g : hom A y z) →
-    is-contr (Σ (h : hom A x z) , (hom2 A x y z f g h))
+    ( x : A) → (y : A) → (z : A)
+  → ( f : hom A x y) → (g : hom A y z)
+  → is-contr (Σ (h : hom A x z) , (hom2 A x y z f g h))
 ```
 
 Segal types have a composition functor and witnesses to the composition
@@ -360,11 +360,11 @@ composite equals $h$.
     first-path-Σ
       ( hom A x z)
       ( hom2 A x y z f g)
-      ( comp-is-segal A is-segal-A x y z f g ,
-        witness-comp-is-segal A is-segal-A x y z f g)
+      ( comp-is-segal A is-segal-A x y z f g
+      , witness-comp-is-segal A is-segal-A x y z f g)
       ( h , alpha)
       ( homotopy-contraction
-        ( Σ (k : hom A x z) , (hom2 A x y z f g k))
+        ( Σ ( k : hom A x z) , (hom2 A x y z f g k))
         ( is-segal-A x y z f g)
         ( h , alpha))
 ```
@@ -396,8 +396,8 @@ A pair of composable arrows form a horn.
   :=
     \ (t , s) →
     recOR
-      ( s ≡ 0₂ ↦ f t ,
-        t ≡ 1₂ ↦ g s)
+      ( s ≡ 0₂ ↦ f t
+      , t ≡ 1₂ ↦ g s)
 ```
 
 The underlying horn of a simplex:
@@ -405,7 +405,7 @@ The underlying horn of a simplex:
 ```rzk
 #def horn-restriction
   ( A : U)
-  : (Δ² → A) → (Λ → A)
+  : ( Δ² → A) → (Λ → A)
   := \ f t → f t
 ```
 
@@ -436,31 +436,31 @@ witnesses of the equivalence).
   ( f : hom A x y)
   ( g : hom A y z)
   : Equiv
-    ( Σ (h : hom A x z) , (hom2 A x y z f g h))
-    ( (t : Δ²) → A [Λ t ↦ horn A x y z f g t])
+    ( Σ ( h : hom A x z) , (hom2 A x y z f g h))
+    ( ( t : Δ²) → A [Λ t ↦ horn A x y z f g t])
   :=
-    ( \ hh t → (second hh) t ,
-      ( ( \ k → (\ t → k (t , t) , \ (t , s) → k (t , s)) ,
-          \ hh → refl) ,
-        ( \ k → (\ t → k (t , t) , \ (t , s) → k (t , s)) ,
-          \ hh → refl)))
+    ( \ hh t → (second hh) t
+    , ( ( \ k → (\ t → k (t , t) , \ (t , s) → k (t , s))
+        , \ hh → refl)
+      , ( \ k → (\ t → k (t , t) , \ (t , s) → k (t , s))
+        , \ hh → refl)))
 
 #def equiv-horn-restriction
   ( A : U)
   : Equiv
     ( Δ² → A)
-    ( Σ ( k : Λ → A) ,
-        ( Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
-            ( hom2 A
+    ( Σ ( k : Λ → A)
+      , ( Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂)))
+          , ( hom2 A
               ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
               ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
               ( h))))
   :=
     ( \ k →
-      ( ( \ t → k t) ,
-        ( \ t → k (t , t) , \ t → k t)) ,
-      ( ( \ khh t → (second (second khh)) t , \ k → refl) ,
-        ( \ khh t → (second (second khh)) t , \ k → refl)))
+      ( ( \ t → k t)
+      , ( \ t → k (t , t) , \ t → k t))
+    , ( ( \ khh t → (second (second khh)) t , \ k → refl)
+      , ( \ khh t → (second (second khh)) t , \ k → refl)))
 ```
 
 ```rzk title="RS17, Theorem 5.5 (the hard direction)"
@@ -471,9 +471,9 @@ witnesses of the equivalence).
   :=
     equiv-comp
       ( Δ² → A)
-      ( Σ ( k : Λ → A) ,
-          ( Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
-              ( hom2 A
+      ( Σ ( k : Λ → A)
+        , ( Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂)))
+            , ( hom2 A
                 ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
                 ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
                 ( h))))
@@ -482,16 +482,16 @@ witnesses of the equivalence).
       ( projection-total-type
         ( Λ → A)
         ( \ k →
-          Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
-            ( hom2 A
+          Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂)))
+          , ( hom2 A
               ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
               ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
-              ( h))) ,
-      ( is-equiv-projection-contractible-fibers
+              ( h)))
+    , ( is-equiv-projection-contractible-fibers
           ( Λ → A)
           ( \ k →
-            Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
-              ( hom2 A
+            Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂)))
+            , ( hom2 A
                 ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
                 ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
                 ( h)))
@@ -508,7 +508,7 @@ is exactly `#!rzk horn-restriction A`.
 #def test-equiv-horn-restriction-is-segal
   ( A : U)
   ( is-segal-A : is-segal A)
-  : (first (equiv-horn-restriction-is-segal A is-segal-A)) = (horn-restriction A)
+  : ( first (equiv-horn-restriction-is-segal A is-segal-A)) = (horn-restriction A)
   := refl
 ```
 
@@ -530,28 +530,28 @@ is exactly `#!rzk horn-restriction A`.
     contractible-fibers-is-equiv-projection
       ( Λ → A)
       ( \ k →
-        Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
-          ( hom2 A
+        Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂)))
+        , ( hom2 A
             ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
             ( \ t → k (t , 0₂))
             ( \ t → k (1₂ , t))
             ( h)))
       ( second
         ( equiv-comp
-          ( Σ ( k : Λ → A) ,
-            Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
-              ( hom2 A
+          ( Σ ( k : Λ → A)
+          , Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂)))
+            , ( hom2 A
                 ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
                 ( \ t → k (t , 0₂))
                 ( \ t → k (1₂ , t))
                 ( h)))
           ( Δ² → A)
-          ( Λ  → A)
+          ( Λ → A)
           ( inv-equiv
             ( Δ² → A)
-            ( Σ ( k : Λ → A) ,
-              Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
-                ( hom2 A
+            ( Σ ( k : Λ → A)
+            , Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂)))
+              , ( hom2 A
                   ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
                   ( \ t → k (t , 0₂))
                   ( \ t → k (1₂ , t))
@@ -608,8 +608,8 @@ all $x$ then $(x : X) → A x$ is a Segal type.
   :=
     is-equiv-triple-comp
       ( Δ² → ((x : X) → A x))
-      ( (x : X) → Δ² → A x)
-      ( (x : X) → Λ → A x)
+      ( ( x : X) → Δ² → A x)
+      ( ( x : X) → Λ → A x)
       ( Λ → ((x : X) → A x))
       ( \ g x t → g t x) -- first equivalence
       ( second (flip-ext-fun
@@ -642,7 +642,7 @@ all $x$ then $(x : X) → A x$ is a Segal type.
   : is-segal ((x : X) → A x)
   :=
     is-segal-is-local-horn-inclusion
-      ( (x : X) → A x)
+      ( ( x : X) → A x)
       ( is-local-horn-inclusion-function-type
         ( X) (A)
         ( \ x → is-local-horn-inclusion-is-segal (A x)(fiberwise-is-segal-A x)))
@@ -661,8 +661,8 @@ then $(x : X) → A x$ is a Segal type.
   :=
     is-equiv-triple-comp
       ( Δ² → (s : ψ) → A s)
-      ( (s : ψ) → Δ² → A s)
-      ( (s : ψ) → Λ → A s)
+      ( ( s : ψ) → Δ² → A s)
+      ( ( s : ψ) → Λ → A s)
       ( Λ → (s : ψ) → A s)
       ( \ g s t → g t s)  -- first equivalence
       ( second
@@ -701,7 +701,7 @@ then $(x : X) → A x$ is a Segal type.
   : is-segal ((s : ψ) → A s)
   :=
     is-segal-is-local-horn-inclusion
-      ( (s : ψ) → A s)
+      ( ( s : ψ) → A s)
       ( is-local-horn-inclusion-extension-type
         ( I) (ψ) (A)
         ( \ s → is-local-horn-inclusion-is-segal (A s)(fiberwise-is-segal-A s)))
@@ -832,7 +832,7 @@ needed in the definition of Segal types.
   ( is-segal-A : is-segal A)
   ( x y : A)
   ( f : hom A x y)
-  : (comp-is-segal A is-segal-A x x y (id-hom A x) f) =_{hom A x y} f
+  : ( comp-is-segal A is-segal-A x x y (id-hom A x) f) =_{hom A x y} f
   :=
     uniqueness-comp-is-segal
       ( A)
@@ -871,8 +871,8 @@ that the type of arrows in a Segal type is itself a Segal type.
   :=
     \ (t , s) →
     recOR
-      ( t ≤ s ↦ triangle (s , t) ,
-        s ≤ t ↦ triangle (t , s))
+      ( t ≤ s ↦ triangle (s , t)
+      , s ≤ t ↦ triangle (t , s))
 ```
 
 For use in the proof of associativity:
@@ -975,7 +975,7 @@ The `#!rzk witness-square-comp-is-segal` as an arrow in the arrow type:
     witness-comp-is-segal
       ( arr A)
       ( is-segal-arr A is-segal-A)
-      ( f) ( g) ( h)
+      ( f) (g) (h)
       ( arr-in-arr-is-segal A is-segal-A w x y f g)
       ( arr-in-arr-is-segal A is-segal-A x y z g h)
 ```
@@ -1013,7 +1013,7 @@ middle-simplex map $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$
   : Δ³ → A
   :=
     \ ((t , s) , r) →
-    (witness-asociative-is-segal A is-segal-A w x y z f g h) (t , r) s
+    ( witness-asociative-is-segal A is-segal-A w x y z f g h) (t , r) s
 ```
 
 <svg style="float: right" viewBox="0 0 200 250" width="150" height="200">
@@ -1049,7 +1049,7 @@ The diagonal composite of three arrows extracted from the
   :=
     \ t →
     tetrahedron-associative-is-segal A is-segal-A w x y z f g h
-      ( (t , t) , t)
+      ( ( t , t) , t)
 ```
 
 <svg style="float: right" viewBox="0 0 200 250" width="150" height="200">
@@ -1081,13 +1081,13 @@ The diagonal composite of three arrows extracted from the
   ( g : hom A x y)
   ( h : hom A y z)
   : hom2 A w y z
-    (comp-is-segal A is-segal-A w x y f g)
+    ( comp-is-segal A is-segal-A w x y f g)
     h
-    (triple-comp-is-segal A is-segal-A w x y z f g h)
+    ( triple-comp-is-segal A is-segal-A w x y z f g h)
   :=
     \ (t , s) →
     tetrahedron-associative-is-segal A is-segal-A w x y z f g h
-      ( (t , t) , s)
+      ( ( t , t) , s)
 ```
 
 The front face:
@@ -1127,7 +1127,7 @@ The front face:
   :=
     \ (t , s) →
     tetrahedron-associative-is-segal A is-segal-A w x y z f g h
-      ( (t , s) , s)
+      ( ( t , s) , s)
 ```
 
 ```rzk
@@ -1138,8 +1138,8 @@ The front face:
   ( f : hom A w x)
   ( g : hom A x y)
   ( h : hom A y z)
-  : ( comp-is-segal A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h) =
-    ( triple-comp-is-segal A is-segal-A w x y z f g h)
+  : ( comp-is-segal A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h)
+  = ( triple-comp-is-segal A is-segal-A w x y z f g h)
   :=
     uniqueness-comp-is-segal
       A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h
@@ -1153,8 +1153,8 @@ The front face:
   ( f : hom A w x)
   ( g : hom A x y)
   ( h : hom A y z)
-  : ( comp-is-segal A is-segal-A w x z f (comp-is-segal A is-segal-A x y z g h)) =
-    ( triple-comp-is-segal A is-segal-A w x y z f g h)
+  : ( comp-is-segal A is-segal-A w x z f (comp-is-segal A is-segal-A x y z g h))
+  = ( triple-comp-is-segal A is-segal-A w x y z f g h)
   :=
     uniqueness-comp-is-segal
       ( A) (is-segal-A) (w) (x) (z) (f) (comp-is-segal A is-segal-A x y z g h)
@@ -1172,8 +1172,8 @@ We conclude that Segal composition is associative.
   ( f : hom A w x)
   ( g : hom A x y)
   ( h : hom A y z)
-  : ( comp-is-segal A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h) =
-    ( comp-is-segal A is-segal-A w x z f (comp-is-segal A is-segal-A x y z g h))
+  : ( comp-is-segal A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h)
+  = ( comp-is-segal A is-segal-A w x z f (comp-is-segal A is-segal-A x y z g h))
   :=
     zig-zag-concat
     ( hom A w z)
@@ -1190,8 +1190,8 @@ We conclude that Segal composition is associative.
   ( f : hom A w x)
   ( g : hom A x y)
   ( h : hom A y z)
-  : ( comp-is-segal A is-segal-A w x z f (comp-is-segal A is-segal-A x y z g h)) =
-    ( comp-is-segal A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h)
+  : ( comp-is-segal A is-segal-A w x z f (comp-is-segal A is-segal-A x y z g h))
+  = ( comp-is-segal A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h)
   :=
     rev (hom A w z)
     ( comp-is-segal A is-segal-A w y z (comp-is-segal A is-segal-A w x y f g) h)
@@ -1203,7 +1203,7 @@ We conclude that Segal composition is associative.
   ( is-segal-A : is-segal A)
   ( x y : A)
   ( f : hom A x y)
-  : (z : A) → (hom A z x) → (hom A z y)
+  : ( z : A) → (hom A z x) → (hom A z y)
   := \ z g → comp-is-segal A is-segal-A z x y g f
 
 #def precomp-is-segal
@@ -1211,7 +1211,7 @@ We conclude that Segal composition is associative.
   ( is-segal-A : is-segal A)
   ( x y : A)
   ( f : hom A x y)
-  : (z : A) → (hom A y z) → (hom A x z)
+  : ( z : A) → (hom A y z) → (hom A x z)
   := \ z → comp-is-segal A is-segal-A x y z f
 ```
 
@@ -1226,7 +1226,7 @@ arrow.
   ( A : U)
   ( x y : A)
   ( f g : hom A x y)
-  : (f = g) → (hom2 A x x y (id-hom A x) f g)
+  : ( f = g) → (hom2 A x x y (id-hom A x) f g)
   :=
     ind-path
       ( hom A x y)
@@ -1239,8 +1239,8 @@ arrow.
   ( A : U)
   ( x y : A)
   ( f : hom A x y)
-  : ( Σ (g : hom A x y) , (f = g)) →
-    ( Σ (g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
+  : ( Σ ( g : hom A x y) , (f = g))
+  → ( Σ ( g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
   := \ (g , p) → (g , map-hom2-homotopy A x y f g p)
 
 #def is-equiv-map-total-hom2-homotopy-is-segal
@@ -1249,13 +1249,13 @@ arrow.
   ( x y : A)
   ( f : hom A x y)
   : is-equiv
-      ( Σ (g : hom A x y) , f = g)
-      ( Σ (g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
+      ( Σ ( g : hom A x y) , f = g)
+      ( Σ ( g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
       ( map-total-hom2-homotopy A x y f)
   :=
     is-equiv-are-contr
-      ( Σ (g : hom A x y) , (f = g))
-      ( Σ (g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
+      ( Σ ( g : hom A x y) , (f = g))
+      ( Σ ( g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
       ( is-contr-based-paths (hom A x y) f)
       ( is-segal-A x x y (id-hom A x) f)
       ( map-total-hom2-homotopy A x y f)
@@ -1269,8 +1269,8 @@ arrow.
   ( f h : hom A x y)
   : Equiv (f = h) (hom2 A x x y (id-hom A x) f h)
   :=
-    ( ( map-hom2-homotopy A x y f h) ,
-      ( is-equiv-fiberwise-is-equiv-total
+    ( ( map-hom2-homotopy A x y f h)
+    , ( is-equiv-fiberwise-is-equiv-total
         ( hom A x y)
         ( \ k → (f = k))
         ( \ k → (hom2 A x x y (id-hom A x) f k))
@@ -1287,7 +1287,7 @@ A dual notion of homotopy can be defined similarly.
   ( x y : A)
   ( f g : hom A x y)
   ( p : f = g)
-  : (hom2 A x y y f (id-hom A y) g)
+  : ( hom2 A x y y f (id-hom A y) g)
   :=
     ind-path
       ( hom A x y)
@@ -1301,8 +1301,8 @@ A dual notion of homotopy can be defined similarly.
   ( A : U)
   ( x y : A)
   ( f : hom A x y)
-  : ( Σ (g : hom A x y) , (f = g)) →
-    ( Σ (g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
+  : ( Σ ( g : hom A x y) , (f = g))
+  → ( Σ ( g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
   := \ (g , p) → (g , map-hom2-homotopy' A x y f g p)
 
 #def is-equiv-map-total-hom2-homotopy'-is-segal
@@ -1311,13 +1311,13 @@ A dual notion of homotopy can be defined similarly.
   ( x y : A)
   ( f : hom A x y)
   : is-equiv
-      ( Σ (g : hom A x y) , f = g)
-      ( Σ (g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
+      ( Σ ( g : hom A x y) , f = g)
+      ( Σ ( g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
       ( map-total-hom2-homotopy' A x y f)
   :=
     is-equiv-are-contr
-      ( Σ (g : hom A x y) , (f = g))
-      ( Σ (g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
+      ( Σ ( g : hom A x y) , (f = g))
+      ( Σ ( g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
       ( is-contr-based-paths (hom A x y) f)
       ( is-segal-A x y y f (id-hom A y))
       ( map-total-hom2-homotopy' A x y f)
@@ -1331,8 +1331,8 @@ A dual notion of homotopy can be defined similarly.
   ( f h : hom A x y)
   : Equiv (f = h) (hom2 A x y y f (id-hom A y) h)
   :=
-    ( ( map-hom2-homotopy' A x y f h) ,
-      ( is-equiv-fiberwise-is-equiv-total
+    ( ( map-hom2-homotopy' A x y f h)
+    , ( is-equiv-fiberwise-is-equiv-total
         ( hom A x y)
         ( \ k → (f = k))
         ( \ k → (hom2 A x y y f (id-hom A y) k))
@@ -1369,8 +1369,8 @@ the data provided by a commutative triangle with that boundary.
   ( x y z : A)
   ( f : hom A x y)
   ( g : hom A y z)
-  : ( Σ (h : hom A x z) , (comp-is-segal A is-segal-A x y z f g) = h) →
-    ( Σ (h : hom A x z) , (hom2 A x y z f g h))
+  : ( Σ ( h : hom A x z) , (comp-is-segal A is-segal-A x y z f g) = h)
+  → ( Σ ( h : hom A x z) , (hom2 A x y z f g h))
   := \ (h , p) → (h , map-hom2-eq-is-segal A is-segal-A x y z f g h p)
 
 #def is-equiv-map-total-hom2-eq-is-segal
@@ -1380,13 +1380,13 @@ the data provided by a commutative triangle with that boundary.
   ( f : hom A x y)
   ( g : hom A y z)
   : is-equiv
-      ( Σ (h : hom A x z) , (comp-is-segal A is-segal-A x y z f g) = h)
-      ( Σ (h : hom A x z) , (hom2 A x y z f g h))
+      ( Σ ( h : hom A x z) , (comp-is-segal A is-segal-A x y z f g) = h)
+      ( Σ ( h : hom A x z) , (hom2 A x y z f g h))
       ( map-total-hom2-eq-is-segal A is-segal-A x y z f g)
   :=
     is-equiv-are-contr
-      ( Σ (h : hom A x z) , (comp-is-segal A is-segal-A x y z f g) = h)
-      ( Σ (h : hom A x z) , (hom2 A x y z f g h))
+      ( Σ ( h : hom A x z) , (comp-is-segal A is-segal-A x y z f g) = h)
+      ( Σ ( h : hom A x z) , (hom2 A x y z f g h))
       ( is-contr-based-paths (hom A x z) (comp-is-segal A is-segal-A x y z f g))
       ( is-segal-A x y z f g)
       ( map-total-hom2-eq-is-segal A is-segal-A x y z f g)
@@ -1402,8 +1402,8 @@ the data provided by a commutative triangle with that boundary.
   ( k : hom A x z)
   : Equiv ((comp-is-segal A is-segal-A x y z f g) = k) (hom2 A x y z f g k)
   :=
-    ( ( map-hom2-eq-is-segal A is-segal-A x y z f g k) ,
-      ( is-equiv-fiberwise-is-equiv-total
+    ( ( map-hom2-eq-is-segal A is-segal-A x y z f g k)
+    , ( is-equiv-fiberwise-is-equiv-total
         ( hom A x z)
         ( \ m → (comp-is-segal A is-segal-A x y z f g) = m)
         ( hom2 A x y z f g)
@@ -1424,21 +1424,21 @@ composition:
   ( h k : hom A y z)
   ( p : f = g)
   ( q : h = k)
-  : ( comp-is-segal A is-segal-A x y z f h) =
-    ( comp-is-segal A is-segal-A x y z g k)
+  : ( comp-is-segal A is-segal-A x y z f h)
+  = ( comp-is-segal A is-segal-A x y z g k)
   :=
     ind-path
       ( hom A y z)
       ( h)
       ( \ k' q' →
-        ( comp-is-segal A is-segal-A x y z f h) =
-        ( comp-is-segal A is-segal-A x y z g k'))
+        ( comp-is-segal A is-segal-A x y z f h)
+      = ( comp-is-segal A is-segal-A x y z g k'))
       ( ind-path
         ( hom A x y)
         ( f)
         ( \ g' p' →
-          ( comp-is-segal A is-segal-A x y z f h) =
-          ( comp-is-segal A is-segal-A x y z g' h))
+          ( comp-is-segal A is-segal-A x y z f h)
+        = ( comp-is-segal A is-segal-A x y z g' h))
         ( refl)
         ( g)
         ( p))
@@ -1470,8 +1470,8 @@ As a special case of the above:
   ( k : hom A w x)
   ( f g : hom A x y)
   ( p : f = g)
-  : ( comp-is-segal A is-segal-A w x y k f) =
-    ( comp-is-segal A is-segal-A w x y k g)
+  : ( comp-is-segal A is-segal-A w x y k f)
+  = ( comp-is-segal A is-segal-A w x y k g)
   := congruence-homotopy-is-segal A is-segal-A w x y k k f g refl p
 ```
 
@@ -1483,17 +1483,17 @@ As a special case of the above:
   ( f g : hom A x y)
   ( h : hom A y z)
   ( p : f = g)
-  : ( postwhisker-homotopy-is-segal A is-segal-A x y z f g h p) =
-    ( ap (hom A x y) (hom A x z) f g (\ k → comp-is-segal A is-segal-A x y z k h) p)
+  : ( postwhisker-homotopy-is-segal A is-segal-A x y z f g h p)
+  = ( ap (hom A x y) (hom A x z) f g (\ k → comp-is-segal A is-segal-A x y z k h) p)
   :=
     ind-path
       ( hom A x y)
       ( f)
       ( \ g' p' →
-        ( postwhisker-homotopy-is-segal A is-segal-A x y z f g' h p') =
-        ( ap
-          (hom A x y) (hom A x z)
-          (f) (g') (\ k → comp-is-segal A is-segal-A x y z k h) (p')))
+        ( postwhisker-homotopy-is-segal A is-segal-A x y z f g' h p')
+      = ( ap
+          ( hom A x y) (hom A x z)
+          ( f) (g') (\ k → comp-is-segal A is-segal-A x y z k h) (p')))
       ( refl)
       ( g)
       ( p)
@@ -1507,15 +1507,15 @@ As a special case of the above:
   ( k : hom A w x)
   ( f g : hom A x y)
   ( p : f = g)
-  : ( prewhisker-homotopy-is-segal A is-segal-A w x y k f g p) =
-    ( ap (hom A x y) (hom A w y) f g (comp-is-segal A is-segal-A w x y k) p)
+  : ( prewhisker-homotopy-is-segal A is-segal-A w x y k f g p)
+  = ( ap (hom A x y) (hom A w y) f g (comp-is-segal A is-segal-A w x y k) p)
   :=
     ind-path
       ( hom A x y)
       ( f)
       ( \ g' p' →
-        ( prewhisker-homotopy-is-segal A is-segal-A w x y k f g' p') =
-        ( ap (hom A x y) (hom A w y) f g' (comp-is-segal A is-segal-A w x y k) p'))
+        ( prewhisker-homotopy-is-segal A is-segal-A w x y k f g' p')
+      = ( ap (hom A x y) (hom A w y) f g' (comp-is-segal A is-segal-A w x y k) p'))
       ( refl)
       ( g)
       ( p)
@@ -1525,8 +1525,8 @@ As a special case of the above:
 #def is-contr-Δ²→Unit uses (extext)
   : is-contr (Δ² → Unit)
   :=
-    ( \ _ → unit ,
-      \ k →
+    ( \ _ → unit
+    , \ k →
       naiveextext-extext extext
         ( 2 × 2) Δ² (\ _ → BOT)
         ( \ _ → Unit) (\ _ → recBOT)
@@ -1538,10 +1538,10 @@ As a special case of the above:
   :=
     \ x y z f g →
     is-contr-is-retract-of-is-contr
-      ( Σ (h : hom Unit x z) , (hom2 Unit x y z f g h))
+      ( Σ ( h : hom Unit x z) , (hom2 Unit x y z f g h))
       ( Δ² → Unit)
-      ( ( \ (_ , k) → k) ,
-        ( \ k → ((\ t → k (t , t)) , k) , \ _ → refl))
+      ( ( \ (_ , k) → k)
+      , ( \ k → ((\ t → k (t , t)) , k) , \ _ → refl))
       ( is-contr-Δ²→Unit)
 
 #end is-segal-Unit
@@ -1621,8 +1621,8 @@ Interchange law
   : U
   := congruence-homotopy-is-segal A is-segal-A x y z f1 f3 h1 h3
       ( concat (hom A x y) f1 f2 f3 p q)
-      ( concat (hom A y z) h1 h2 h3 p' q') =
-    concat
+      ( concat (hom A y z) h1 h2 h3 p' q')
+  = concat
       ( hom A x z)
       ( comp-is-segal A is-segal-A x y z f1 h1)
       ( comp-is-segal A is-segal-A x y z f2 h2)
@@ -1643,21 +1643,21 @@ Interchange law
   := ind-path
     ( hom A x y)
     ( f2)
-    ( \ f3 q -> statement-homotopy-interchange-law f1 f2 f3 h1 h2 h3 p q p' q')
+    ( \ f3 q → statement-homotopy-interchange-law f1 f2 f3 h1 h2 h3 p q p' q')
     ( ind-path
       ( hom A x y)
       ( f1)
-      ( \ f2 p -> statement-homotopy-interchange-law f1 f2 f2 h1 h2 h3
+      ( \ f2 p → statement-homotopy-interchange-law f1 f2 f2 h1 h2 h3
           p refl p' q')
       ( ind-path
         ( hom A y z)
         ( h2)
-        ( \ h3 q' -> statement-homotopy-interchange-law f1 f1 f1 h1 h2 h3
+        ( \ h3 q' → statement-homotopy-interchange-law f1 f1 f1 h1 h2 h3
             refl refl p' q')
         ( ind-path
           ( hom A y z)
           ( h1)
-          ( \ h2 p' -> statement-homotopy-interchange-law f1 f1 f1 h1 h2 h2
+          ( \ h2 p' → statement-homotopy-interchange-law f1 f1 f1 h1 h2 h2
               refl refl p' refl)
           ( refl)
           ( h2)
@@ -1702,7 +1702,7 @@ We say that a shape inclusion `ϕ ⊂ ψ` is **inner anodyne** if it is anodyne 
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   : is-inner-anodyne I ψ ϕ
-  = ( (A' : U) → (A : U) → (α : A' → A)
+  = ( ( A' : U) → (A : U) → (α : A' → A)
     → is-inner-fibration A' A α
     → is-right-orthogonal-to-shape I ψ ϕ A' A α)
   := refl
@@ -1774,20 +1774,20 @@ general statements about weak anodyne shape inclusions.
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   : is-weak-inner-anodyne (I × J)
-      (\ (t,s) → ψ t ∧ ζ s)
-      (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
+      ( \ (t , s) → ψ t ∧ ζ s)
+      ( \ (t , s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
   := \ A is-segal-A h →
     is-contr-equiv-is-contr'
-      (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
-      ( (s : ζ) → ((t : ψ) → A[ Φ t ↦ h (t,s)])[ χ s ↦ \ t → h (t, s)])
-      (uncurry-opcurry I J ψ Φ ζ χ (\ s t → A) h)
-      (weakextext
+      ( ( ( t , s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t , s)])
+      ( ( s : ζ) → ((t : ψ) → A[ Φ t ↦ h (t , s)])[ χ s ↦ \ t → h (t , s)])
+      ( uncurry-opcurry I J ψ Φ ζ χ (\ s t → A) h)
+      ( weakextext
         ( J)
         ( ζ)
         ( χ)
-        ( \ s → (t : ψ) → A[ Φ t ↦ h (t,s)])
-        ( \ s → is-weak-inner-anodyne-ψ-Φ A is-segal-A (\ t → h (t,s)))
-        ( \ s t → h (t,s)))
+        ( \ s → (t : ψ) → A[ Φ t ↦ h (t , s)])
+        ( \ s → is-weak-inner-anodyne-ψ-Φ A is-segal-A (\ t → h (t , s)))
+        ( \ s t → h (t , s)))
 
 #def is-weak-inner-anodyne-pushout-product-right-is-weak-inner-anodyne uses (weakextext)
   ( I J : CUBE)
@@ -1795,22 +1795,22 @@ general statements about weak anodyne shape inclusions.
   ( Φ : ψ → TOPE)
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
-  (is-weak-inner-anodyne-ζ-χ : is-weak-inner-anodyne J ζ χ)
+  ( is-weak-inner-anodyne-ζ-χ : is-weak-inner-anodyne J ζ χ)
   : is-weak-inner-anodyne (I × J)
-      (\ (t,s) → ψ t ∧ ζ s)
-      (\ (t,s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
+      ( \ (t , s) → ψ t ∧ ζ s)
+      ( \ (t , s) → (Φ t ∧ ζ s) ∨ (ψ t ∧ χ s))
   := \ A is-segal-A h →
     is-contr-equiv-is-contr
-      ( (t : ψ) → ((s : ζ) → A[ χ s ↦ h (t,s)])[ Φ t ↦ \ s → h (t, s)])
-      (((t,s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t,s)])
-      (curry-uncurry I J ψ Φ ζ χ (\ s t → A) h)
-      (weakextext
+      ( ( t : ψ) → ((s : ζ) → A[ χ s ↦ h (t , s)])[ Φ t ↦ \ s → h (t , s)])
+      ( ( ( t , s) : I × J | ψ t ∧ ζ s) → A[(Φ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ h (t , s)])
+      ( curry-uncurry I J ψ Φ ζ χ (\ s t → A) h)
+      ( weakextext
         ( I)
         ( ψ)
         ( Φ)
-        ( \ t → (s : ζ) → A[ χ s ↦ h (t,s)])
-        ( \ t → is-weak-inner-anodyne-ζ-χ A is-segal-A (\ s → h (t,s)))
-        ( \ s t → h (s,t)))
+        ( \ t → (s : ζ) → A[ χ s ↦ h (t , s)])
+        ( \ t → is-weak-inner-anodyne-ζ-χ A is-segal-A (\ s → h (t , s)))
+        ( \ s t → h (s , t)))
 ```
 
 The following argument from RS17 proves that `Λ³₂ ⊂ Δ³` is weakly inner anodyne.
@@ -1821,7 +1821,7 @@ It should be easy to adapt it to prove that it is actually inner anodyne.
 
 -- Δ³×Λ²₁ ∪_{Λ³₂×Λ²₁} Λ³₂×Δ²
 #def pushout-prod-Λ³₂-Λ²₁
-  : (Δ³×Δ²) → TOPE
+  : ( Δ³×Δ²) → TOPE
   := shape-pushout-prod (2 × 2 × 2) (2 × 2) Δ³ Λ³₂ Δ² Λ²₁
 
 
@@ -1830,14 +1830,14 @@ It should be easy to adapt it to prove that it is actually inner anodyne.
 
 #def h^
   : pushout-prod-Λ³₂-Λ²₁ → A
-  := \ ( ((t1, t2), t3), (s1, s2) ) →
+  := \ (((t1 , t2) , t3) , (s1 , s2)) →
     recOR
-      ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ h ((t1, t2), t3),
-        t1 ≤ s1 ∧ t2 ≤ s2 ↦ h ((s1, t2), t3),
-        s1 ≤ t1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ h ((t1, s2), t3),
-        t1 ≤ s1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ h ((s1, s2), t3),
-        s1 ≤ t1 ∧ s2 ≤ t3 ↦ h ((t1, s2), s2),
-        t1 ≤ s1 ∧ s2 ≤ t3 ↦ h ((s1, s2), s2))
+      ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ h ((t1 , t2) , t3)
+      , t1 ≤ s1 ∧ t2 ≤ s2 ↦ h ((s1 , t2) , t3)
+      , s1 ≤ t1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ h ((t1 , s2) , t3)
+      , t1 ≤ s1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ h ((s1 , s2) , t3)
+      , s1 ≤ t1 ∧ s2 ≤ t3 ↦ h ((t1 , s2) , s2)
+      , t1 ≤ s1 ∧ s2 ≤ t3 ↦ h ((s1 , s2) , s2))
 
 
 #def extend-against-Λ³₂-Δ³
@@ -1849,22 +1849,22 @@ It should be easy to adapt it to prove that it is actually inner anodyne.
   := (x : Δ³×Δ²) → A[ pushout-prod-Λ³₂-Λ²₁ x ↦ h^ x]
 
 #def retract-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² uses (A h)
-  (f : extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
+  ( f : extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²)
   : extend-against-Λ³₂-Δ³
-  := \ ((t1, t2), t3) → f ( ((t1, t2), t3), (t1, t2) )
+  := \ ((t1 , t2) , t3) → f (((t1 , t2) , t3) , (t1 , t2))
 
 #def section-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² uses (A h)
-  (g : (t : Δ³) → A[ Λ³₂ t ↦ h t ])
-  : (x : Δ³×Δ²) → A[ pushout-prod-Λ³₂-Λ²₁ x ↦ h^ x]
+  ( g : (t : Δ³) → A[ Λ³₂ t ↦ h t ])
+  : ( x : Δ³×Δ²) → A[ pushout-prod-Λ³₂-Λ²₁ x ↦ h^ x]
   :=
-    \ ( ((t1, t2), t3), (s1, s2) ) →
+    \ (((t1 , t2) , t3) , (s1 , s2)) →
     recOR
-      ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ g ((t1, t2), t3),
-        t1 ≤ s1 ∧ t2 ≤ s2 ↦ g ((s1, t2), t3),
-        s1 ≤ t1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ g ((t1, s2), t3),
-        t1 ≤ s1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ g ((s1, s2), t3),
-        s1 ≤ t1 ∧ s2 ≤ t3 ↦ g ((t1, s2), s2),
-        t1 ≤ s1 ∧ s2 ≤ t3 ↦ g ((s1, s2), s2))
+      ( s1 ≤ t1 ∧ t2 ≤ s2 ↦ g ((t1 , t2) , t3)
+      , t1 ≤ s1 ∧ t2 ≤ s2 ↦ g ((s1 , t2) , t3)
+      , s1 ≤ t1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ g ((t1 , s2) , t3)
+      , t1 ≤ s1 ∧ t3 ≤ s2 ∧ s2 ≤ t2 ↦ g ((s1 , s2) , t3)
+      , s1 ≤ t1 ∧ s2 ≤ t3 ↦ g ((t1 , s2) , s2)
+      , t1 ≤ s1 ∧ s2 ≤ t3 ↦ g ((s1 , s2) , s2))
 
 #def homotopy-retraction-section-id-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² uses (A h)
   : homotopy extend-against-Λ³₂-Δ³ extend-against-Λ³₂-Δ³
@@ -1882,9 +1882,9 @@ It should be easy to adapt it to prove that it is actually inner anodyne.
       extend-against-Λ³₂-Δ³
       extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²
   :=
-    ( section-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² ,
-      ( retract-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² ,
-        homotopy-retraction-section-id-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²))
+    ( section-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²
+    , ( retract-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²
+      , homotopy-retraction-section-id-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ²))
 
 #end retraction-Λ³₂-Δ³-pushout-product-Λ²₁-Δ²
 
@@ -1893,10 +1893,10 @@ It should be easy to adapt it to prove that it is actually inner anodyne.
   :=
     \ A is-segal-A h →
     is-contr-is-retract-of-is-contr
-      (extend-against-Λ³₂-Δ³ A h)
-      (extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² A h)
-      (is-retract-of-Δ³-Δ³×Δ² A h)
-      (is-weak-inner-anodyne-pushout-product-right-is-weak-inner-anodyne
+      ( extend-against-Λ³₂-Δ³ A h)
+      ( extend-against-pushout-prod-Λ³₂-Λ²₁-Δ³×Δ² A h)
+      ( is-retract-of-Δ³-Δ³×Δ² A h)
+      ( is-weak-inner-anodyne-pushout-product-right-is-weak-inner-anodyne
         ( 2 × 2 × 2)
         ( 2 × 2)
         ( Δ³)
@@ -1917,43 +1917,43 @@ products of morphisms. It is implicitly stated in Proposition 8.21.
 ```rzk
 #section morphisms-of-products-is-products-of-morphisms
 #variables A B : U
-#variable p : ( product A B )
-#variable p' : ( product A B )
+#variable p : (product A B)
+#variable p' : (product A B)
 
 #def morphism-in-product-to-product-of-morphism
-  : hom ( product A B ) p p' →
-    product ( hom A ( first p ) ( first p' ) ) ( hom B ( second p ) ( second p' ) )
-  :=  \ f → ( \ ( t : Δ¹ ) → first ( f t ) , \ ( t : Δ¹ ) → second ( f t ) )
+  : hom (product A B) p p'
+  → product (hom A (first p) (first p')) (hom B (second p) (second p'))
+  := \ f → (\ (t : Δ¹) → first (f t) , \ (t : Δ¹) → second (f t))
 
 #def product-of-morphism-to-morphism-in-product
-  : product ( hom A ( first p ) ( first p' ) ) ( hom B ( second p ) ( second p' ) ) →
-    hom ( product A B ) p p'
-  := \ ( f , g ) ( t : Δ¹ ) → ( f t , g t )
+  : product (hom A (first p) (first p')) (hom B (second p) (second p'))
+  → hom (product A B) p p'
+  := \ (f , g) (t : Δ¹) → (f t , g t)
 
 #def morphisms-in-product-to-product-of-morphism-to-morphism-in-product-is-id
-  : ( f :  product ( hom A ( first p ) ( first p' ) ) ( hom B ( second p ) ( second p' ) ) ) →
-    ( morphism-in-product-to-product-of-morphism )
-    ( ( product-of-morphism-to-morphism-in-product )
-      f ) = f
+  : ( f : product (hom A (first p) (first p')) (hom B (second p) (second p')))
+  → ( morphism-in-product-to-product-of-morphism)
+    ( ( product-of-morphism-to-morphism-in-product)
+      f) = f
   := \ f → refl
 
 #def product-of-morphism-to-morphisms-in-product-to-product-of-morphism-is-id
-  : ( f :  hom ( product A B ) p p' ) →
-    ( product-of-morphism-to-morphism-in-product )
-    ( ( morphism-in-product-to-product-of-morphism )
-      f ) = f
+  : ( f : hom (product A B) p p')
+  → ( product-of-morphism-to-morphism-in-product)
+    ( ( morphism-in-product-to-product-of-morphism)
+      f) = f
   := \ f → refl
 
 #def morphism-in-product-equiv-product-of-morphism
   : Equiv
-    ( hom ( product A B ) p p' )
-    ( product ( hom A ( first p ) ( first p' ) ) ( hom B ( second p ) ( second p' ) ) )
+    ( hom (product A B) p p')
+    ( product (hom A (first p) (first p')) (hom B (second p) (second p')))
   :=
-    ( ( morphism-in-product-to-product-of-morphism ) ,
-      ( ( ( product-of-morphism-to-morphism-in-product ) ,
-          ( product-of-morphism-to-morphisms-in-product-to-product-of-morphism-is-id ) ) ,
-        ( ( product-of-morphism-to-morphism-in-product ) ,
-          ( morphisms-in-product-to-product-of-morphism-to-morphism-in-product-is-id ) ) ) )
+    ( ( morphism-in-product-to-product-of-morphism)
+    , ( ( ( product-of-morphism-to-morphism-in-product)
+        , ( product-of-morphism-to-morphisms-in-product-to-product-of-morphism-is-id))
+      , ( ( product-of-morphism-to-morphism-in-product)
+        , ( morphisms-in-product-to-product-of-morphism-to-morphism-in-product-is-id))))
 
 #end morphisms-of-products-is-products-of-morphisms
 ```

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -45,7 +45,7 @@ targets. The action is called `#!rzk ap-hom` to avoid conflicting with
   ( f : hom A x y)
   ( g : hom A y z)
   ( h : hom A x z)
-  (α : hom2 A x y z f g h)
+  ( α : hom2 A x y z f g h)
   : hom2 B (F x) (F y) (F z)
     ( ap-hom A B F x y f) (ap-hom A B F y z g) (ap-hom A B F x z h)
   := \ t → F (α t)
@@ -90,8 +90,8 @@ Preservation of composition requires the Segal hypothesis.
       ( F x) (F y) (F z)
       ( ap-hom A B F x y f)
       ( ap-hom A B F y z g))
-    =
-    ( ap-hom A B F x z (comp-is-segal A is-segal-A x y z f g))
+
+  = ( ap-hom A B F x z (comp-is-segal A is-segal-A x y z f g))
   :=
     uniqueness-comp-is-segal B is-segal-B
       ( F x) (F y) (F z)
@@ -112,8 +112,8 @@ Preservation of composition requires the Segal hypothesis.
   ( g : hom A y z)
   :
     ( ap-hom A B F x z (comp-is-segal A is-segal-A x y z f g))
-    =
-    ( comp-is-segal B is-segal-B
+
+  = ( comp-is-segal B is-segal-B
       ( F x) (F y) (F z)
       ( ap-hom A B F x y f)
       ( ap-hom A B F y z g))
@@ -143,8 +143,8 @@ The action on morphisms commutes with transport.
     ( hom C (k (g x)) (k (g y)))
     ( ap-hom B C k (g x) (g y))
     ( transport (A → B) (\ f' → hom B (f' x) (f' y)) f g p)
-    =
-    comp
+
+  = comp
     ( hom B (f x) (f y)) (hom C (h (f x)) (h (f y))) (hom C (k (g x)) (k (g y)))
     ( transport (A → C) (\ f' → hom C (f' x) (f' y))
       ( comp A B C h f)
@@ -157,8 +157,8 @@ The action on morphisms commutes with transport.
     comp (hom B (f x) (f y)) (hom B (g' x) (g' y)) (hom C (k (g' x)) (k (g' y)))
     ( ap-hom B C k (g' x) (g' y))
     ( transport (A → B) (\ f' → hom B (f' x) (f' y)) f g' p')
-    =
-    comp
+
+  = comp
     ( hom B (f x) (f y))(hom C (h (f x)) (h (f y)))(hom C (k (g' x)) (k (g' y)))
     ( transport (A → C) (\ f' → hom C (f' x) (f' y))
       ( comp A B C h f)
@@ -170,8 +170,8 @@ The action on morphisms commutes with transport.
       comp (hom B (f x) (f y)) (hom B (f x) (f y)) (hom C (k' (f x)) (k' (f y)))
       ( ap-hom B C k' (f x) (f y))
       ( transport (A → B) (\ f' → hom B (f' x) (f' y)) f f refl)
-      =
-      comp
+
+    = comp
       ( hom B (f x) (f y))
       ( hom C (h (f x)) (h (f y)))
       ( hom C (k' (f x)) (k' (f y)))
@@ -211,7 +211,7 @@ Equivalently , natural transformations can be determined by their **components**
   ( B : A → U)
   ( f g : (x : A) → (B x))
   : U
-  := ( x : A) → hom (B x) (f x) (g x)
+  := (x : A) → hom (B x) (f x) (g x)
 ```
 
 ```rzk
@@ -244,8 +244,8 @@ Equivalently , natural transformations can be determined by their **components**
       ( nat-trans-components A B f g)
       ( ev-components-nat-trans A B f g)
   :=
-    ( ( \ η t x → η x t , \ _ → refl) ,
-      ( \ η t x → η x t , \ _ → refl))
+    ( ( \ η t x → η x t , \ _ → refl)
+    , ( \ η t x → η x t , \ _ → refl))
 
 #def equiv-components-nat-trans
   ( A : U)
@@ -253,8 +253,8 @@ Equivalently , natural transformations can be determined by their **components**
   ( f g : (x : A) → (B x))
   : Equiv (nat-trans A B f g) (nat-trans-components A B f g)
   :=
-    ( ev-components-nat-trans A B f g ,
-      is-equiv-ev-components-nat-trans A B f g)
+    ( ev-components-nat-trans A B f g
+    , is-equiv-ev-components-nat-trans A B f g)
 ```
 
 ### Naturality square
@@ -269,29 +269,53 @@ type.
 #variable is-segal-A : is-segal A
 #variable α : (Δ¹×Δ¹) → A
 
-#def α00 : A := α (0₂,0₂)
-#def α01 : A := α (0₂,1₂)
-#def α10 : A := α (1₂,0₂)
-#def α11 : A := α (1₂,1₂)
+#def α00
+  : A
+  := α (0₂ , 0₂)
+#def α01
+  : A
+  := α (0₂ , 1₂)
+#def α10
+  : A
+  := α (1₂ , 0₂)
+#def α11
+  : A
+  := α (1₂ , 1₂)
 
-#def α0* : Δ¹ → A := \ t → α (0₂,t)
-#def α1* : Δ¹ → A := \ t → α (1₂,t)
-#def α*0 : Δ¹ → A := \ s → α (s,0₂)
-#def α*1 : Δ¹ → A := \ s → α (s,1₂)
-#def α-diag : Δ¹ → A := \ s → α (s,s)
+#def α0*
+  : Δ¹ → A
+  := \ t → α (0₂ , t)
+#def α1*
+  : Δ¹ → A
+  := \ t → α (1₂ , t)
+#def α*0
+  : Δ¹ → A
+  := \ s → α (s , 0₂)
+#def α*1
+  : Δ¹ → A
+  := \ s → α (s , 1₂)
+#def α-diag
+  : Δ¹ → A
+  := \ s → α (s , s)
 
-#def lhs uses (α) : Δ¹ → A := comp-is-segal A is-segal-A α00 α01 α11 α0* α*1
-#def rhs uses (α) : Δ¹ → A := comp-is-segal A is-segal-A α00 α10 α11 α*0 α1*
+#def lhs uses (α)
+  : Δ¹ → A
+  := comp-is-segal A is-segal-A α00 α01 α11 α0* α*1
+#def rhs uses (α)
+  : Δ¹ → A
+  := comp-is-segal A is-segal-A α00 α10 α11 α*0 α1*
 
-#def lower-triangle-square : hom2 A α00 α01 α11 α0* α*1 α-diag
-  := \ (s, t) → α (t,s)
+#def lower-triangle-square
+  : hom2 A α00 α01 α11 α0* α*1 α-diag
+  := \ (s , t) → α (t , s)
 
-#def upper-triangle-square : hom2 A α00 α10 α11 α*0 α1* α-diag
-  := \ (s,t) → α (s,t)
+#def upper-triangle-square
+  : hom2 A α00 α10 α11 α*0 α1* α-diag
+  := \ (s , t) → α (s , t)
 
 #def comp-eq-square-is-segal uses (α)
-  : comp-is-segal A is-segal-A α00 α01 α11 α0* α*1 =
-    comp-is-segal A is-segal-A α00 α10 α11 α*0 α1*
+  : comp-is-segal A is-segal-A α00 α01 α11 α0* α*1
+  = comp-is-segal A is-segal-A α00 α10 α11 α*0 α1*
   :=
     zig-zag-concat (hom A α00 α11) lhs α-diag rhs
     ( uniqueness-comp-is-segal A is-segal-A α00 α01 α11 α0* α*1 α-diag
@@ -308,19 +332,19 @@ is a Segal type.
 
 ```rzk title="RS17, Proposition 6.6"
 #def naturality-nat-trans-is-segal
-  (A B : U)
-  (is-segal-B : is-segal B)
-  (f g : A → B)
-  (α : nat-trans A (\ _ → B) f g)
-  (x y : A)
-  (k : hom A x y)
+  ( A B : U)
+  ( is-segal-B : is-segal B)
+  ( f g : A → B)
+  ( α : nat-trans A (\ _ → B) f g)
+  ( x y : A)
+  ( k : hom A x y)
   : comp-is-segal B is-segal-B (f x) (f y) (g y)
     ( ap-hom A B f x y k)
-    ( \ s → α s y) =
-    comp-is-segal B is-segal-B (f x) (g x) (g y)
+    ( \ s → α s y)
+  = comp-is-segal B is-segal-B (f x) (g x) (g y)
     ( \ s → α s x)
     ( ap-hom A B g x y k)
-  := comp-eq-square-is-segal B is-segal-B (\ (s,t) → α s (k t))
+  := comp-eq-square-is-segal B is-segal-B (\ (s , t) → α s (k t))
 ```
 
 ### Vertical composition
@@ -366,8 +390,8 @@ The components of the identity natural transformation are identity arrows.
   ( B : A → U)
   ( f : (x : A) → (B x))
   ( a : A)
-  : (ev-components-nat-trans A B f f (id-hom ((x : A) → B x) f)) a =
-    id-hom (B a) (f a)
+  : ( ev-components-nat-trans A B f f (id-hom ((x : A) → B x) f)) a
+  = id-hom (B a) (f a)
   := refl
 ```
 
@@ -386,14 +410,14 @@ components of the natural transformation defined by composing in the Segal type
   ( a : A)
   : ( comp-is-segal (B a) (is-segal-B a) (f a) (g a) (h a)
       ( ev-components-nat-trans A B f g α a)
-      ( ev-components-nat-trans A B g h β a)) =
-    ( ev-components-nat-trans A B f h
+      ( ev-components-nat-trans A B g h β a))
+  = ( ev-components-nat-trans A B f h
       ( comp-is-segal
-        ( (x : A) → B x) ( is-segal-function-type (funext) (A) (B) (is-segal-B))
+        ( ( x : A) → B x) (is-segal-function-type (funext) (A) (B) (is-segal-B))
         ( f) (g) (h) (α) (β))) a
   :=
     functors-pres-comp
-    ( (x : A) → (B x)) (B a)
+    ( ( x : A) → (B x)) (B a)
     ( is-segal-function-type (funext) (A) (B) (is-segal-B)) (is-segal-B a)
     ( \ s → s a) (f) (g) (h) (α) (β)
 ```
@@ -474,7 +498,7 @@ the "Gray interchanger" built from two commutative triangles.
   ( η : nat-trans A (\ _ → B) f g)
   ( η' : nat-trans B (\ _ → C) f' g')
   : Δ¹×Δ¹ → (A → C)
-  := \ (t, s) a → η' s (η t a)
+  := \ (t , s) a → η' s (η t a)
 
 #def left-gray-interchanger-horizontal-comp-nat-trans
   ( A B C : U)
@@ -486,7 +510,7 @@ the "Gray interchanger" built from two commutative triangles.
     ( postwhisker-nat-trans A B C f g f' η)
     ( prewhisker-nat-trans A B C g f' g' η')
     ( horizontal-comp-nat-trans A B C f g f' g' η η')
-  := \ (t, s) a → η' s (η t a)
+  := \ (t , s) a → η' s (η t a)
 
 #def right-gray-interchanger-horizontal-comp-nat-trans
   ( A B C : U)
@@ -498,7 +522,7 @@ the "Gray interchanger" built from two commutative triangles.
     ( prewhisker-nat-trans A B C f f' g' η')
     ( postwhisker-nat-trans A B C f g g' η)
     ( horizontal-comp-nat-trans A B C f g f' g' η η')
-  := \ (t, s) a → η' t (η s a)
+  := \ (t , s) a → η' t (η s a)
 ```
 
 ## Equivalences are fully faithful
@@ -516,7 +540,7 @@ that `#!rzk ap-hom` is an equivalence when f is an equivalence.
   : is-equiv (hom A x y) (hom B (f x) (f y)) (ap-hom A B f x y)
   :=
     is-equiv-extensions-is-equiv extext 2 Δ¹ ∂Δ¹
-    ( \ _ → A) ( \ _ → B)
+    ( \ _ → A) (\ _ → B)
     ( \ _ → f)
     ( \ t → recOR (t ≡ 0₂ ↦ x , t ≡ 1₂ ↦ y))
     ( \ _ → is-equiv-f)
@@ -543,7 +567,7 @@ More precicely:
   : is-contr (fiber-ap-hom A B x y f β)
   :=
     is-contr-fiber-postcomp-Π-ext-is-equiv-fam extext 2 Δ¹ ∂Δ¹
-    ( \ _ → A) ( \ _ → B)
+    ( \ _ → A) (\ _ → B)
     ( \ _ → f)
     ( \ t → recOR (t ≡ 0₂ ↦ x , t ≡ 1₂ ↦ y))
     ( β)
@@ -561,7 +585,7 @@ We can also define a retraction of `#!rzk ap-hom` directly.
   : has-retraction (hom A x y) (hom B (f x) (f y)) (ap-hom A B f x y)
   :=
     has-retraction-extensions-has-retraction extext 2 Δ¹ ∂Δ¹
-    ( \ _ → A) ( \ _ → B)
+    ( \ _ → A) (\ _ → B)
     ( \ _ → f)
     ( \ _ → has-retraction-f)
     ( \ t → recOR (t ≡ 0₂ ↦ x , t ≡ 1₂ ↦ y))

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -76,7 +76,7 @@ First ot all, note that we have two section-retraction pairs
 ```rzk
 #def is-section-retraction-0-Δ¹-0
   : is-section-retraction-pair
-    ( A) ( Δ¹ → A) ( (t : 2 | Δ¹ t ∧ t ≡ 0₂) → A)
+    ( A) (Δ¹ → A) ((t : 2 | Δ¹ t ∧ t ≡ 0₂) → A)
     ( \ a _ → a) (\ τ t → τ t)
   :=
     ( ( \ σ → σ 0₂ , \ _ → refl)
@@ -84,7 +84,7 @@ First ot all, note that we have two section-retraction pairs
 
 #def is-section-retraction-1-Δ¹-1
   : is-section-retraction-pair
-    ( A) ( Δ¹ → A) ( (t : 2 | Δ¹ t ∧ t ≡ 1₂) → A)
+    ( A) (Δ¹ → A) ((t : 2 | Δ¹ t ∧ t ≡ 1₂) → A)
     ( \ a _ → a) (\ τ t → τ t)
   :=
     ( ( \ σ → σ 1₂ , \ _ → refl)
@@ -99,7 +99,7 @@ to each other.
   : is-Δ¹-local → is-left-local
   :=
     is-equiv-retraction-is-equiv-section-is-section-retraction-pair
-      ( A) ( Δ¹ → A) ( (t : 2 | Δ¹ t ∧ t ≡ 0₂) → A)
+      ( A) (Δ¹ → A) ((t : 2 | Δ¹ t ∧ t ≡ 0₂) → A)
       ( \ a _ → a) (\ τ t → τ t)
     ( is-section-retraction-0-Δ¹-0)
 
@@ -107,7 +107,7 @@ to each other.
   : is-left-local → is-Δ¹-local
   :=
     is-equiv-section-is-equiv-retraction-is-section-retraction-pair
-      ( A) ( Δ¹ → A) ( (t : 2 | Δ¹ t ∧ t ≡ 0₂) → A)
+      ( A) (Δ¹ → A) ((t : 2 | Δ¹ t ∧ t ≡ 0₂) → A)
       ( \ a _ → a) (\ τ t → τ t)
     ( is-section-retraction-0-Δ¹-0)
 
@@ -115,7 +115,7 @@ to each other.
   : is-Δ¹-local → is-right-local
   :=
     is-equiv-retraction-is-equiv-section-is-section-retraction-pair
-      ( A) ( Δ¹ → A) ( (t : 2 | Δ¹ t ∧ t ≡ 1₂) → A)
+      ( A) (Δ¹ → A) ((t : 2 | Δ¹ t ∧ t ≡ 1₂) → A)
       ( \ a _ → a) (\ τ t → τ t)
     ( is-section-retraction-1-Δ¹-1)
 
@@ -123,7 +123,7 @@ to each other.
   : is-right-local → is-Δ¹-local
   :=
     is-equiv-section-is-equiv-retraction-is-section-retraction-pair
-      ( A) ( Δ¹ → A) ( (t : 2 | Δ¹ t ∧ t ≡ 1₂) → A)
+      ( A) (Δ¹ → A) ((t : 2 | Δ¹ t ∧ t ≡ 1₂) → A)
       ( \ a _ → a) (\ τ t → τ t)
     ( is-section-retraction-1-Δ¹-1)
 ```
@@ -136,10 +136,10 @@ and the total map of the family `\ (a, b) → hom-eq a b : a = b → hom A a b` 
 ```rzk
 #def equiv-of-maps-total-map-hom-eq-const-Δ¹
   : Equiv-of-maps
-    ( A) ( Δ¹ → A)
+    ( A) (Δ¹ → A)
     ( \ a _ → a)
-    ( free-paths A) ( fibered-arr' A)
-    ( \ ((a,b), p) → ((a,b), hom-eq A a b p))
+    ( free-paths A) (fibered-arr' A)
+    ( \ ((a , b) , p) → ((a , b) , hom-eq A a b p))
   :=
   ( ( ( constant-free-path A
       , fibered-arr-free-arr' A)
@@ -156,29 +156,29 @@ equivalences of maps and when passing to/from total types.
   ( is-discrete-A : is-discrete A)
   : is-Δ¹-local
   :=
-    is-equiv-Equiv-is-equiv ( A) ( Δ¹ → A) ( \ a _ → a)
-      ( free-paths A) ( fibered-arr' A)
-      ( \ ((a,b), p) → ((a,b), hom-eq A a b p))
+    is-equiv-Equiv-is-equiv (A) (Δ¹ → A) (\ a _ → a)
+      ( free-paths A) (fibered-arr' A)
+      ( \ ((a , b) , p) → ((a , b) , hom-eq A a b p))
     ( equiv-of-maps-total-map-hom-eq-const-Δ¹)
     ( is-equiv-total-is-equiv-fiberwise
-        ( product A A) ( \ (a,b) → a = b) ( \ (a,b) → hom A a b)
-      ( \ (a,b) → hom-eq A a b)
-      ( \ (a,b) → is-discrete-A a b))
+        ( product A A) (\ (a , b) → a = b) (\ (a , b) → hom A a b)
+      ( \ (a , b) → hom-eq A a b)
+      ( \ (a , b) → is-discrete-A a b))
 
 #def is-discrete-is-Δ¹-local
   ( is-Δ¹-local-A : is-Δ¹-local)
   : is-discrete A
   :=
   \ a b →
-    ( is-equiv-fiberwise-is-equiv-total ( product A A) ( \ (a,b) → a = b)
-        ( \ (a,b) → hom A a b)
-      ( \ (a,b) → hom-eq A a b)
-      ( is-equiv-Equiv-is-equiv' ( A) ( Δ¹ → A) ( \ a _ → a)
-          ( free-paths A) ( fibered-arr' A)
-          ( \ ((a,b), p) → ((a,b), hom-eq A a b p))
+    ( is-equiv-fiberwise-is-equiv-total (product A A) (\ (a , b) → a = b)
+        ( \ (a , b) → hom A a b)
+      ( \ (a , b) → hom-eq A a b)
+      ( is-equiv-Equiv-is-equiv' (A) (Δ¹ → A) (\ a _ → a)
+          ( free-paths A) (fibered-arr' A)
+          ( \ ((a , b) , p) → ((a , b) , hom-eq A a b p))
         ( equiv-of-maps-total-map-hom-eq-const-Δ¹)
-        (is-Δ¹-local-A)))
-    ( a, b)
+        ( is-Δ¹-local-A)))
+    ( a , b)
 
 #end discrete-types-alternative
 ```
@@ -198,8 +198,8 @@ of discrete types is discrete.
   :=
     equiv-triple-comp
       ( f = g)
-      ( (x : X) → f x = g x)
-      ( (x : X) → hom (A x) (f x) (g x))
+      ( ( x : X) → f x = g x)
+      ( ( x : X) → hom (A x) (f x) (g x))
       ( hom ((x : X) → A x) f g)
       ( equiv-FunExt funext X A f g)
       ( equiv-function-equiv-family funext X
@@ -220,15 +220,15 @@ of discrete types is discrete.
   ( is-discrete-A : (x : X) → is-discrete (A x))
   ( f g : (x : X) → A x)
   ( h : f = g)
-  : ( hom-eq ((x : X) → A x) f g h) =
-    ( first (equiv-hom-eq-function-type-is-discrete X A is-discrete-A f g)) h
+  : ( hom-eq ((x : X) → A x) f g h)
+  = ( first (equiv-hom-eq-function-type-is-discrete X A is-discrete-A f g)) h
   :=
     ind-path
-      ( (x : X) → A x)
+      ( ( x : X) → A x)
       ( f)
       ( \ g' h' →
-        hom-eq ((x : X) → A x) f g' h' =
-        (first (equiv-hom-eq-function-type-is-discrete X A is-discrete-A f g')) h')
+        hom-eq ((x : X) → A x) f g' h'
+      = ( first (equiv-hom-eq-function-type-is-discrete X A is-discrete-A f g')) h')
       ( refl)
       ( g)
       ( h)
@@ -265,8 +265,8 @@ is discrete.
   :=
     equiv-triple-comp
       ( f = g)
-      ( (t : ψ) → f t = g t)
-      ( (t : ψ) → hom (A t) (f t) (g t))
+      ( ( t : ψ) → f t = g t)
+      ( ( t : ψ) → hom (A t) (f t) (g t))
       ( hom ((t : ψ) → A t) f g)
       ( equiv-ExtExt extext I ψ (\ _ → BOT) A (\ _ → recBOT) f g)
       ( equiv-extensions-equiv extext I ψ (\ _ → BOT)
@@ -291,15 +291,15 @@ is discrete.
   ( is-discrete-A : (t : ψ) → is-discrete (A t))
   ( f g : (t : ψ) → A t)
   ( h : f = g)
-  : ( hom-eq ((t : ψ) → A t) f g h) =
-    ( first (equiv-hom-eq-extension-type-is-discrete I ψ A is-discrete-A f g)) h
+  : ( hom-eq ((t : ψ) → A t) f g h)
+  = ( first (equiv-hom-eq-extension-type-is-discrete I ψ A is-discrete-A f g)) h
   :=
     ind-path
-      ( (t : ψ) → A t)
+      ( ( t : ψ) → A t)
       ( f)
       ( \ g' h' →
-        ( hom-eq ((t : ψ) → A t) f g' h') =
-        ( first (equiv-hom-eq-extension-type-is-discrete I ψ A is-discrete-A f g') h'))
+        ( hom-eq ((t : ψ) → A t) f g' h')
+      = ( first (equiv-hom-eq-extension-type-is-discrete I ψ A is-discrete-A f g') h'))
       ( refl)
       ( g)
       ( h)
@@ -369,13 +369,13 @@ we introduce covariant and contravariant type families.
   ( A' A : U)
   ( α : A' → A)
   : U
-  := is-right-orthogonal-to-shape 2 Δ¹ ( \ s → s ≡ 0₂) A' A α
+  := is-right-orthogonal-to-shape 2 Δ¹ (\ s → s ≡ 0₂) A' A α
 
 #def is-right-fibration
   ( A' A : U)
   ( α : A' → A)
   : U
-  := is-right-orthogonal-to-shape 2 Δ¹ ( \ s → s ≡ 1₂) A' A α
+  := is-right-orthogonal-to-shape 2 Δ¹ (\ s → s ≡ 1₂) A' A α
 ```
 
 ### Left and right anodyne shape inclusions
@@ -386,14 +386,14 @@ we introduce covariant and contravariant type families.
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   : U
-  := is-anodyne-for-shape 2 Δ¹ ( \ s → s ≡ 0₂) I ψ ϕ
+  := is-anodyne-for-shape 2 Δ¹ (\ s → s ≡ 0₂) I ψ ϕ
 
 #def is-right-anodyne
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( ϕ : ψ → TOPE)
   : U
-  := is-anodyne-for-shape 2 Δ¹ ( \ s → s ≡ 1₂) I ψ ϕ
+  := is-anodyne-for-shape 2 Δ¹ (\ s → s ≡ 1₂) I ψ ϕ
 ```
 
 ### Left fibrations are inner fibrations
@@ -406,8 +406,8 @@ The first step is to identify the pair `{0} ⊂ Δ¹` with the pair of subshapes
 
 ```rzk
 #def is-left-anodyne-1-right-leg-of-Λ
-  : is-left-anodyne ( 2 × 2)
-    (\ ts → right-leg-of-Λ ts) ( \ (_,s) → s ≡ 0₂)
+  : is-left-anodyne (2 × 2)
+    ( \ ts → right-leg-of-Λ ts) (\ (_ , s) → s ≡ 0₂)
   :=
   \ A' A α →
   is-right-orthogonal-to-shape-isomorphism A' A α
@@ -420,16 +420,17 @@ Next we use that `Λ` is the pushout of its left leg and its right leg to deduce
 that the pair `left-leg-of-Λ ⊂ Λ` is left anodyne.
 
 ```rzk
-#def left-leg-of-Λ : Λ → TOPE
-  := \ (t, s) → s ≡ 0₂
+#def left-leg-of-Λ
+  : Λ → TOPE
+  := \ (t , s) → s ≡ 0₂
 
 #def is-left-anodyne-left-leg-of-Λ-Λ
-  : is-left-anodyne ( 2 × 2)
-    ( \ ts → Λ ts) ( \ ts → left-leg-of-Λ ts)
+  : is-left-anodyne (2 × 2)
+    ( \ ts → Λ ts) (\ ts → left-leg-of-Λ ts)
   :=
   \ A' A α is-left-fib-α →
     is-right-orthogonal-to-shape-pushout A' A α
-    ( 2 × 2) ( \ ts → right-leg-of-Λ ts) (\ ts → left-leg-of-Λ ts)
+    ( 2 × 2) (\ ts → right-leg-of-Λ ts) (\ ts → left-leg-of-Λ ts)
     ( is-left-anodyne-1-right-leg-of-Λ A' A α is-left-fib-α)
 ```
 
@@ -438,12 +439,12 @@ Furthermore, we observe that the pair `left-leg-of-Δ ⊂ Δ¹×Δ¹` is the pro
 
 ```rzk
 #def is-left-anodyne-left-leg-of-Λ-Δ¹×Δ¹ uses (extext)
-  : is-left-anodyne ( 2 × 2)
-    ( \ ts → Δ¹×Δ¹ ts) ( \ ts → left-leg-of-Λ ts)
+  : is-left-anodyne (2 × 2)
+    ( \ ts → Δ¹×Δ¹ ts) (\ ts → left-leg-of-Λ ts)
   :=
   \ A' A α →
     is-right-orthogonal-to-shape-product extext A' A α
-      2 Δ¹ 2 Δ¹ ( \ s → s ≡ 0₂)
+      2 Δ¹ 2 Δ¹ (\ s → s ≡ 0₂)
 ```
 
 Next, we use the left cancellation of left anodyne shape inclusions to deduce
@@ -451,11 +452,11 @@ that `Λ ⊂ Δ¹×Δ¹` is left anodyne.
 
 ```rzk
 #def is-left-anodyne-Λ-Δ¹×Δ¹ uses (extext)
-  : is-left-anodyne ( 2 × 2)
-    ( \ ts → Δ¹×Δ¹ ts) ( \ ts → Λ ts)
+  : is-left-anodyne (2 × 2)
+    ( \ ts → Δ¹×Δ¹ ts) (\ ts → Λ ts)
   :=
   is-anodyne-left-cancel-for-shape 2 Δ¹ (\ t → t ≡ 0₂)
-  ( 2 × 2) ( \ ts → Δ¹×Δ¹ ts) ( \ ts → Λ ts) ( \ ts → left-leg-of-Λ ts)
+  ( 2 × 2) (\ ts → Δ¹×Δ¹ ts) (\ ts → Λ ts) (\ ts → left-leg-of-Λ ts)
   ( is-left-anodyne-left-leg-of-Λ-Λ)
   ( is-left-anodyne-left-leg-of-Λ-Δ¹×Δ¹)
 ```
@@ -469,7 +470,7 @@ desired left anodyne shape inclusion `Λ ⊂ Δ²`.
     Δ² (\ t → Λ t)
   :=
   is-anodyne-right-cancel-retract-for-shape 2 Δ¹ (\ t → t ≡ 0₂)
-  ( 2 × 2) ( \ ts → Δ¹×Δ¹ ts) ( \ ts → Δ² ts) ( \ ts → Λ ts)
+  ( 2 × 2) (\ ts → Δ¹×Δ¹ ts) (\ ts → Δ² ts) (\ ts → Λ ts)
   ( is-functorial-retract-Δ²-Δ¹×Δ¹)
   ( is-left-anodyne-Λ-Δ¹×Δ¹)
 ```
@@ -500,7 +501,7 @@ type, then so is `A'`.
   :=
     is-segal-is-local-horn-inclusion A'
       ( is-local-type-right-orthogonal-is-local-type
-        ( 2 × 2) Δ² ( \ ts → Λ ts) A' A α
+        ( 2 × 2) Δ² (\ ts → Λ ts) A' A α
         ( is-inner-fibration-is-left-fibration A' A α is-left-fib-α)
         ( is-local-horn-inclusion-is-segal A is-segal-A))
 ```
@@ -517,7 +518,7 @@ Another immediate corollary is that every discrete type is Segal.
   \ is-discrete-A →
   ( is-segal-has-unique-inner-extensions A
     ( is-weak-anodyne-is-anodyne-for-shape extext
-      ( 2) (Δ¹) (\ t → t ≡ 0₂) ( 2 × 2) (Δ²) (\ t → Λ t)
+      ( 2) (Δ¹) (\ t → t ≡ 0₂) (2 × 2) (Δ²) (\ t → Λ t)
       ( is-left-anodyne-Λ-Δ²)
       ( A)
       ( has-unique-extensions-is-local-type 2 Δ¹ (\ t → t ≡ 0₂) A
@@ -551,19 +552,19 @@ might still be of use.
 #def equiv-square-hom-arr
   : Equiv
       ( hom (arr A) f g)
-      ( Σ ( h : hom A x z) ,
-          ( Σ ( k : hom A y w) ,
-              ( ( (t , s) : Δ¹×Δ¹) →
-                A [ t ≡ 0₂ ∧ Δ¹ s ↦ f s ,
-                    t ≡ 1₂ ∧ Δ¹ s ↦ g s ,
-                    Δ¹ t ∧ s ≡ 0₂ ↦ h t ,
-                    Δ¹ t ∧ s ≡ 1₂ ↦ k t])))
+      ( Σ ( h : hom A x z)
+        , ( Σ ( k : hom A y w)
+            , ( ( ( t , s) : Δ¹×Δ¹)
+              → A [ t ≡ 0₂ ∧ Δ¹ s ↦ f s
+                  , t ≡ 1₂ ∧ Δ¹ s ↦ g s
+                  , Δ¹ t ∧ s ≡ 0₂ ↦ h t
+                  , Δ¹ t ∧ s ≡ 1₂ ↦ k t])))
   :=
     ( \ α →
-      ( ( \ t → α t 0₂) ,
-        ( ( \ t → α t 1₂) , (\ (t , s) → α t s))) ,
-      ( ( ( \ σ t s → (second (second σ)) (t , s)) , (\ α → refl)) ,
-        ( ( \ σ t s → (second (second σ)) (t , s)) , (\ σ → refl))))
+      ( ( \ t → α t 0₂)
+      , ( ( \ t → α t 1₂) , (\ (t , s) → α t s)))
+    , ( ( ( \ σ t s → (second (second σ)) (t , s)) , (\ α → refl))
+      , ( ( \ σ t s → (second (second σ)) (t , s)) , (\ σ → refl))))
 ```
 
 ```rzk
@@ -573,14 +574,14 @@ might still be of use.
       ( fibered-arr-free-arr A f = fibered-arr-free-arr A g)
       ( ap
         ( arr A)
-        ( Σ (u : A) , (Σ (v : A) , (hom A u v)))
+        ( Σ ( u : A) , (Σ (v : A) , (hom A u v)))
         ( f)
         ( g)
         ( fibered-arr-free-arr A))
   :=
     is-emb-is-equiv
       ( arr A)
-      ( Σ (u : A) , (Σ (v : A) , (hom A u v)))
+      ( Σ ( u : A) , (Σ (v : A) , (hom A u v)))
       ( fibered-arr-free-arr A)
       ( is-equiv-fibered-arr-free-arr A)
       ( f)
@@ -591,7 +592,7 @@ might still be of use.
   :=
     equiv-ap-is-equiv
       ( arr A)
-      ( Σ (u : A) , (Σ (v : A) , (hom A u v)))
+      ( Σ ( u : A) , (Σ (v : A) , (hom A u v)))
       ( fibered-arr-free-arr A)
       ( is-equiv-fibered-arr-free-arr A)
       ( f)
@@ -600,9 +601,9 @@ might still be of use.
 #def equiv-sigma-over-product-hom-eq
   : Equiv
       ( fibered-arr-free-arr A f = fibered-arr-free-arr A g)
-      ( Σ ( p : x = z) ,
-          ( Σ ( q : y = w) ,
-              ( product-transport A A (hom A) x z y w p q f = g)))
+      ( Σ ( p : x = z)
+        , ( Σ ( q : y = w)
+            , ( product-transport A A (hom A) x z y w p q f = g)))
   :=
     extensionality-Σ-over-product
       ( A) (A)
@@ -612,47 +613,47 @@ might still be of use.
 
 #def equiv-square-sigma-over-product uses (extext is-discrete-A)
   : Equiv
-    ( Σ ( p : x = z) ,
-        ( Σ (q : y = w) ,
-            ( product-transport A A (hom A) x z y w p q f = g)))
-    ( Σ ( h : hom A x z) ,
-        ( Σ ( k : hom A y w) ,
-            ( ((t , s) : Δ¹×Δ¹) →
-              A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                  (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                  (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
-                  (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
+    ( Σ ( p : x = z)
+      , ( Σ ( q : y = w)
+          , ( product-transport A A (hom A) x z y w p q f = g)))
+    ( Σ ( h : hom A x z)
+      , ( Σ ( k : hom A y w)
+          , ( ( ( t , s) : Δ¹×Δ¹)
+            → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+                , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+                , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ h t
+                , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
   :=
     equiv-left-cancel
       ( f =_{Δ¹ → A} g)
-      ( Σ ( p : x = z) ,
-          ( Σ ( q : y = w) ,
-              ( product-transport A A (hom A) x z y w p q f = g)))
-      ( Σ ( h : hom A x z) ,
-          ( Σ ( k : hom A y w) ,
-              ( ((t , s) : Δ¹×Δ¹) →
-                A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                    (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                    (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
-                    (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
+      ( Σ ( p : x = z)
+        , ( Σ ( q : y = w)
+            , ( product-transport A A (hom A) x z y w p q f = g)))
+      ( Σ ( h : hom A x z)
+        , ( Σ ( k : hom A y w)
+            , ( ( ( t , s) : Δ¹×Δ¹)
+              → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+                  , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+                  , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ h t
+                  , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
       ( equiv-comp
         ( f =_{Δ¹ → A} g)
         ( fibered-arr-free-arr A f = fibered-arr-free-arr A g)
-        ( Σ ( p : x = z) ,
-            ( Σ ( q : y = w) ,
-                ( product-transport A A (hom A) x z y w p q f = g)))
+        ( Σ ( p : x = z)
+          , ( Σ ( q : y = w)
+              , ( product-transport A A (hom A) x z y w p q f = g)))
         equiv-eq-fibered-arr-eq-free-arr
         equiv-sigma-over-product-hom-eq)
       ( equiv-comp
         ( f =_{Δ¹ → A} g)
         ( hom (arr A) f g)
-        ( Σ ( h : hom A x z) ,
-            ( Σ ( k : hom A y w) ,
-                ( ( (t , s) : Δ¹×Δ¹) →
-                  A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                      (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                      (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
-                      (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
+        ( Σ ( h : hom A x z)
+          , ( Σ ( k : hom A y w)
+              , ( ( ( t , s) : Δ¹×Δ¹)
+                → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+                    , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+                    , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ h t
+                    , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
         ( equiv-hom-eq-discrete)
         ( equiv-square-hom-arr))
 ```
@@ -670,45 +671,45 @@ We close the section so we can use path induction.
   ( f : hom A x y)
   ( p : x = z)
   ( q : y = w)
-  : ( g : hom A z w) →
-    ( product-transport A A (hom A) x z y w p q f = g) →
-    ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ (hom-eq A x z p) t ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w q) t])
+  : ( g : hom A z w)
+  → ( product-transport A A (hom A) x z y w p q f = g)
+  → ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ (hom-eq A x z p) t
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w q) t])
   :=
     ind-path
       ( A)
       ( x)
       ( \ z' p' →
-        ( g : hom A z' w) →
-        ( product-transport A A (hom A) x z' y w p' q f = g) →
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ (hom-eq A x z' p') t ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w q) t]))
+        ( g : hom A z' w)
+      → ( product-transport A A (hom A) x z' y w p' q f = g)
+      → ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ (hom-eq A x z' p') t
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w q) t]))
       ( ind-path
         ( A)
         ( y)
         ( \ w' q' →
-          ( g : hom A x w') →
-          ( product-transport A A (hom A) x x y w' refl q' f = g) →
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w' q') t]))
+          ( g : hom A x w')
+        → ( product-transport A A (hom A) x x y w' refl q' f = g)
+        → ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w' q') t]))
         ( ind-path
           ( hom A x y)
           ( f)
           ( \ g' τ' →
-            ( ( (t , s) : Δ¹×Δ¹) →
-              A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                  (t ≡ 1₂) ∧ (Δ¹ s) ↦ g' s ,
-                  (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                  (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+            ( ( ( t , s) : Δ¹×Δ¹)
+            → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+                , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g' s
+                , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+                , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
           ( \ (t , s) → f s))
         ( w)
         ( q))
@@ -721,20 +722,20 @@ We close the section so we can use path induction.
   ( f : hom A x y)
   ( g : hom A z w)
   ( ( p , (q , τ)) :
-    ( Σ ( p : x = z) ,
-        ( Σ ( q : y = w) ,
-            ( product-transport A A (hom A) x z y w p q f = g))))
-  : Σ ( h : hom A x z) ,
-      ( Σ ( k : hom A y w) ,
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t]))
+    ( Σ ( p : x = z)
+      , ( Σ ( q : y = w)
+          , ( product-transport A A (hom A) x z y w p q f = g))))
+  : Σ ( h : hom A x z)
+    , ( Σ ( k : hom A y w)
+        , ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ h t
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ k t]))
   :=
-    ( ( hom-eq A x z p) ,
-      ( ( hom-eq A y w q) ,
-        ( fibered-map-square-sigma-over-product
+    ( ( hom-eq A x z p)
+    , ( ( hom-eq A y w q)
+      , ( fibered-map-square-sigma-over-product
           ( A)
           ( x) (y) (z) (w)
           ( f) (p) (q) (g)
@@ -748,8 +749,8 @@ We close the section so we can use path induction.
   ( τ : product-transport A A (hom A) x x y y refl refl f = g)
   : ( first
       ( equiv-square-sigma-over-product A is-discrete-A x y x y f g)
-      (refl , (refl , τ))) =
-    ( square-sigma-over-product
+      ( refl , (refl , τ)))
+  = ( square-sigma-over-product
       ( A)
       ( x) (y) (x) (y)
       ( f) (g)
@@ -761,8 +762,8 @@ We close the section so we can use path induction.
       ( \ g' τ' →
         ( first
           ( equiv-square-sigma-over-product A is-discrete-A x y x y f g')
-          ( refl , (refl , τ'))) =
-        ( square-sigma-over-product
+          ( refl , (refl , τ')))
+      = ( square-sigma-over-product
           ( A)
           ( x) (y) (x) (y)
           ( f) (g')
@@ -778,36 +779,36 @@ We close the section so we can use path induction.
   ( f : hom A x y)
   ( p : x = z)
   ( q : y = w)
-  : ( g : hom A z w) →
-    ( τ : product-transport A A (hom A) x z y w p q f = g) →
-    ( first
+  : ( g : hom A z w)
+  → ( τ : product-transport A A (hom A) x z y w p q f = g)
+  → ( first
       ( equiv-square-sigma-over-product A is-discrete-A x y z w f g)
-      ( p , (q , τ))) =
-    ( square-sigma-over-product
+      ( p , (q , τ)))
+  = ( square-sigma-over-product
         A x y z w f g (p , (q , τ)))
   :=
     ind-path
       ( A)
       ( y)
       ( \ w' q' →
-        ( g : hom A z w') →
-        ( τ : product-transport A A (hom A) x z y w' p q' f = g) →
-        ( first
+        ( g : hom A z w')
+      → ( τ : product-transport A A (hom A) x z y w' p q' f = g)
+      → ( first
           ( equiv-square-sigma-over-product
               A is-discrete-A x y z w' f g))
-          ( p , (q' , τ)) =
-        ( square-sigma-over-product A x y z w' f g)
+          ( p , (q' , τ))
+      = ( square-sigma-over-product A x y z w' f g)
           ( p , (q' , τ)))
       ( ind-path
         ( A)
         ( x)
         ( \ z' p' →
-          ( g : hom A z' y) →
-          ( τ : product-transport A A (hom A) x z' y y p' refl f = g) →
-          ( first
+          ( g : hom A z' y)
+        → ( τ : product-transport A A (hom A) x z' y y p' refl f = g)
+        → ( first
             ( equiv-square-sigma-over-product A is-discrete-A x y z' y f g)
-            ( p' , (refl , τ))) =
-          ( square-sigma-over-product A x y z' y f g (p' , (refl , τ))))
+            ( p' , (refl , τ)))
+        = ( square-sigma-over-product A x y z' y f g (p' , (refl , τ))))
         ( refl-refl-map-equiv-square-sigma-over-product
             ( A) (is-discrete-A) (x) (y) (f))
         ( z)
@@ -822,29 +823,29 @@ We close the section so we can use path induction.
   ( f : hom A x y)
   ( g : hom A z w)
   : is-equiv
-    ( Σ ( p : x = z) ,
-        ( Σ ( q : y = w) ,
-            ( product-transport A A (hom A) x z y w p q f = g)))
-    ( Σ ( h : hom A x z) ,
-        ( Σ ( k : hom A y w) ,
-            ( ( (t , s) : Δ¹×Δ¹) →
-              A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                  (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                  (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
-                  (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
+    ( Σ ( p : x = z)
+      , ( Σ ( q : y = w)
+          , ( product-transport A A (hom A) x z y w p q f = g)))
+    ( Σ ( h : hom A x z)
+      , ( Σ ( k : hom A y w)
+          , ( ( ( t , s) : Δ¹×Δ¹)
+            → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+                , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+                , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ h t
+                , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
     ( square-sigma-over-product A x y z w f g)
   :=
     is-equiv-rev-homotopy
-    ( Σ ( p : x = z) ,
-        ( Σ ( q : y = w) ,
-            ( product-transport A A (hom A) x z y w p q f = g)))
-    ( Σ ( h : hom A x z) ,
-        ( Σ ( k : hom A y w) ,
-            ( ( (t , s) : Δ¹×Δ¹) →
-              A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                  (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                  (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
-                  (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
+    ( Σ ( p : x = z)
+      , ( Σ ( q : y = w)
+          , ( product-transport A A (hom A) x z y w p q f = g)))
+    ( Σ ( h : hom A x z)
+      , ( Σ ( k : hom A y w)
+          , ( ( ( t , s) : Δ¹×Δ¹)
+            → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+                , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+                , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ h t
+                , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ k t])))
     ( first (equiv-square-sigma-over-product A is-discrete-A x y z w f g))
     ( square-sigma-over-product A x y z w f g)
     ( \ (p , (q , τ)) →
@@ -861,11 +862,11 @@ We close the section so we can use path induction.
   ( q : y = w)
   : is-equiv
     ( product-transport A A (hom A) x z y w p q f = g)
-    ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ (hom-eq A x z p) t ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w q) t])
+    ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ (hom-eq A x z p) t
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ (hom-eq A y w q) t])
     ( fibered-map-square-sigma-over-product A x y z w f p q g)
   :=
     fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
@@ -875,11 +876,11 @@ We close the section so we can use path induction.
       ( hom A y w)
       ( \ p' q' → (product-transport A A (hom A) x z y w p' q' f) = g)
       ( \ h' k' →
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ h' t ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ k' t]))
+        ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ h' t
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ k' t]))
       ( hom-eq A x z)
       ( hom-eq A y w)
       ( \ p' q' →
@@ -903,12 +904,12 @@ We close the section so we can use path induction.
   ( f : hom A x y)
   ( g : hom A x y)
   : is-equiv
-    (f = g)
-    ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
+    ( f = g)
+    ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
     ( fibered-map-square-sigma-over-product
       A x y x y f refl refl g)
   :=
@@ -926,21 +927,21 @@ The previous calculations allow us to establish a family of equivalences:
   ( f : hom A x y)
   : is-equiv
     ( Σ ( g : hom A x y) , f = g)
-    ( Σ ( g : hom A x y) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+    ( Σ ( g : hom A x y)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
     ( total-map
       ( hom A x y)
       ( \ g → f = g)
       ( \ g →
-        ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
+        ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
       ( fibered-map-square-sigma-over-product
           A x y x y f refl refl))
   :=
@@ -948,11 +949,11 @@ The previous calculations allow us to establish a family of equivalences:
       ( hom A x y)
       ( \ g → f = g)
       ( \ g →
-        ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
+        ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
       ( fibered-map-square-sigma-over-product
           A x y x y f refl refl)
       ( \ g →
@@ -967,26 +968,26 @@ The previous calculations allow us to establish a family of equivalences:
   ( x y : A)
   ( f : hom A x y)
   : Equiv
-      ( Σ (g : hom A x y) , f = g)
-      ( Σ (g : hom A x y) ,
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+      ( Σ ( g : hom A x y) , f = g)
+      ( Σ ( g : hom A x y)
+        , ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
   :=
     ( ( total-map
         ( hom A x y)
         ( \ g → f = g)
         ( \ g →
-          ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
+          ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
         ( fibered-map-square-sigma-over-product
-            A x y x y f refl refl)) ,
-    is-equiv-sum-fibered-map-square-sigma-over-product-refl-refl
+            A x y x y f refl refl))
+  , is-equiv-sum-fibered-map-square-sigma-over-product-refl-refl
       A is-discrete-A x y f)
 ```
 
@@ -1000,21 +1001,21 @@ spaces, we conclude that the codomain extension type is contractible.
   ( x y : A)
   ( f : hom A x y)
   : is-contr
-    ( Σ ( g : hom A x y) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+    ( Σ ( g : hom A x y)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
   :=
     is-contr-equiv-is-contr
       ( Σ ( g : hom A x y) , f = g)
-      ( Σ ( g : hom A x y) ,
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+      ( Σ ( g : hom A x y)
+        , ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
       ( equiv-sum-fibered-map-square-sigma-over-product-refl-refl
           A is-discrete-A x y f)
       ( is-contr-based-paths (hom A x y) f)
@@ -1029,56 +1030,56 @@ The extension types that appear in the Segal condition are retracts of this type
   ( x y : A)
   ( f g : hom A x y)
   ( α : hom2 A x y y f (id-hom A y) g)
-  : ( (t , s) : Δ¹×Δ¹) →
-    A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-        (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-        (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-        (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]
+  : ( ( t , s) : Δ¹×Δ¹)
+  → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+      , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+      , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+      , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]
   := \ (t , s) → recOR (t ≤ s ↦ α (s , t) , s ≤ t ↦ g s)
 
 #def sigma-triangle-to-sigma-square-section
   ( A : U)
   ( x y : A)
   ( f : hom A x y)
-  ( (d , α) : Σ (d : hom A x y) , hom2 A x y y f (id-hom A y) d)
-  : Σ ( g : hom A x y) ,
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
-  := ( d , triangle-to-square-section A x y f d α)
+  ( ( d , α) : Σ (d : hom A x y) , hom2 A x y y f (id-hom A y) d)
+  : Σ ( g : hom A x y)
+    , ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y])
+  := (d , triangle-to-square-section A x y f d α)
 
 #def sigma-square-to-sigma-triangle-retraction
   ( A : U)
   ( x y : A)
   ( f : hom A x y)
-  ( (g , σ) :
-    Σ ( g : hom A x y) ,
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
-  : Σ (d : hom A x y) , (hom2 A x y y f (id-hom A y) d)
-  := ( (\ t → σ (t , t)) , (\ (t , s) → σ (s , t)))
+  ( ( g , σ) :
+    Σ ( g : hom A x y)
+    , ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+  : Σ ( d : hom A x y) , (hom2 A x y y f (id-hom A y) d)
+  := ((\ t → σ (t , t)) , (\ (t , s) → σ (s , t)))
 
 #def sigma-triangle-to-sigma-square-retract
   ( A : U)
   ( x y : A)
   ( f : hom A x y)
   : is-retract-of
-      ( Σ (d : hom A x y) , (hom2 A x y y f (id-hom A y) d))
-      ( Σ ( g : hom A x y) ,
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+      ( Σ ( d : hom A x y) , (hom2 A x y y f (id-hom A y) d))
+      ( Σ ( g : hom A x y)
+        , ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
   :=
-    ( ( sigma-triangle-to-sigma-square-section A x y f) ,
-      ( ( sigma-square-to-sigma-triangle-retraction A x y f) ,
-        ( \ dα → refl)))
+    ( ( sigma-triangle-to-sigma-square-section A x y f)
+    , ( ( sigma-square-to-sigma-triangle-retraction A x y f)
+      , ( \ dα → refl)))
 ```
 
 We can now verify the Segal condition in the case of composable pairs in which
@@ -1090,16 +1091,16 @@ the second arrow is an identity.
   ( is-discrete-A : is-discrete A)
   ( x y : A)
   ( f : hom A x y)
-  : is-contr ( Σ (d : hom A x y) , (hom2 A x y y f (id-hom A y) d))
+  : is-contr (Σ (d : hom A x y) , (hom2 A x y y f (id-hom A y) d))
   :=
     is-contr-is-retract-of-is-contr
       ( Σ ( d : hom A x y) , (hom2 A x y y f (id-hom A y) d))
-      ( Σ ( g : hom A x y) ,
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
+      ( Σ ( g : hom A x y)
+        , ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ g s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ x
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ y]))
       ( sigma-triangle-to-sigma-square-retract A x y f)
       ( is-contr-horn-refl-refl-extension-type A is-discrete-A x y f)
 ```
@@ -1123,7 +1124,7 @@ general case to the one just proven:
       ( \ w → hom A y w)
       ( \ w → hom-eq A y w)
       ( is-discrete-A y)
-      ( \ w d → is-contr ( Σ (h : hom A x w) , hom2 A x y w f d h))
+      ( \ w d → is-contr (Σ (h : hom A x w) , hom2 A x y w f d h))
       ( is-contr-hom2-with-id-is-discrete A is-discrete-A x y f)
       ( z)
       ( g)
@@ -1154,8 +1155,8 @@ Finally, we conclude:
     ( ap-hom A B f x y)
     ( hom-eq A x y)
     ( p)
-  =
-  comp (x = y) ((f x) = (f y)) (hom B (f x) (f y))
+
+  = comp (x = y) ((f x) = (f y)) (hom B (f x) (f y))
     ( hom-eq B (f x) (f y))
     ( ap A B x y f)
     ( p)
@@ -1166,8 +1167,8 @@ Finally, we conclude:
           ( ap-hom A B f x y')
           ( hom-eq A x y')
           ( p')
-        =
-        comp (x = y') ((f x) = (f y')) (hom B (f x) (f y'))
+
+      = comp (x = y') ((f x) = (f y')) (hom B (f x) (f y'))
           ( hom-eq B (f x) (f y'))
           ( ap A B x y' f)
           ( p'))

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -54,7 +54,7 @@ but varying codomain.
   ( C : A → U)
   ( u : C x)
   : U
-  := ( Σ (v : C y) , dhom A x y f C u v)
+  := (Σ (v : C y) , dhom A x y f C u v)
 ```
 
 There is also a type of dependent commutative triangles over a base commutative
@@ -77,10 +77,10 @@ triangle.
   ( hh : dhom A x z h C u w)
   : U
   :=
-    ( (t1 , t2) : Δ²) → C (α (t1 , t2)) [
-        t2 ≡ 0₂ ↦ ff t1 ,
-        t1 ≡ 1₂ ↦ gg t2 ,
-        t2 ≡ t1 ↦ hh t2
+    ( ( t1 , t2) : Δ²) → C (α (t1 , t2)) [
+        t2 ≡ 0₂ ↦ ff t1
+      , t1 ≡ 1₂ ↦ gg t2
+      , t2 ≡ t1 ↦ hh t2
       ]
 ```
 
@@ -95,13 +95,14 @@ unique lift with specified domain.
   ( C : A → U)
   : U
   :=
-    ( x : A) → (y : A) → (f : hom A x y) → (u : C x) →
-    is-contr (dhom-from A x y f C u)
+    ( x : A) → (y : A) → (f : hom A x y) → (u : C x)
+  → is-contr (dhom-from A x y f C u)
 ```
 
 ```rzk title="The type of covariant families over a fixed type"
-#def covariant-family (A : U) : U
-  := ( Σ (C : (A → U)) , is-covariant A C)
+#def covariant-family (A : U)
+  : U
+  := (Σ (C : (A → U)) , is-covariant A C)
 ```
 
 The notion of a covariant family is stable under substitution into the base.
@@ -126,8 +127,8 @@ contractibility of the type of extensions along the domain inclusion into the
   ( C : A → U)
   : U
   :=
-    ( x : A) → (y : A) → (f : hom A x y) → (u : C x) →
-    is-contr ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
+    ( x : A) → (y : A) → (f : hom A x y) → (u : C x)
+  → is-contr ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -143,12 +144,12 @@ here.
   ( f : hom A x y)
   ( u : C x)
   : Equiv
-      ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
-      (dhom-from A x y f C u)
+      ( ( t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
+      ( dhom-from A x y f C u)
   :=
-    ( \ h → (h 1₂ , \ t → h t) ,
-      ( ( \ fg t → (second fg) t , \ h → refl) ,
-        ( ( \ fg t → (second fg) t , \ h → refl))))
+    ( \ h → (h 1₂ , \ t → h t)
+    , ( ( \ fg t → (second fg) t , \ h → refl)
+      , ( ( \ fg t → (second fg) t , \ h → refl))))
 ```
 
 By the equivalence-invariance of contractibility, this proves the desired
@@ -158,11 +159,11 @@ logical equivalence
 #def is-covariant-has-unique-fixed-domain-lifts
   ( A : U)
   ( C : A → U)
-  : (has-unique-fixed-domain-lifts A C) → ( is-covariant A C)
+  : ( has-unique-fixed-domain-lifts A C) → (is-covariant A C)
   :=
     \ C-has-unique-lifts x y f u →
       is-contr-equiv-is-contr
-        ( (t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
+        ( ( t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( C-has-unique-lifts x y f u)
@@ -170,11 +171,11 @@ logical equivalence
 #def has-unique-fixed-domain-lifts-is-covariant
   ( A : U)
   ( C : A → U)
-  : (is-covariant A C) → (has-unique-fixed-domain-lifts A C)
+  : ( is-covariant A C) → (has-unique-fixed-domain-lifts A C)
   :=
     \ is-covariant-C x y f u →
       is-contr-equiv-is-contr'
-        ( (t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
+        ( ( t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( is-covariant-C x y f u)
@@ -188,8 +189,8 @@ logical equivalence
       ( has-unique-fixed-domain-lifts A C)
       ( is-covariant A C)
   :=
-    ( is-covariant-has-unique-fixed-domain-lifts A C,
-      has-unique-fixed-domain-lifts-is-covariant A C)
+    ( is-covariant-has-unique-fixed-domain-lifts A C
+    , has-unique-fixed-domain-lifts-is-covariant A C)
 ```
 
 ## Naive left fibrations
@@ -215,8 +216,8 @@ As a sanity check we unpack the definition of `is-naive-left-fibration`.
 #def is-naive-left-fibration-unpacked
   ( A Ĉ : U)
   ( p : Ĉ → A)
-  : is-naive-left-fibration A Ĉ p =
-      ((c : Ĉ) → is-equiv (coslice Ĉ c) (coslice A (p c)) (coslice-fun Ĉ A p c))
+  : is-naive-left-fibration A Ĉ p
+    = ( ( c : Ĉ) → is-equiv (coslice Ĉ c) (coslice A (p c)) (coslice-fun Ĉ A p c))
   := refl
 ```
 
@@ -243,8 +244,8 @@ This notion agrees with that of a naive left fibration.
         ( \ σ' t → α (σ' t))
         ( coslice A' (a' 0₂)) (coslice A (α (a' 0₂)))
         ( coslice-fun A' A α (a' 0₂))
-        ( ( coslice-coslice' A' (a' 0₂), coslice-coslice' A (α (a' 0₂))),
-          \ _ → refl)
+        ( ( coslice-coslice' A' (a' 0₂) , coslice-coslice' A (α (a' 0₂)))
+        , \ _ → refl)
         ( is-equiv-coslice-coslice' A' (a' 0₂))
         ( is-equiv-coslice-coslice' A (α (a' 0₂)))
         ( is-nlf (a' 0₂))
@@ -259,8 +260,8 @@ This notion agrees with that of a naive left fibration.
         ( \ σ' t → α (σ' t))
         ( coslice A' a') (coslice A (α a'))
         ( coslice-fun A' A α a')
-        ( ( coslice-coslice' A' a', coslice-coslice' A (α a')),
-          \ _ → refl)
+        ( ( coslice-coslice' A' a' , coslice-coslice' A (α a'))
+        , \ _ → refl)
         ( is-equiv-coslice-coslice' A' a')
         ( is-equiv-coslice-coslice' A (α a'))
         ( is-lf (\ t → a'))
@@ -270,8 +271,8 @@ This notion agrees with that of a naive left fibration.
       ( is-naive-left-fibration A A' α)
       ( is-left-fibration A' A α)
   :=
-    ( is-left-fibration-is-naive-left-fibration,
-      is-naive-left-fibration-is-left-fibration)
+    ( is-left-fibration-is-naive-left-fibration
+    , is-naive-left-fibration-is-left-fibration)
 
 #end is-left-fibration-is-naive-left-fibration
 ```
@@ -309,18 +310,18 @@ We make some abbreviations to make the proof more readable:
 -- Once rzk supports local variables, these should be renamed.
 
 #def temp-b9wX-coslice-fun
-  : coslice (total-type A C) (a, c) → coslice A a
-  := coslice-fun (total-type A C) A (\ (x, _) → x) (a, c)
+  : coslice (total-type A C) (a , c) → coslice A a
+  := coslice-fun (total-type A C) A (\ (x , _) → x) (a , c)
 
 #def temp-b9wX-fib
-  (a' : A)
-  (f : hom A a a')
+  ( a' : A)
+  ( f : hom A a a')
   : U
   :=
-    fib (coslice (total-type A C) (a, c))
-        (coslice A a)
-        (temp-b9wX-coslice-fun)
-        (a', f)
+    fib (coslice (total-type A C) (a , c))
+        ( coslice A a)
+        ( temp-b9wX-coslice-fun)
+        ( a' , f)
 ```
 
 We construct the forward map; this one is straightforward since it goes from
@@ -332,7 +333,7 @@ strict extension type to a weak one.
   ( f : hom A a a')
   : dhom-from A a a' f C c → temp-b9wX-fib a' f
   :=
-    \ (c', f̂) → (((a', c'), \ t → (f t, f̂ t)) , refl)
+    \ (c' , f̂) → (((a' , c') , \ t → (f t , f̂ t)) , refl)
 ```
 
 The only non-trivial part is showing that this map has a section. We do this by
@@ -340,22 +341,22 @@ the following fiber induction.
 
 ```rzk
 #def temp-b9wX-has-section'-forward
-  ( (a', f) : coslice A a)
+  ( ( a' , f) : coslice A a)
   ( u : temp-b9wX-fib a' f)
   : U
-  := Σ ( v : dhom-from A a a' f C c), ( temp-b9wX-forward a' f v = u)
+  := Σ (v : dhom-from A a a' f C c) , (temp-b9wX-forward a' f v = u)
 
 #def temp-b9wX-forward-section'
-  : ( (a', f) : coslice A a) →
-    ( u : temp-b9wX-fib a' f) →
-    temp-b9wX-has-section'-forward (a', f) u
+  : ( ( a' , f) : coslice A a)
+  → ( u : temp-b9wX-fib a' f)
+  → temp-b9wX-has-section'-forward (a' , f) u
   :=
     ind-fib
-      ( coslice (total-type A C) (a, c))
+      ( coslice (total-type A C) (a , c))
       ( coslice A a)
       ( temp-b9wX-coslice-fun)
       ( temp-b9wX-has-section'-forward)
-      (\ ((a', c'), ĝ) → ((c', \ t → second (ĝ t)) , refl))
+      ( \ ((a' , c') , ĝ) → ((c' , \ t → second (ĝ t)) , refl))
 ```
 
 We have constructed a section. It is also definitionally a retraction, yielding
@@ -366,28 +367,28 @@ the desired equivalence.
   ( a' : A)
   ( f : hom A a a')
   : has-inverse
-      (dhom-from A a a' f C c)
-      (temp-b9wX-fib a' f)
-      (temp-b9wX-forward a' f)
+      ( dhom-from A a a' f C c)
+      ( temp-b9wX-fib a' f)
+      ( temp-b9wX-forward a' f)
   :=
-    ( \ u → first (temp-b9wX-forward-section' (a', f) u),
-    ( \ _ → refl,
-      \ u → second (temp-b9wX-forward-section' (a', f) u)
+    ( \ u → first (temp-b9wX-forward-section' (a' , f) u)
+  , ( \ _ → refl
+    , \ u → second (temp-b9wX-forward-section' (a' , f) u)
     ))
 
 #def temp-b9wX-the-equivalence
   ( a' : A)
   ( f : hom A a a')
   : Equiv
-      (dhom-from A a a' f C c)
-      (temp-b9wX-fib a' f)
+      ( dhom-from A a a' f C c)
+      ( temp-b9wX-fib a' f)
   :=
-    ( (temp-b9wX-forward a' f),
-      is-equiv-has-inverse
-        (dhom-from A a a' f C c)
-        (temp-b9wX-fib a' f)
-        (temp-b9wX-forward a' f)
-        (temp-b9wX-has-inverse-forward a' f)
+    ( ( temp-b9wX-forward a' f)
+    , is-equiv-has-inverse
+        ( dhom-from A a a' f C c)
+        ( temp-b9wX-fib a' f)
+        ( temp-b9wX-forward a' f)
+        ( temp-b9wX-has-inverse-forward a' f)
     )
 
 #end is-naive-left-fibration-is-covariant-proof
@@ -400,25 +401,25 @@ Finally, we deduce the theorem by some straightforward logical bookkeeping.
   ( A : U)
   ( C : A → U)
   ( is-covariant-C : is-covariant A C)
-  : is-naive-left-fibration A (total-type A C) (\ (a, _) → a)
+  : is-naive-left-fibration A (total-type A C) (\ (a , _) → a)
   :=
-    \ (a, c) →
+    \ (a , c) →
       is-equiv-is-contr-map
-        ( coslice (total-type A C) (a, c))
+        ( coslice (total-type A C) (a , c))
         ( coslice A a)
         ( temp-b9wX-coslice-fun A a C c)
-        ( \ (a', f) →
+        ( \ (a' , f) →
           is-contr-equiv-is-contr
-            (dhom-from A a a' f C c)
-            (temp-b9wX-fib A a C c a' f)
-            (temp-b9wX-the-equivalence A a C c a' f)
-            (is-covariant-C a a' f c)
+            ( dhom-from A a a' f C c)
+            ( temp-b9wX-fib A a C c a' f)
+            ( temp-b9wX-the-equivalence A a C c a' f)
+            ( is-covariant-C a a' f c)
         )
 
 #def is-covariant-is-naive-left-fibration
   ( A : U)
   ( C : A → U)
-  ( inlf-ΣC : is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
+  ( inlf-ΣC : is-naive-left-fibration A (total-type A C) (\ (a , _) → a))
   : is-covariant A C
   :=
     \ a a' f c →
@@ -427,11 +428,11 @@ Finally, we deduce the theorem by some straightforward logical bookkeeping.
         ( temp-b9wX-fib A a C c a' f)
         ( temp-b9wX-the-equivalence A a C c a' f)
         ( is-contr-map-is-equiv
-          ( coslice (total-type A C) (a, c))
+          ( coslice (total-type A C) (a , c))
           ( coslice A a)
           ( temp-b9wX-coslice-fun A a C c)
-          ( inlf-ΣC (a, c))
-          (a', f)
+          ( inlf-ΣC (a , c))
+          ( a' , f)
         )
 
 #def is-naive-left-fibration-iff-is-covariant
@@ -439,11 +440,11 @@ Finally, we deduce the theorem by some straightforward logical bookkeeping.
   ( C : A → U)
   :
     iff
-      (is-covariant A C)
-      (is-naive-left-fibration A (total-type A C) (\ (a, _) → a))
+      ( is-covariant A C)
+      ( is-naive-left-fibration A (total-type A C) (\ (a , _) → a))
   :=
-    ( is-naive-left-fibration-is-covariant A C,
-      is-covariant-is-naive-left-fibration A C)
+    ( is-naive-left-fibration-is-covariant A C
+    , is-covariant-is-naive-left-fibration A C)
 ```
 
 ## Total type of a covariant family over a Segal type
@@ -460,9 +461,9 @@ Segal, then so is `Σ A, C`.
   : is-segal A → is-segal (total-type A C)
   :=
     is-segal-domain-left-fibration-is-segal-codomain extext
-      ( total-type A C) A (\ (a,_) → a)
+      ( total-type A C) A (\ (a , _) → a)
         ( is-left-fibration-is-naive-left-fibration
-            ( total-type A C) A (\ (a,_) → a)
+            ( total-type A C) A (\ (a , _) → a)
             ( is-naive-left-fibration-is-covariant A C is-covariant-C))
 ```
 
@@ -495,19 +496,19 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( v : hom A a y)
   : Equiv
     ( dhom-representable A a x y f u v)
-    ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
   :=
     curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
     ( \ (t , s) →
       recOR
-        ( (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
+        ( ( t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
 
 #def dhom-from-representable
   ( A : U)
@@ -528,22 +529,22 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
-    ( Σ ( v : hom A a y) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+    ( Σ ( v : hom A a y)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
   :=
     total-equiv-family-of-equiv
       ( hom A a y)
       ( \ v → dhom-representable A a x y f u v)
       ( \ v →
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+        ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
       ( \ v → uncurried-dhom-representable A a x y f u v)
 
 #def square-to-hom2-pushout
@@ -553,12 +554,12 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( f : hom A x z)
   ( g : hom A w y)
   ( v : hom A y z)
-  : ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ g t ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]) →
-    ( Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
+  : ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ g t
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+  → ( Σ ( d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
   :=
     \ sq →
     ( ( \ t → sq (t , t)) , (\ (t , s) → sq (s , t) , \ (t , s) → sq (t , s)))
@@ -570,18 +571,18 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( f : hom A x z)
   ( g : hom A w y)
   ( v : hom A y z)
-  : ( Σ ( d : hom A w z) ,
-        ( product (hom2 A w x z u f d) (hom2 A w y z g v d))) →
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ g t ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+  : ( Σ ( d : hom A w z)
+      , ( product (hom2 A w x z u f d) (hom2 A w y z g v d)))
+    → ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ g t
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
   :=
     \ (d , (α1 , α2)) (t , s) →
     recOR
-      ( t ≤ s ↦ α1 (s , t) ,
-        s ≤ t ↦ α2 (t , s))
+      ( t ≤ s ↦ α1 (s , t)
+      , s ≤ t ↦ α2 (t , s))
 
 #def equiv-square-hom2-pushout
   ( A : U)
@@ -591,16 +592,16 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( g : hom A w y)
   ( v : hom A y z)
   : Equiv
-    ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ g t ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
-    ( Σ (d : hom A w z) , (product (hom2 A w x z u f d) (hom2 A w y z g v d)))
+    ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ g t
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( Σ ( d : hom A w z) , (product (hom2 A w x z u f d) (hom2 A w y z g v d)))
   :=
-    ( ( square-to-hom2-pushout A w x y z u f g v) ,
-      ( ( hom2-pushout-to-square A w x y z u f g v , \ sq → refl) ,
-        ( hom2-pushout-to-square A w x y z u f g v , \ αs → refl)))
+    ( ( square-to-hom2-pushout A w x y z u f g v)
+    , ( ( hom2-pushout-to-square A w x y z u f g v , \ sq → refl)
+      , ( hom2-pushout-to-square A w x y z u f g v , \ αs → refl)))
 
 #def representable-dhom-from-uncurry-hom2
   ( A : U)
@@ -608,27 +609,27 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( f : hom A x y)
   ( u : hom A a x)
   : Equiv
-    ( Σ (v : hom A a y) ,
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
-    ( Σ ( v : hom A a y) ,
-        ( Σ ( d : hom A a y) ,
-            ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
+    ( Σ ( v : hom A a y)
+    , ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+    ( Σ ( v : hom A a y)
+      , ( Σ ( d : hom A a y)
+          , ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
   :=
     total-equiv-family-of-equiv
     ( hom A a y)
     ( \ v →
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+      ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
     ( \ v →
-      ( Σ ( d : hom A a y) ,
-          ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
+      ( Σ ( d : hom A a y)
+        , ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
     ( \ v → equiv-square-hom2-pushout A a x a y u f (id-hom A a) v)
 
 #def representable-dhom-from-hom2
@@ -638,24 +639,24 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
-    ( Σ ( d : hom A a y) ,
-        ( Σ ( v : hom A a y) ,
-            ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
+    ( Σ ( d : hom A a y)
+      , ( Σ ( v : hom A a y)
+          , ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
   :=
     equiv-triple-comp
     ( dhom-from-representable A a x y f u)
-    ( Σ ( v : hom A a y) ,
-        ( ((t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
-    ( Σ ( v : hom A a y) ,
-        ( Σ ( d : hom A a y) ,
-            ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
-    ( Σ ( d : hom A a y) ,
-        ( Σ ( v : hom A a y) ,
-            ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
+    ( Σ ( v : hom A a y)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+    ( Σ ( v : hom A a y)
+      , ( Σ ( d : hom A a y)
+          , ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
+    ( Σ ( d : hom A a y)
+      , ( Σ ( v : hom A a y)
+          , ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
     ( uncurried-dhom-from-representable A a x y f u)
     ( representable-dhom-from-uncurry-hom2 A a x y f u)
     ( fubini-Σ (hom A a y) (hom A a y)
@@ -668,30 +669,30 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
-    ( Σ ( d : hom A a y) ,
-        ( product
+    ( Σ ( d : hom A a y)
+      , ( product
           ( hom2 A a x y u f d)
-          ( Σ (v : hom A a y) , (hom2 A a a y (id-hom A a) v d))))
+          ( Σ ( v : hom A a y) , (hom2 A a a y (id-hom A a) v d))))
   :=
     equiv-right-cancel
     ( dhom-from-representable A a x y f u)
-    ( Σ ( d : hom A a y) ,
-        ( product
+    ( Σ ( d : hom A a y)
+      , ( product
           ( hom2 A a x y u f d)
-          ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
-    ( Σ ( d : hom A a y) ,
-        ( Σ ( v : hom A a y) ,
-            ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
+          ( Σ ( v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
+    ( Σ ( d : hom A a y)
+      , ( Σ ( v : hom A a y)
+          , ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
     ( representable-dhom-from-hom2 A a x y f u)
     ( total-equiv-family-of-equiv
       ( hom A a y)
       ( \ d →
         ( product
           ( hom2 A a x y u f d)
-          ( Σ (v : hom A a y) , (hom2 A a a y (id-hom A a) v d))))
+          ( Σ ( v : hom A a y) , (hom2 A a a y (id-hom A a) v d))))
       ( \ d →
-        ( Σ ( v : hom A a y) ,
-            ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
+        ( Σ ( v : hom A a y)
+          , ( product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d))))
       ( \ d →
         ( distributive-product-Σ
           ( hom2 A a x y u f d)
@@ -710,17 +711,17 @@ Now we introduce the hypothesis that A is Segal type.
   ( u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
-    ( Σ ( d : hom A a y) ,
-        ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
+    ( Σ ( d : hom A a y)
+      , ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
   :=
     equiv-right-cancel
     ( dhom-from-representable A a x y f u)
-    ( Σ ( d : hom A a y) ,
-        ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
-    ( Σ ( d : hom A a y) ,
-        ( product
+    ( Σ ( d : hom A a y)
+      , ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
+    ( Σ ( d : hom A a y)
+      , ( product
           ( hom2 A a x y u f d)
-          ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
+          ( Σ ( v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
     ( representable-dhom-from-hom2-dist A a x y f u)
     ( total-equiv-family-of-equiv
       ( hom A a y)
@@ -728,7 +729,7 @@ Now we introduce the hypothesis that A is Segal type.
       ( \ d →
         ( product
           ( hom2 A a x y u f d)
-          ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
+          ( Σ ( v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
       ( \ d →
         ( total-equiv-family-of-equiv
           ( hom2 A a x y u f d)
@@ -765,13 +766,13 @@ Now we introduce the hypothesis that A is Segal type.
   ( u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
-    ( Σ (d : hom A a y) , (hom2 A a x y u f d))
+    ( Σ ( d : hom A a y) , (hom2 A a x y u f d))
   :=
     equiv-comp
     ( dhom-from-representable A a x y f u)
-    ( Σ (d : hom A a y) ,
-      ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
-    ( Σ (d : hom A a y) , (hom2 A a x y u f d))
+    ( Σ ( d : hom A a y)
+    , ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
+    ( Σ ( d : hom A a y) , (hom2 A a x y u f d))
     ( representable-dhom-from-path-space-is-segal A is-segal-A a x y f u)
     ( total-equiv-family-of-equiv
       ( hom A a y)
@@ -789,7 +790,7 @@ Now we introduce the hypothesis that A is Segal type.
   :=
     is-contr-equiv-is-contr'
       ( dhom-from-representable A a x y f u)
-      ( Σ (d : hom A a y) , (hom2 A a x y u f d))
+      ( Σ ( d : hom A a y) , (hom2 A a x y u f d))
       ( is-segal-representable-dhom-from-hom2 A is-segal-A a x y f u)
       ( is-segal-A a x y u f)
 ```
@@ -798,9 +799,9 @@ Finally, we see that covariant hom families in a Segal type are covariant.
 
 ```rzk title="RS17, Proposition 8.13(<-)"
 #def is-covariant-representable-is-segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (a : A)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( a : A)
   : is-covariant A (hom A a)
   := is-segal-representable-dhom-from-contractible A is-segal-A a
 ```
@@ -812,31 +813,31 @@ we argue as follows:
 ```rzk title="RS17, Proposition 8.13(→)"
 #def is-segal-is-covariant-representable
   ( A : U)
-  ( corepresentable-family-is-covariant : (a : A) →
-    is-covariant A (\ x → hom A a x))
+  ( corepresentable-family-is-covariant : (a : A)
+  → is-covariant A (\ x → hom A a x))
   : is-segal A
   :=
     \ x y z f g →
     is-contr-base-is-contr-Σ
-    ( Σ (h : hom A x z) , hom2 A x y z f g h)
+    ( Σ ( h : hom A x z) , hom2 A x y z f g h)
     ( \ hk → Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk))
     ( \ hk → (first hk , \ (t , s) → first hk s))
     ( is-contr-equiv-is-contr'
-      ( Σ ( hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-          ( Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk)))
+      ( Σ ( hk : Σ (h : hom A x z) , hom2 A x y z f g h)
+        , ( Σ ( v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk)))
       ( dhom-from-representable A x y z g f)
       ( inv-equiv
         ( dhom-from-representable A x y z g f)
-        ( Σ ( hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-            ( Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk)))
+        ( Σ ( hk : Σ (h : hom A x z) , hom2 A x y z f g h)
+          , ( Σ ( v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk)))
         ( equiv-comp
           ( dhom-from-representable A x y z g f)
-          ( Σ ( h : hom A x z) ,
-              ( product
+          ( Σ ( h : hom A x z)
+            , ( product
                 ( hom2 A x y z f g h)
-                ( Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v h)))
-          ( Σ ( hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-              ( Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk)))
+                ( Σ ( v : hom A x z) , hom2 A x x z (id-hom A x) v h)))
+          ( Σ ( hk : Σ (h : hom A x z) , hom2 A x y z f g h)
+            , ( Σ ( v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk)))
           ( representable-dhom-from-hom2-dist A x y z g f)
           ( associative-Σ
             ( hom A x z)
@@ -856,25 +857,25 @@ types as follows.
   ( f : hom A x y)
   ( u : hom A a x)
   : Equiv
-    ( ( (t , s) : ∂□) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
-    ( ( (t , s) : 2 × 2 | (t ≡ 1₂) ∧ (Δ¹ s)) →
-      A [ (t ≡ 1₂) ∧ (s ≡ 0₂) ↦ a ,
-          (t ≡ 1₂) ∧ (s ≡ 1₂) ↦ y])
+    ( ( ( t , s) : ∂□)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( ( ( t , s) : 2 × 2 | (t ≡ 1₂) ∧ (Δ¹ s))
+    → A [ (t ≡ 1₂) ∧ (s ≡ 0₂) ↦ a
+        , ( t ≡ 1₂) ∧ (s ≡ 1₂) ↦ y])
   :=
     cofibration-union
     ( 2 × 2)
     ( \ (t , s) → (t ≡ 1₂) ∧ Δ¹ s)
     ( \ (t , s) →
-      ((t ≡ 0₂) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (s ≡ 0₂)) ∨ ((Δ¹ t) ∧ (s ≡ 1₂)))
+      ( ( t ≡ 0₂) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (s ≡ 0₂)) ∨ ((Δ¹ t) ∧ (s ≡ 1₂)))
     ( \ (t , s) → A)
     ( \ (t , s) →
       recOR
-        ( (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
+        ( ( t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
 
 #def base-hom-rewriting
   ( A : U)
@@ -882,14 +883,14 @@ types as follows.
   ( f : hom A x y)
   ( u : hom A a x)
   : Equiv
-    ( ( (t , s) : 2 × 2 | (t ≡ 1₂) ∧ (Δ¹ s)) →
-      A [ (t ≡ 1₂) ∧ (s ≡ 0₂) ↦ a ,
-          (t ≡ 1₂) ∧ (s ≡ 1₂) ↦ y])
+    ( ( ( t , s) : 2 × 2 | (t ≡ 1₂) ∧ (Δ¹ s))
+    → A [ (t ≡ 1₂) ∧ (s ≡ 0₂) ↦ a
+        , ( t ≡ 1₂) ∧ (s ≡ 1₂) ↦ y])
     ( hom A a y)
   :=
-    ( ( \ v → (\ r → v ((1₂ , r)))) ,
-      ( ( \ v (t , s) → v s , \ _ → refl) ,
-        ( \ v (_ , s) → v s , \ _ → refl)))
+    ( ( \ v → (\ r → v ((1₂ , r))))
+    , ( ( \ v (t , s) → v s , \ _ → refl)
+      , ( \ v (_ , s) → v s , \ _ → refl)))
 
 #def base-hom-expansion
   ( A : U)
@@ -897,20 +898,20 @@ types as follows.
   ( f : hom A x y)
   ( u : hom A a x)
   : Equiv
-    ( ( (t , s) : ∂□) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( ( ( t , s) : ∂□)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
     ( hom A a y)
   :=
     equiv-comp
-    ( ( (t , s) : ∂□) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
-    ( ( (t , s) : 2 × 2 | (t ≡ 1₂) ∧ (Δ¹ s)) →
-      A [ (t ≡ 1₂) ∧ (s ≡ 0₂) ↦ a ,
-          (t ≡ 1₂) ∧ (s ≡ 1₂) ↦ y])
+    ( ( ( t , s) : ∂□)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( ( ( t , s) : 2 × 2 | (t ≡ 1₂) ∧ (Δ¹ s))
+    → A [ (t ≡ 1₂) ∧ (s ≡ 0₂) ↦ a
+        , ( t ≡ 1₂) ∧ (s ≡ 1₂) ↦ y])
     ( hom A a y)
     ( cofibration-union-test A a x y f u)
     ( base-hom-rewriting A a x y f u)
@@ -922,36 +923,36 @@ types as follows.
   ( u : hom A a x)
   : Equiv
     ( Σ ( sq :
-          ( (t , s) : ∂□) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s)) ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
-    ( Σ ( v : hom A a y) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+          ( ( t , s) : ∂□)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s))
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+    ( Σ ( v : hom A a y)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
   :=
     equiv-total-pullback-is-equiv
-    ( ( (t , s) : ∂□) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( ( ( t , s) : ∂□)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
     ( hom A a y)
     ( first (base-hom-expansion A a x y f u))
     ( second (base-hom-expansion A a x y f u))
     ( \ v →
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+      ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
 
 #def representable-dhom-from-composite-expansion
   ( A : U)
@@ -961,34 +962,34 @@ types as follows.
   : Equiv
     ( dhom-from-representable A a x y f u)
     ( Σ ( sq :
-          ( (t , s) : ∂□) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s)) ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+          ( ( t , s) : ∂□)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s))
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
   :=
     equiv-right-cancel
       ( dhom-from-representable A a x y f u)
       ( Σ ( sq :
-            ( (t , s) : ∂□) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]) ,
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s)) ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
-      ( Σ ( v : hom A a y) ,
-          ( ( (t , s) : Δ¹×Δ¹) →
-            A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+            ( ( t , s) : ∂□)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+        , ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s))
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+      ( Σ ( v : hom A a y)
+        , ( ( ( t , s) : Δ¹×Δ¹)
+          → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+              , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+              , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+              , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
       ( uncurried-dhom-from-representable A a x y f u)
       ( representable-dhom-from-expansion A a x y f u)
 
@@ -998,30 +999,30 @@ types as follows.
   ( f : hom A x y)
   ( u : hom A a x)
   : Equiv
-    ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
     ( Σ ( sq :
-          ( (t , s) : ∂□) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s)) ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+          ( ( t , s) : ∂□)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s))
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
   :=
     cofibration-composition (2 × 2) Δ¹×Δ¹ ∂□
       ( \ (t , s) →
-        ( (t ≡ 0₂) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (s ≡ 0₂)) ∨ ((Δ¹ t) ∧ (s ≡ 1₂)))
+        ( ( t ≡ 0₂) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (s ≡ 0₂)) ∨ ((Δ¹ t) ∧ (s ≡ 1₂)))
       ( \ ts → A)
       ( \ (t , s) →
         recOR
-          ( (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
+          ( ( t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
 
 #def representable-dhom-from-as-extension-type
   ( A : U)
@@ -1030,27 +1031,27 @@ types as follows.
   ( u : hom A a x)
   : Equiv
       ( dhom-from-representable A a x y f u)
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+      ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
   :=
     equiv-right-cancel
     ( dhom-from-representable A a x y f u)
-    ( ( (t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+    ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
     ( Σ ( sq :
-          ( (t , s) : ∂□) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s)) ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
+          ( ( t , s) : ∂□)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ (sq (1₂ , s))
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ a
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ f t]))
     ( representable-dhom-from-composite-expansion A a x y f u)
     ( representable-dhom-from-cofibration-composition A a x y f u)
 ```
@@ -1085,8 +1086,8 @@ is covariant as shown above. Transport of an `e : C x` along an arrow
   ( e : hom A a x)
   ( f : hom A x y)
   : covariant-transport A x y f
-      (hom A a) (is-covariant-representable-is-segal A is-segal-A a) e =
-    comp-is-segal A is-segal-A a x y e f
+      ( hom A a) (is-covariant-representable-is-segal A is-segal-A a) e
+  = comp-is-segal A is-segal-A a x y e f
   :=
     refl
 ```
@@ -1131,7 +1132,7 @@ is covariant as shown above. Transport of an `e : C x` along an arrow
   → ( dhom A x y f C u v)
   → ( covariant-transport A x y f C is-covariant-C u) = v
   :=
-    \ v g → covariant-uniqueness A x y f C is-covariant-C u (v, g)
+    \ v g → covariant-uniqueness A x y f C is-covariant-C u (v , g)
 
 ```
 
@@ -1148,23 +1149,23 @@ equivalence. This follows from the fact that the total types (summed over
   ( is-covariant-C : is-covariant A C)
   ( u : C x)
   : is-equiv
-      (Σ (v : C y), dhom A x y f C u v)
-      (Σ (v : C y), covariant-transport A x y f C is-covariant-C u = v)
+      ( Σ ( v : C y) , dhom A x y f C u v)
+      ( Σ ( v : C y) , covariant-transport A x y f C is-covariant-C u = v)
       ( total-map (C y)
-        (dhom A x y f C u)
-        (\ v → covariant-transport A x y f C is-covariant-C u = v)
-        (covariant-uniqueness-curried A x y f C is-covariant-C u)
+        ( dhom A x y f C u)
+        ( \ v → covariant-transport A x y f C is-covariant-C u = v)
+        ( covariant-uniqueness-curried A x y f C is-covariant-C u)
       )
   :=
     is-equiv-are-contr
-      (Σ (v : C y), dhom A x y f C u v)
-      (Σ (v : C y), covariant-transport A x y f C is-covariant-C u = v)
-      (is-covariant-C x y f u)
-      (is-contr-based-paths (C y) (covariant-transport A x y f C is-covariant-C u))
+      ( Σ ( v : C y) , dhom A x y f C u v)
+      ( Σ ( v : C y) , covariant-transport A x y f C is-covariant-C u = v)
+      ( is-covariant-C x y f u)
+      ( is-contr-based-paths (C y) (covariant-transport A x y f C is-covariant-C u))
       ( total-map (C y)
-        (dhom A x y f C u)
-        (\ v → covariant-transport A x y f C is-covariant-C u = v)
-        (covariant-uniqueness-curried A x y f C is-covariant-C u)
+        ( dhom A x y f C u)
+        ( \ v → covariant-transport A x y f C is-covariant-C u = v)
+        ( covariant-uniqueness-curried A x y f C is-covariant-C u)
       )
 
 #def is-equiv-covariant-uniqueness-curried
@@ -1176,17 +1177,17 @@ equivalence. This follows from the fact that the total types (summed over
   ( u : C x)
   ( v : C y)
   : is-equiv
-      (dhom A x y f C u v)
-      (covariant-transport A x y f C is-covariant-C u = v)
-      (covariant-uniqueness-curried A x y f C is-covariant-C u v)
+      ( dhom A x y f C u v)
+      ( covariant-transport A x y f C is-covariant-C u = v)
+      ( covariant-uniqueness-curried A x y f C is-covariant-C u v)
   :=
 
     is-equiv-fiberwise-is-equiv-total
-      (C y)
-      (dhom A x y f C u)
-      (\ v' → covariant-transport A x y f C is-covariant-C u = v')
-      (covariant-uniqueness-curried A x y f C is-covariant-C u)
-      (is-equiv-total-map-covariant-uniqueness-curried A x y f C is-covariant-C u)
+      ( C y)
+      ( dhom A x y f C u)
+      ( \ v' → covariant-transport A x y f C is-covariant-C u = v')
+      ( covariant-uniqueness-curried A x y f C is-covariant-C u)
+      ( is-equiv-total-map-covariant-uniqueness-curried A x y f C is-covariant-C u)
       v
 ```
 
@@ -1203,8 +1204,8 @@ We compute covariant transport of a substitution.
   ( u : C (g x))
   : covariant-transport B x y f (\ b → C (g b))
     ( is-covariant-substitution-is-covariant A B C is-covariant-C g) u
-    =
-    covariant-transport A (g x) (g y) (ap-hom B A g x y f) C
+
+  = covariant-transport A (g x) (g y) (ap-hom B A g x y f) C
     ( is-covariant-C) u
   := refl
 ```
@@ -1254,8 +1255,8 @@ with the covariant lifts.
   ( u : C x)
   : dhom-from A x y f D (ϕ x u)
   :=
-    ( ( ϕ y (covariant-transport A x y f C is-covariant-C u)) ,
-      ( \ t → ϕ (f t) (covariant-lift A x y f C is-covariant-C u t)))
+    ( ( ϕ y (covariant-transport A x y f C is-covariant-C u))
+    , ( \ t → ϕ (f t) (covariant-lift A x y f C is-covariant-C u t)))
 
 #def naturality-covariant-fiberwise-transformation
   ( A : U)
@@ -1266,8 +1267,8 @@ with the covariant lifts.
   ( is-covariant-D : is-covariant A D)
   ( ϕ : (z : A) → C z → D z)
   ( u : C x)
-  : ( covariant-transport A x y f D is-covariant-D (ϕ x u)) =
-    ( ϕ y (covariant-transport A x y f C is-covariant-C u))
+  : ( covariant-transport A x y f D is-covariant-D (ϕ x u))
+  = ( ϕ y (covariant-transport A x y f C is-covariant-C u))
   :=
     covariant-uniqueness A x y f D is-covariant-D (ϕ x u)
       ( covariant-fiberwise-transformation-application
@@ -1288,12 +1289,12 @@ domain are equivalent:
   ( x y : A)
   ( f : hom A x y)
   : Equiv
-    ( (t : Δ¹) → C (f t))
-    ( Σ (u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
+    ( ( t : Δ¹) → C (f t))
+    ( Σ ( u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
   :=
-    ( ( \ h → (h 0₂ , \ t → h t)) ,
-      ( ( \ k t → (second k) t , \ h → refl) ,
-        ( ( \ k t → (second k) t , \ h → refl))))
+    ( ( \ h → (h 0₂ , \ t → h t))
+    , ( ( \ k t → (second k) t , \ h → refl)
+      , ( ( \ k t → (second k) t , \ h → refl))))
 ```
 
 ```rzk
@@ -1306,7 +1307,7 @@ domain are equivalent:
 #variable f : hom A x y
 
 #def equiv-total-dhom-equiv uses (A x y)
-  : Equiv ( (t : Δ¹) → B (f t)) ((t : Δ¹) → C (f t))
+  : Equiv ((t : Δ¹) → B (f t)) ((t : Δ¹) → C (f t))
   :=
     equiv-extensions-equiv extext 2 Δ¹ (\ _ → BOT)
       ( \ t → B (f t))
@@ -1316,25 +1317,25 @@ domain are equivalent:
 
 #def equiv-total-covariant-dhom-equiv uses (extext equiv-BC)
   : Equiv
-    ( Σ (i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
-    ( Σ (u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
+    ( Σ ( i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
+    ( Σ ( u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
   :=
     equiv-triple-comp
-    ( Σ (i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
-    ( (t : Δ¹) → B (f t))
-    ( (t : Δ¹) → C (f t))
-    ( Σ (u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
+    ( Σ ( i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
+    ( ( t : Δ¹) → B (f t))
+    ( ( t : Δ¹) → C (f t))
+    ( Σ ( u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
     ( inv-equiv
-      ( (t : Δ¹) → B (f t))
-      ( Σ (i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
+      ( ( t : Δ¹) → B (f t))
+      ( Σ ( i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
       ( equiv-covariant-total-dhom A B x y f))
     ( equiv-total-dhom-equiv)
     ( equiv-covariant-total-dhom A C x y f)
 
 #def equiv-pullback-total-covariant-dhom-equiv uses (A y)
   : Equiv
-    ( Σ (i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
-    ( Σ (u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
+    ( Σ ( i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ ( u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
   :=
     equiv-total-pullback-is-equiv
       ( B x)
@@ -1345,14 +1346,14 @@ domain are equivalent:
 
 #def is-equiv-to-pullback-total-covariant-dhom-equiv uses (extext A y)
   : is-equiv
-    ( Σ (i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
-    ( Σ (i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ ( i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
+    ( Σ ( i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
     ( \ (i , h) → (i , \ t → (first (equiv-BC (f t))) (h t)))
   :=
     is-equiv-right-factor
-    ( Σ (i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
-    ( Σ (i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
-    ( Σ (u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
+    ( Σ ( i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
+    ( Σ ( i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ ( u : C x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ u]))
     ( \ (i , h) → (i , \ t → (first (equiv-BC (f t))) (h t)))
     ( first (equiv-pullback-total-covariant-dhom-equiv))
     ( second (equiv-pullback-total-covariant-dhom-equiv))
@@ -1360,17 +1361,17 @@ domain are equivalent:
 
 #def equiv-to-pullback-total-covariant-dhom-equiv uses (extext A y)
   : Equiv
-    ( Σ (i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
-    ( Σ (i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ ( i : B x) , ((t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i]))
+    ( Σ ( i : B x) , ((t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
   :=
-    ( \ (i , h) → (i , \ t → (first (equiv-BC (f t))) (h t)) ,
-      is-equiv-to-pullback-total-covariant-dhom-equiv)
+    ( \ (i , h) → (i , \ t → (first (equiv-BC (f t))) (h t))
+    , is-equiv-to-pullback-total-covariant-dhom-equiv)
 
 #def family-equiv-dhom-family-equiv uses (extext A y)
-  (i : B x)
+  ( i : B x)
   : Equiv
-    ( (t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i])
-    ( (t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i])
+    ( ( t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i])
+    ( ( t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i])
   :=
     family-of-equiv-is-equiv-total
     ( B x)
@@ -1397,8 +1398,8 @@ Now we introduce the hypothesis that `#!rzk C` is covariant in the form of
   :=
     \ x y f i →
     is-contr-equiv-is-contr'
-    ( (t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i])
-    ( (t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i])
+    ( ( t : Δ¹) → B (f t) [t ≡ 0₂ ↦ i])
+    ( ( t : Δ¹) → C (f t) [t ≡ 0₂ ↦ (first (equiv-BC x)) i])
     ( family-equiv-dhom-family-equiv A B C equiv-BC x y f i)
     ( has-unique-fixed-domain-lifts-C x y f ((first (equiv-BC x)) i))
 
@@ -1412,7 +1413,7 @@ Now we introduce the hypothesis that `#!rzk C` is covariant in the form of
     ( first (has-unique-fixed-domain-lifts-iff-is-covariant A B))
       ( equiv-has-unique-fixed-domain-lifts
         A B C equiv-BC
-        ( (second (has-unique-fixed-domain-lifts-iff-is-covariant A C))
+        ( ( second (has-unique-fixed-domain-lifts-iff-is-covariant A C))
           is-covariant-C))
 ```
 
@@ -1429,7 +1430,7 @@ has a unique lift with specified codomain.
   ( C : A → U)
   ( v : C y)
   : U
-  := ( Σ (u : C x) , dhom A x y f C u v)
+  := (Σ (u : C x) , dhom A x y f C u v)
 ```
 
 ```rzk title="RS17, Definition 8.2, dual form"
@@ -1438,13 +1439,14 @@ has a unique lift with specified codomain.
   ( C : A → U)
   : U
   :=
-    ( x : A) → (y : A) → (f : hom A x y) → (v : C y) →
-    is-contr (dhom-to A x y f C v)
+    ( x : A) → (y : A) → (f : hom A x y) → (v : C y)
+  → is-contr (dhom-to A x y f C v)
 ```
 
 ```rzk title="The type of contravariant families over a fixed type"
-#def contravariant-family (A : U) : U
-  := ( Σ (C : A → U) , is-contravariant A C)
+#def contravariant-family (A : U)
+  : U
+  := (Σ (C : A → U) , is-contravariant A C)
 ```
 
 The notion of a contravariant family is stable under substitution into the base.
@@ -1469,8 +1471,8 @@ the 1-simplex.
   ( C : A → U)
   : U
   :=
-    ( x : A) → (y : A) → (f : hom A x y) → (v : C y) →
-    is-contr ((t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
+    ( x : A) → (y : A) → (f : hom A x y) → (v : C y)
+  → is-contr ((t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -1486,12 +1488,12 @@ here.
   ( f : hom A x y)
   ( v : C y)
   : Equiv
-      ( (t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
+      ( ( t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
       ( dhom-to A x y f C v)
   :=
-    ( ( \ h → (h 0₂ , \ t → h t)) ,
-      ( ( \ fg t → (second fg) t , \ h → refl) ,
-        ( ( \ fg t → (second fg) t , \ h → refl))))
+    ( ( \ h → (h 0₂ , \ t → h t))
+    , ( ( \ fg t → (second fg) t , \ h → refl)
+      , ( ( \ fg t → (second fg) t , \ h → refl))))
 ```
 
 By the equivalence-invariance of contractibility, this proves the desired
@@ -1501,11 +1503,11 @@ logical equivalence
 #def is-contravariant-has-unique-fixed-codomain-lifts
   ( A : U)
   ( C : A → U)
-  : (has-unique-fixed-codomain-lifts A C) → ( is-contravariant A C)
+  : ( has-unique-fixed-codomain-lifts A C) → (is-contravariant A C)
   :=
     \ C-has-unique-lifts x y f v →
       is-contr-equiv-is-contr
-      ( (t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
+      ( ( t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
       ( dhom-to A x y f C v)
       ( equiv-lifts-with-fixed-codomain A C x y f v)
       ( C-has-unique-lifts x y f v)
@@ -1513,11 +1515,11 @@ logical equivalence
 #def has-unique-fixed-codomain-lifts-is-contravariant
   ( A : U)
   ( C : A → U)
-  : (is-contravariant A C) → (has-unique-fixed-codomain-lifts A C)
+  : ( is-contravariant A C) → (has-unique-fixed-codomain-lifts A C)
   :=
     \ is-contravariant-C x y f v →
       is-contr-equiv-is-contr'
-      ( (t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
+      ( ( t : Δ¹) → C (f t) [t ≡ 1₂ ↦ v])
       ( dhom-to A x y f C v)
       ( equiv-lifts-with-fixed-codomain A C x y f v)
       ( is-contravariant-C x y f v)
@@ -1531,8 +1533,8 @@ logical equivalence
       ( has-unique-fixed-codomain-lifts A C)
       ( is-contravariant A C)
   :=
-    ( is-contravariant-has-unique-fixed-codomain-lifts A C,
-      has-unique-fixed-codomain-lifts-is-contravariant A C)
+    ( is-contravariant-has-unique-fixed-codomain-lifts A C
+    , has-unique-fixed-codomain-lifts-is-contravariant A C)
 ```
 
 ## Representable contravariant families
@@ -1564,19 +1566,19 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( v : hom A y a)
   : Equiv
     ( dhom-contra-representable A a x y f u v)
-    ( ((t , s) : Δ¹×Δ¹) →
-      A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ a])
+    ( ( ( t , s) : Δ¹×Δ¹)
+    → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ f t
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ a])
   :=
     curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
       ( \ (t , s) →
         recOR
-        ( (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ a))
+        ( ( t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+        , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+        , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ f t
+        , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ a))
 
 #def dhom-to-representable
   ( A : U)
@@ -1597,22 +1599,22 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
-    ( Σ (u : hom A x a) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
+    ( Σ ( u : hom A x a)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ f t
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
   :=
     total-equiv-family-of-equiv
     ( hom A x a)
     ( \ u → dhom-contra-representable A a x y f u v)
     ( \ u →
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
+      ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ f t
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
     ( \ u → uncurried-dhom-contra-representable A a x y f u v)
 
 #def representable-dhom-to-uncurry-hom2
@@ -1621,26 +1623,26 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( f : hom A x y)
   ( v : hom A y a)
   : Equiv
-    ( Σ ( u : hom A x a) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
-    ( Σ (u : hom A x a) ,
-      (Σ (d : hom A x a) ,
-        product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
+    ( Σ ( u : hom A x a)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ f t
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
+    ( Σ ( u : hom A x a)
+    , ( Σ ( d : hom A x a)
+      , product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
   :=
     total-equiv-family-of-equiv (hom A x a)
     ( \ u →
-      ( ( (t , s) : Δ¹×Δ¹) →
-        A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-            (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
+      ( ( ( t , s) : Δ¹×Δ¹)
+      → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+          , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+          , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ f t
+          , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
     ( \ u →
-      Σ ( d : hom A x a) ,
-        ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
+      Σ ( d : hom A x a)
+      , ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
     ( \ u → equiv-square-hom2-pushout A x a y a u (id-hom A a) f v)
 
 #def representable-dhom-to-hom2
@@ -1650,24 +1652,24 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
-    ( Σ (d : hom A x a) ,
-      ( Σ (u : hom A x a) ,
-        product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
+    ( Σ ( d : hom A x a)
+    , ( Σ ( u : hom A x a)
+      , product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
   :=
     equiv-triple-comp
     ( dhom-to-representable A a x y f v)
-    ( Σ ( u : hom A x a) ,
-        ( ( (t , s) : Δ¹×Δ¹) →
-          A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-              (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-              (Δ¹ t) ∧ (s ≡ 0₂) ↦ f t ,
-              (Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
-    ( Σ ( u : hom A x a) ,
-        ( Σ ( d : hom A x a) ,
-            ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))))
-    ( Σ ( d : hom A x a) ,
-        ( Σ ( u : hom A x a) ,
-            ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))))
+    ( Σ ( u : hom A x a)
+      , ( ( ( t , s) : Δ¹×Δ¹)
+        → A [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s
+            , ( t ≡ 1₂) ∧ (Δ¹ s) ↦ v s
+            , ( Δ¹ t) ∧ (s ≡ 0₂) ↦ f t
+            , ( Δ¹ t) ∧ (s ≡ 1₂) ↦ a]))
+    ( Σ ( u : hom A x a)
+      , ( Σ ( d : hom A x a)
+          , ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))))
+    ( Σ ( d : hom A x a)
+      , ( Σ ( u : hom A x a)
+          , ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))))
     ( uncurried-dhom-to-representable A a x y f v)
     ( representable-dhom-to-uncurry-hom2 A a x y f v)
     ( fubini-Σ (hom A x a) (hom A x a)
@@ -1680,26 +1682,26 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
-    ( Σ ( d : hom A x a) ,
-        ( Σ ( u : hom A x a) ,
-            ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))))
+    ( Σ ( d : hom A x a)
+      , ( Σ ( u : hom A x a)
+          , ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))))
   :=
     equiv-comp
       ( dhom-to-representable A a x y f v)
-      ( Σ ( d : hom A x a) ,
-          ( Σ ( u : hom A x a) ,
-              ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))))
-      ( Σ ( d : hom A x a) ,
-          ( Σ ( u : hom A x a) ,
-              ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))))
+      ( Σ ( d : hom A x a)
+        , ( Σ ( u : hom A x a)
+            , ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))))
+      ( Σ ( d : hom A x a)
+        , ( Σ ( u : hom A x a)
+            , ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))))
       ( representable-dhom-to-hom2 A a x y f v)
       ( total-equiv-family-of-equiv (hom A x a)
-        (\ d →
-          Σ ( u : hom A x a) ,
-            ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
         ( \ d →
-          Σ ( u : hom A x a) ,
-            ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d)))
+          Σ ( u : hom A x a)
+          , ( product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
+        ( \ d →
+          Σ ( u : hom A x a)
+          , ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d)))
         ( \ d → total-equiv-family-of-equiv (hom A x a)
           ( \ u → product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))
           ( \ u → product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))
@@ -1713,20 +1715,20 @@ By uncurrying (RS 4.2) we have an equivalence:
   ( v : hom A y a)
   : Equiv
       ( dhom-to-representable A a x y f v)
-      ( Σ ( d : hom A x a) ,
-          ( product
+      ( Σ ( d : hom A x a)
+        , ( product
             ( hom2 A x y a f v d)
-            ( Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d)))
+            ( Σ ( u : hom A x a) , hom2 A x a a u (id-hom A a) d)))
   :=
     equiv-right-cancel
     ( dhom-to-representable A a x y f v)
-    ( Σ (d : hom A x a) ,
-        ( product
+    ( Σ ( d : hom A x a)
+      , ( product
           ( hom2 A x y a f v d)
-          ( Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d)))
-    ( Σ ( d : hom A x a) ,
-        ( Σ (u : hom A x a) ,
-          product
+          ( Σ ( u : hom A x a) , hom2 A x a a u (id-hom A a) d)))
+    ( Σ ( d : hom A x a)
+      , ( Σ ( u : hom A x a)
+        , product
           ( hom2 A x y a f v d)
           ( hom2 A x a a u (id-hom A a) d)))
     ( representable-dhom-to-hom2-swap A a x y f v)
@@ -1734,10 +1736,10 @@ By uncurrying (RS 4.2) we have an equivalence:
       ( \ d →
         ( product
           ( hom2 A x y a f v d)
-          ( Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d)))
+          ( Σ ( u : hom A x a) , hom2 A x a a u (id-hom A a) d)))
       ( \ d →
-        ( Σ ( u : hom A x a) ,
-            ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))))
+        ( Σ ( u : hom A x a)
+          , ( product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))))
       ( \ d →
         ( distributive-product-Σ
           ( hom2 A x y a f v d)
@@ -1756,24 +1758,24 @@ Now we introduce the hypothesis that A is Segal type.
   ( v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
-    ( Σ ( d : hom A x a) ,
-        ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
+    ( Σ ( d : hom A x a)
+      , ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
   :=
     equiv-right-cancel
     ( dhom-to-representable A a x y f v)
-    ( Σ ( d : hom A x a) ,
-        ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
-    ( Σ ( d : hom A x a) ,
-        ( product
+    ( Σ ( d : hom A x a)
+      , ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
+    ( Σ ( d : hom A x a)
+      , ( product
           ( hom2 A x y a f v d)
-          ( Σ (u : hom A x a) , (hom2 A x a a u (id-hom A a) d))))
+          ( Σ ( u : hom A x a) , (hom2 A x a a u (id-hom A a) d))))
     ( representable-dhom-to-hom2-dist A a x y f v)
     ( total-equiv-family-of-equiv (hom A x a)
       ( \ d → product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d)))
       ( \ d →
         product
           ( hom2 A x y a f v d)
-          ( Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d))
+          ( Σ ( u : hom A x a) , hom2 A x a a u (id-hom A a) d))
       ( \ d →
         total-equiv-family-of-equiv
           ( hom2 A x y a f v d)
@@ -1794,13 +1796,13 @@ Now we introduce the hypothesis that A is Segal type.
   ( v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
-    ( Σ (d : hom A x a) , (hom2 A x y a f v d))
+    ( Σ ( d : hom A x a) , (hom2 A x y a f v d))
   :=
     equiv-comp
     ( dhom-to-representable A a x y f v)
-    ( Σ ( d : hom A x a) ,
-        ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
-    ( Σ (d : hom A x a) , (hom2 A x y a f v d))
+    ( Σ ( d : hom A x a)
+      , ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
+    ( Σ ( d : hom A x a) , (hom2 A x y a f v d))
     ( representable-dhom-to-path-space-is-segal A is-segal-A a x y f v)
     ( total-equiv-family-of-equiv
       ( hom A x a)
@@ -1818,7 +1820,7 @@ Now we introduce the hypothesis that A is Segal type.
   :=
     is-contr-equiv-is-contr'
       ( dhom-to-representable A a x y f v)
-      ( Σ (d : hom A x a) , (hom2 A x y a f v d))
+      ( Σ ( d : hom A x a) , (hom2 A x y a f v d))
       ( is-segal-representable-dhom-to-hom2 A is-segal-A a x y f v)
       ( is-segal-A x y a f v)
 ```
@@ -1842,31 +1844,31 @@ we argue as follows:
 ```rzk title="RS17, Proposition 8.13(→), dual"
 #def is-segal-is-contravariant-representable
   ( A : U)
-  ( representable-family-is-contravariant : (a : A) →
-    is-contravariant A (\ x → hom A x a))
+  ( representable-family-is-contravariant : (a : A)
+  → is-contravariant A (\ x → hom A x a))
   : is-segal A
   :=
     \ x y z f g →
       is-contr-base-is-contr-Σ
-      ( Σ (h : hom A x z) , (hom2 A x y z f g h))
+      ( Σ ( h : hom A x z) , (hom2 A x y z f g h))
       ( \ hk → Σ (u : hom A x z) , (hom2 A x z z u (id-hom A z) (first hk)))
       ( \ hk → (first hk , \ (t , s) → first hk t))
       ( is-contr-equiv-is-contr'
-        ( Σ ( hk : Σ (h : hom A x z) , (hom2 A x y z f g h)) ,
-            ( Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk)))
+        ( Σ ( hk : Σ (h : hom A x z) , (hom2 A x y z f g h))
+          , ( Σ ( u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk)))
         ( dhom-to-representable A z x y f g)
         ( inv-equiv
           ( dhom-to-representable A z x y f g)
-          ( Σ ( hk : Σ (h : hom A x z) , (hom2 A x y z f g h)) ,
-              ( Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk)))
+          ( Σ ( hk : Σ (h : hom A x z) , (hom2 A x y z f g h))
+            , ( Σ ( u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk)))
           ( equiv-comp
             ( dhom-to-representable A z x y f g)
-            ( Σ ( h : hom A x z) ,
-                ( product
+            ( Σ ( h : hom A x z)
+              , ( product
                   ( hom2 A x y z f g h)
-                  ( Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) h)))
-            ( Σ ( hk : Σ (h : hom A x z) , (hom2 A x y z f g h)) ,
-                ( Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk)))
+                  ( Σ ( u : hom A x z) , hom2 A x z z u (id-hom A z) h)))
+            ( Σ ( hk : Σ (h : hom A x z) , (hom2 A x y z f g h))
+              , ( Σ ( u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk)))
             ( representable-dhom-to-hom2-dist A z x y f g)
             ( associative-Σ
               ( hom A x z)
@@ -1965,8 +1967,8 @@ commuting with the contravariant lifts.
   ( v : C y)
   : dhom-to A x y f D (ϕ y v)
   :=
-    ( ϕ x (contravariant-transport A x y f C is-contravariant-C v) ,
-      \ t → ϕ (f t) (contravariant-lift A x y f C is-contravariant-C v t))
+    ( ϕ x (contravariant-transport A x y f C is-contravariant-C v)
+    , \ t → ϕ (f t) (contravariant-lift A x y f C is-contravariant-C v t))
 
 #def naturality-contravariant-fiberwise-transformation
   ( A : U)
@@ -1977,8 +1979,8 @@ commuting with the contravariant lifts.
   ( is-contravariant-D : is-contravariant A D)
   ( ϕ : (z : A) → C z → D z)
   ( v : C y)
-  : ( contravariant-transport A x y f D is-contravariant-D (ϕ y v)) =
-    ( ϕ x (contravariant-transport A x y f C is-contravariant-C v))
+  : ( contravariant-transport A x y f D is-contravariant-D (ϕ y v))
+  = ( ϕ x (contravariant-transport A x y f C is-contravariant-C v))
   :=
     contravariant-uniqueness A x y f D is-contravariant-D (ϕ y v)
     ( contravariant-fiberwise-transformation-application
@@ -1994,8 +1996,8 @@ commuting with the contravariant lifts.
   : U
   :=
     product
-      ( (a : A) → is-covariant B (\b → C a b))
-      ( (b : B) → is-contravariant A (\ a → C a b))
+      ( ( a : A) → is-covariant B (\ b → C a b))
+      ( ( b : B) → is-contravariant A (\ a → C a b))
 ```
 
 ```rzk title="RS17, Proposition 8.29"
@@ -2004,8 +2006,8 @@ commuting with the contravariant lifts.
   ( is-segal-A : is-segal A)
   : is-two-sided-discrete A A (hom A)
   :=
-    ( is-covariant-representable-is-segal A is-segal-A ,
-      is-contravariant-representable-is-segal A is-segal-A)
+    ( is-covariant-representable-is-segal A is-segal-A
+    , is-contravariant-representable-is-segal A is-segal-A)
 
 ```
 
@@ -2015,23 +2017,23 @@ commuting with the contravariant lifts.
 #def is-covariant-is-locally-covariant uses (weakfunext)
   ( A B : U)
   ( C : A → B → U)
-  ( is-locally-covariant : (b : B) → is-covariant A ( \ a → C a b ) )
-  : is-covariant A ( \ a → (( b : B ) → (C a b)))
+  ( is-locally-covariant : (b : B) → is-covariant A (\ a → C a b))
+  : is-covariant A (\ a → ((b : B) → (C a b)))
   :=
     is-covariant-has-unique-fixed-domain-lifts
       ( A)
-      ( \ a → ( b : B ) → (C a b) )
+      ( \ a → (b : B) → (C a b))
       ( \ x y f g →
         is-contr-equiv-is-contr'
-          ( (t : Δ¹) → ((b : B) → C (f t) b) [  t ≡ 0₂ ↦ g ])
-          ( (b : B) → (t : Δ¹) → C (f t) b [ t ≡ 0₂ ↦ g b])
-          ( flip-ext-fun 2 Δ¹ (\ t → t ≡ 0₂) B ( \ t →  C (f t)) ( \ t → g))
+          ( ( t : Δ¹) → ((b : B) → C (f t) b) [  t ≡ 0₂ ↦ g ])
+          ( ( b : B) → (t : Δ¹) → C (f t) b [ t ≡ 0₂ ↦ g b])
+          ( flip-ext-fun 2 Δ¹ (\ t → t ≡ 0₂) B (\ t → C (f t)) (\ t → g))
           ( weakfunext B
-            ( \ b → ( (t : Δ¹) → C (f t) b [ t ≡ 0₂ ↦ g b] ) )
+            ( \ b → ((t : Δ¹) → C (f t) b [ t ≡ 0₂ ↦ g b]))
             ( \ b →
               ( has-unique-fixed-domain-lifts-is-covariant
                 ( A)
-                ( \ a  → (C a b))
+                ( \ a → (C a b))
                 ( is-locally-covariant b))
              x y f (g b))))
 
@@ -2057,8 +2059,8 @@ The fibers of a covariant fibration over a Segal type are discrete types.
       ( hom (C x) u)
       ( hom-eq (C x) u)
       ( is-equiv-are-contr
-        ( Σ (y : (C x)) , u = y)
-        ( Σ (y : (C x)) , hom (C x) u y)
+        ( Σ ( y : (C x)) , u = y)
+        ( Σ ( y : (C x)) , hom (C x) u y)
         ( is-contr-based-paths (C x) u)
         ( is-cov-C x x (id-hom A x) u)
         ( total-map
@@ -2099,10 +2101,10 @@ preservation of local types by equivalences.
   : is-discrete A
   :=
   is-discrete-is-Δ¹-local A
-    (is-Δ¹-local-is-left-local A
+    ( is-Δ¹-local-is-left-local A
       ( is-local-type-equiv-is-local-type extext 2 Δ¹ (\ t → t ≡ 0₂) A B A≅B
         ( is-left-local-is-Δ¹-local B
-          (is-Δ¹-local-is-discrete B is-discrete-B))))
+          ( is-Δ¹-local-is-discrete B is-discrete-B))))
 ```
 
 ```rzk title="RS17, Corollary 8.20"
@@ -2116,5 +2118,5 @@ preservation of local types by equivalences.
   ( hom-eq A x y , is-discrete-A x y)
   ( is-discrete-hom-is-segal A
     ( is-segal-is-discrete extext A is-discrete-A)
-    ( x) ( y))
+    ( x) (y))
 ```

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -50,11 +50,11 @@ naturality-covariant-fiberwise-transformation naturality is automatic.
   ( C : A → U)
   ( is-covariant-C : is-covariant A C)
   ( ϕ : (z : A) → hom A a z → C z)
-  : (covariant-transport A x y g C is-covariant-C (ϕ x f)) =
-    (ϕ y (comp-is-segal A is-segal-A a x y f g))
+  : ( covariant-transport A x y g C is-covariant-C (ϕ x f))
+  = ( ϕ y (comp-is-segal A is-segal-A a x y f g))
   :=
     naturality-covariant-fiberwise-transformation A x y g
-      (\ z → hom A a z)
+      ( \ z → hom A a z)
       ( C)
       ( is-covariant-representable-is-segal A is-segal-A a)
       ( is-covariant-C)
@@ -80,7 +80,7 @@ representable functor at the identity arrow.
   ( A : U)
   ( a : A)
   ( C : A → U)
-  : ( (z : A) → hom A a z → C z) → C a
+  : ( ( z : A) → hom A a z → C z) → C a
   := \ ϕ → ϕ a (id-hom A a)
 ```
 
@@ -93,7 +93,7 @@ The inverse map only exists for Segal types.
   ( a : A)
   ( C : A → U)
   ( is-covariant-C : is-covariant A C)
-  : C a → ( (z : A) → hom A a z → C z)
+  : C a → ((z : A) → hom A a z → C z)
   := \ u x f → covariant-transport A a x f C is-covariant-C u
 ```
 
@@ -136,11 +136,11 @@ The composite `#!rzk yon-evid` of `#!rzk ϕ` equals `#!rzk ϕ` at all
   ( ϕ : (z : A) → hom A a z → C z)
   ( x : A)
   ( f : hom A a x)
-  : ( (yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x f = ϕ x f
+  : ( ( yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x f = ϕ x f
   :=
     concat
       ( C x)
-      ( ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x f)
+      ( ( ( yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x f)
       ( ϕ x (comp-is-segal A is-segal-A a a x (id-hom A a) f))
       ( ϕ x f)
       ( naturality-covariant-fiberwise-representable-transformation
@@ -161,7 +161,7 @@ By `#!rzk funext`, these are equals as functions of `#!rzk f` pointwise in
 #def yon-evid-once-pointwise uses (funext)
   ( ϕ : (z : A) → hom A a z → C z)
   ( x : A)
-  : ( (yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x = ϕ x
+  : ( ( yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x = ϕ x
   :=
     eq-htpy funext
       ( hom A a x)
@@ -177,7 +177,7 @@ By `#!rzk funext` again, these are equal as functions of `#!rzk x` and
 ```rzk
 #def yon-evid uses (funext)
   ( ϕ : (z : A) → hom A a z → C z)
-  : ( (yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) = ϕ
+  : ( ( yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) = ϕ
   :=
     eq-htpy funext
       ( A)
@@ -203,10 +203,10 @@ This is proven combining the previous steps.
   ( is-covariant-C : is-covariant A C)
   : is-equiv ((z : A) → hom A a z → C z) (C a) (evid A a C)
   :=
-    ( ( ( yon A is-segal-A a C is-covariant-C) ,
-        ( yon-evid A is-segal-A a C is-covariant-C)) ,
-      ( ( yon A is-segal-A a C is-covariant-C) ,
-        ( evid-yon A is-segal-A a C is-covariant-C)))
+    ( ( ( yon A is-segal-A a C is-covariant-C)
+      , ( yon-evid A is-segal-A a C is-covariant-C))
+    , ( ( yon A is-segal-A a C is-covariant-C)
+      , ( evid-yon A is-segal-A a C is-covariant-C)))
 ```
 
 For later use, we observe that the same proof shows that the inverse map is an
@@ -222,10 +222,10 @@ equivalence.
   : is-equiv (C a) ((z : A) → hom A a z → C z)
       ( yon A is-segal-A a C is-covariant-C)
   :=
-    ( ( ( evid A a C) ,
-        ( evid-yon A is-segal-A a C is-covariant-C)) ,
-      ( ( evid A a C) ,
-        ( yon-evid A is-segal-A a C is-covariant-C)))
+    ( ( ( evid A a C)
+      , ( evid-yon A is-segal-A a C is-covariant-C))
+    , ( ( evid A a C)
+      , ( yon-evid A is-segal-A a C is-covariant-C)))
 ```
 
 ## Naturality
@@ -248,9 +248,9 @@ Naturality in `#!rzk a` follows from the fact that the maps `#!rzk evid` and
     equiv-is-covariant
     ( extext)
     ( A)
-    ( \ a -> (z : A) → hom A a z → C z)
+    ( \ a → (z : A) → hom A a z → C z)
     ( C)
-    ( \ a -> (evid A a C , yoneda-lemma A is-segal-A a C is-covariant-C))
+    ( \ a → (evid A a C , yoneda-lemma A is-segal-A a C is-covariant-C))
     ( is-covariant-C)
 
 #def is-natural-in-object-evid uses (funext extext)
@@ -258,14 +258,14 @@ Naturality in `#!rzk a` follows from the fact that the maps `#!rzk evid` and
   ( is-segal-A : is-segal A)
   ( a b : A)
   ( f : hom A a b)
-  ( C : A -> U)
+  ( C : A → U)
   ( is-covariant-C : is-covariant A C)
   ( ϕ : (z : A) → hom A a z → C z)
-  : ( covariant-transport A a b f C is-covariant-C (evid A a C ϕ)) =
-    ( evid A b C
+  : ( covariant-transport A a b f C is-covariant-C (evid A a C ϕ))
+  = ( evid A b C
 
       ( covariant-transport A a b f
-        ( \ x -> (z : A) → hom A x z → C z)
+        ( \ x → (z : A) → hom A x z → C z)
 
         ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C) ϕ))
   :=
@@ -274,11 +274,11 @@ Naturality in `#!rzk a` follows from the fact that the maps `#!rzk evid` and
     ( a)
     ( b)
     ( f)
-    ( \ x -> (z : A) → hom A x z → C z)
+    ( \ x → (z : A) → hom A x z → C z)
     ( C)
     ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
     ( is-covariant-C)
-    ( \ x -> evid A x C)
+    ( \ x → evid A x C)
     ( ϕ)
 
 #def is-natural-in-object-yon uses (funext extext)
@@ -286,15 +286,15 @@ Naturality in `#!rzk a` follows from the fact that the maps `#!rzk evid` and
   ( is-segal-A : is-segal A)
   ( a b : A)
   ( f : hom A a b)
-  ( C : A -> U)
+  ( C : A → U)
   ( is-covariant-C : is-covariant A C)
   ( u : C a)
   : ( covariant-transport
       A a b f
-      ( \ x -> (z : A) → hom A x z → C z)
+      ( \ x → (z : A) → hom A x z → C z)
       ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
-      ( yon A is-segal-A a C is-covariant-C u)) =
-    ( yon A is-segal-A b C is-covariant-C
+      ( yon A is-segal-A a C is-covariant-C u))
+  = ( yon A is-segal-A b C is-covariant-C
       ( covariant-transport A a b f C is-covariant-C u))
   :=
     naturality-covariant-fiberwise-transformation
@@ -303,10 +303,10 @@ Naturality in `#!rzk a` follows from the fact that the maps `#!rzk evid` and
     ( b)
     ( f)
     ( C)
-    ( \ x -> (z : A) → hom A x z → C z)
+    ( \ x → (z : A) → hom A x z → C z)
     ( is-covariant-C)
     ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
-    ( \ x -> yon A is-segal-A x C is-covariant-C)
+    ( \ x → yon A is-segal-A x C is-covariant-C)
     ( u)
 ```
 
@@ -319,9 +319,9 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( C D : A → U)
   ( ψ : (z : A) → C z → D z)
   ( φ : (z : A) → hom A a z → C z)
-  : ( comp ((z : A) → hom A a z → C z) (C a) (D a) (ψ a) (evid A a C)) φ =
-    ( comp ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z) (D a)
-    ( evid A a D) ( \ α z g → ψ z (α z g))) φ
+  : ( comp ((z : A) → hom A a z → C z) (C a) (D a) (ψ a) (evid A a C)) φ
+  = ( comp ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z) (D a)
+    ( evid A a D) (\ α z g → ψ z (α z g))) φ
   := refl
 ```
 
@@ -338,8 +338,8 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( x : A)
   ( f : hom A a x)
   : ( comp (C a) (D a) ((z : A) → hom A a z → D z)
-      ( yon A is-segal-A a D is-covariant-D) (ψ a)) u x f =
-    ( comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
+      ( yon A is-segal-A a D is-covariant-D) (ψ a)) u x f
+  = ( comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
       ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x f
   :=
     naturality-covariant-fiberwise-transformation
@@ -356,8 +356,8 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( u : C a)
   ( x : A)
   : ( comp (C a) (D a) ((z : A) → hom A a z → D z)
-      ( yon A is-segal-A a D is-covariant-D) (ψ a)) u x =
-    ( comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
+      ( yon A is-segal-A a D is-covariant-D) (ψ a)) u x
+  = ( comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
       ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x
   :=
     eq-htpy funext
@@ -383,8 +383,8 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( ψ : (z : A) → C z → D z)
   ( u : C a)
   : ( comp (C a) (D a) ((z : A) → hom A a z → D z)
-      ( yon A is-segal-A a D is-covariant-D) (ψ a)) u =
-    ( comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
+      ( yon A is-segal-A a D is-covariant-D) (ψ a)) u
+  = ( comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
       ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u
   :=
     eq-htpy funext
@@ -408,7 +408,7 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  :  hom A a' a → (z : A) → hom A a z → hom A a' z
+  : hom A a' a → (z : A) → hom A a z → hom A a' z
   :=
      yon
      ( A)
@@ -421,8 +421,8 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
-  : ( yoneda-embedding A is-segal-A a a') ( ( evid A a ( hom A a')) φ) = φ
+  ( φ : (x : A) → (hom A a x → hom A a' x))
+  : ( yoneda-embedding A is-segal-A a a') ((evid A a (hom A a')) φ) = φ
   :=
      yon-evid
       ( A)
@@ -435,15 +435,15 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
-  : (x : A)
-    → ( ( yoneda-embedding A is-segal-A a a') ( ( evid A a ( hom A a')) φ)) x
+  ( φ : (x : A) → (hom A a x → hom A a' x))
+  : ( x : A)
+    → ( ( yoneda-embedding A is-segal-A a a') ((evid A a (hom A a')) φ)) x
     = φ x
   :=
      htpy-eq
       ( A)
-      ( \ x → ( hom A a x → hom A a' x))
-      ( ( yoneda-embedding A is-segal-A a a') ( ( evid A a ( hom A a')) φ ))
+      ( \ x → (hom A a x → hom A a' x))
+      ( ( yoneda-embedding A is-segal-A a a') ((evid A a (hom A a')) φ))
       ( φ)
       ( compute-yoneda-embedding-evid A is-segal-A a a' φ)
 
@@ -451,17 +451,17 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
+  ( φ : (x : A) → (hom A a x → hom A a' x))
   ( x : A)
   : ( f : hom A a x)
-    → ( ( yoneda-embedding A is-segal-A a a') ( ( evid A a ( hom A a')) φ)) x f
+    → ( ( yoneda-embedding A is-segal-A a a') ((evid A a (hom A a')) φ)) x f
     = φ x f
   :=
      htpy-eq
       ( hom A a x)
       ( \ z → hom A a' x)
       ( ( ( yoneda-embedding A is-segal-A a a')
-          ( ( evid A a ( hom A a')) φ )) x)
+          ( ( evid A a (hom A a')) φ)) x)
       ( φ x)
       ( htpy-compute-yoneda-embedding-evid A is-segal-A a a' φ x)
 
@@ -469,16 +469,16 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
+  ( φ : (x : A) → (hom A a x → hom A a' x))
   ( x : A)
   ( f : hom A a x)
   : φ x f
-    = ( ( yoneda-embedding A is-segal-A a a') ( ( evid A a ( hom A a')) φ)) x f
+    = ( ( yoneda-embedding A is-segal-A a a') ((evid A a (hom A a')) φ)) x f
   :=
      rev
       ( hom A a' x)
       ( ( ( yoneda-embedding A is-segal-A a a')
-          ( ( evid A a ( hom A a')) φ )) x f)
+          ( ( evid A a (hom A a')) φ)) x f)
       ( φ x f)
       ( htpy-yoneda-embedding-evid A is-segal-A a a' φ x f)
 ```
@@ -490,9 +490,9 @@ Define the action by precompostition.
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
-  : ( x : A ) → ( hom A a x → hom A a' x)
-  := \ x f → comp-is-segal A is-segal-A a' a x ( ( evid A a ( hom A a')) φ) f
+  ( φ : (x : A) → (hom A a x → hom A a' x))
+  : ( x : A) → (hom A a x → hom A a' x)
+  := \ x f → comp-is-segal A is-segal-A a' a x ((evid A a (hom A a')) φ) f
 ```
 
 The Yoneda embedding coincides with `#!rzk precomposition-evid-is-segal`.
@@ -502,10 +502,10 @@ The Yoneda embedding coincides with `#!rzk precomposition-evid-is-segal`.
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
+  ( φ : (x : A) → (hom A a x → hom A a' x))
   ( x : A)
   ( f : hom A a x)
-  : ( ( yoneda-embedding A is-segal-A a a') ( ( evid A a ( hom A a')) φ)) x f
+  : ( ( yoneda-embedding A is-segal-A a a') ((evid A a (hom A a')) φ)) x f
     = precomposition-evid-is-segal A is-segal-A a a' φ x f
   :=
      compute-covariant-transport-of-hom-family-is-segal
@@ -514,8 +514,8 @@ The Yoneda embedding coincides with `#!rzk precomposition-evid-is-segal`.
       ( a')
       ( a)
       ( x)
-      ( (evid A a ( hom A a')) φ)
-      ( f )
+      ( ( evid A a (hom A a')) φ)
+      ( f)
 ```
 
 Now we cocatenate the paths to prove the result as stated.
@@ -525,16 +525,16 @@ Now we cocatenate the paths to prove the result as stated.
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
+  ( φ : (x : A) → (hom A a x → hom A a' x))
   ( x : A)
   ( f : hom A a x)
-  : (φ x) f = (precomposition-evid-is-segal A is-segal-A a a' φ x) f
+  : ( φ x) f = (precomposition-evid-is-segal A is-segal-A a a' φ x) f
   :=
      concat
       ( hom A a' x)
       ( φ x f)
       ( ( ( yoneda-embedding A is-segal-A a a')
-          ( ( evid A a ( hom A a')) φ )) x f)
+          ( ( evid A a (hom A a')) φ)) x f)
       ( precomposition-evid-is-segal A is-segal-A a a' φ x f)
       ( rev-compute-htpy-yoneda-embedding-evid A is-segal-A a a' φ x f)
       ( eq-yoneda-embedding-precomposition-evid A is-segal-A a a' φ x f)
@@ -543,7 +543,7 @@ Now we cocatenate the paths to prove the result as stated.
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
+  ( φ : (x : A) → (hom A a x → hom A a' x))
   ( x : A)
   : φ x = precomposition-evid-is-segal A is-segal-A a a' φ x
   :=
@@ -559,13 +559,13 @@ Now we cocatenate the paths to prove the result as stated.
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a a' : A)
-  ( φ : ( x : A) → ( hom A a x → hom A a' x))
+  ( φ : (x : A) → (hom A a x → hom A a' x))
   : φ = precomposition-evid-is-segal A is-segal-A a a' φ
   :=
      eq-htpy
       ( funext)
       ( A)
-      ( \ x → ( hom A a x → hom A a' x))
+      ( \ x → (hom A a x → hom A a' x))
       ( φ)
       ( precomposition-evid-is-segal A is-segal-A a a' φ)
       ( \ x → eq-htpy-precomposition-evid A is-segal-A a a' φ x)
@@ -590,8 +590,8 @@ automatic.
   ( C : A → U)
   ( is-contravariant-C : is-contravariant A C)
   ( ϕ : (z : A) → hom A z a → C z)
-  : ( contravariant-transport A x y g C is-contravariant-C (ϕ y f)) =
-    ( ϕ x (comp-is-segal A is-segal-A x y a g f))
+  : ( contravariant-transport A x y g C is-contravariant-C (ϕ y f))
+  = ( ϕ x (comp-is-segal A is-segal-A x y a g f))
   :=
     naturality-contravariant-fiberwise-transformation A x y g
       ( \ z → hom A z a) C
@@ -617,7 +617,7 @@ a representable functor at the identity arrow.
   ( A : U)
   ( a : A)
   ( C : A → U)
-  : ( (z : A) → hom A z a → C z) → C a
+  : ( ( z : A) → hom A z a → C z) → C a
   := \ ϕ → ϕ a (id-hom A a)
 ```
 
@@ -671,13 +671,13 @@ The composite `#!rzk contra-yon-evid` of `#!rzk ϕ` equals `#!rzk ϕ` at all
   ( ϕ : (z : A) → hom A z a → C z)
   ( x : A)
   ( f : hom A x a)
-  : ( (contra-yon A is-segal-A a C is-contravariant-C)
-        ((contra-evid A a C) ϕ)) x f = ϕ x f
+  : ( ( contra-yon A is-segal-A a C is-contravariant-C)
+        ( ( contra-evid A a C) ϕ)) x f = ϕ x f
   :=
     concat
       ( C x)
-      ( ((contra-yon A is-segal-A a C is-contravariant-C)
-            ((contra-evid A a C) ϕ)) x f)
+      ( ( ( contra-yon A is-segal-A a C is-contravariant-C)
+            ( ( contra-evid A a C) ϕ)) x f)
       ( ϕ x (comp-is-segal A is-segal-A x a a f (id-hom A a)))
       ( ϕ x f)
       ( naturality-contravariant-fiberwise-representable-transformation
@@ -698,15 +698,15 @@ By `#!rzk funext`, these are equals as functions of `#!rzk f` pointwise in
 #def contra-yon-evid-once-pointwise uses (funext)
   ( ϕ : (z : A) → hom A z a → C z)
   ( x : A)
-  : ( (contra-yon A is-segal-A a C is-contravariant-C)
-        ( (contra-evid A a C) ϕ)) x = ϕ x
+  : ( ( contra-yon A is-segal-A a C is-contravariant-C)
+        ( ( contra-evid A a C) ϕ)) x = ϕ x
   :=
     eq-htpy funext
       ( hom A x a)
       ( \ f → C x)
       ( \ f →
-        ( (contra-yon A is-segal-A a C is-contravariant-C)
-          ( (contra-evid A a C) ϕ)) x f)
+        ( ( contra-yon A is-segal-A a C is-contravariant-C)
+          ( ( contra-evid A a C) ϕ)) x f)
       ( \ f → (ϕ x f))
       ( \ f → contra-yon-evid-twice-pointwise ϕ x f)
 ```
@@ -741,10 +741,10 @@ equivalence.
   ( is-contravariant-C : is-contravariant A C)
   : is-equiv ((z : A) → hom A z a → C z) (C a) (contra-evid A a C)
   :=
-    ( ( ( contra-yon A is-segal-A a C is-contravariant-C) ,
-        ( contra-yon-evid A is-segal-A a C is-contravariant-C)) ,
-      ( ( contra-yon A is-segal-A a C is-contravariant-C) ,
-        ( contra-evid-yon A is-segal-A a C is-contravariant-C)))
+    ( ( ( contra-yon A is-segal-A a C is-contravariant-C)
+      , ( contra-yon-evid A is-segal-A a C is-contravariant-C))
+    , ( ( contra-yon A is-segal-A a C is-contravariant-C)
+      , ( contra-evid-yon A is-segal-A a C is-contravariant-C)))
 ```
 
 For later use, we observe that the same proof shows that the inverse map is an
@@ -760,10 +760,10 @@ equivalence.
   : is-equiv (C a) ((z : A) → hom A z a → C z)
       ( contra-yon A is-segal-A a C is-contravariant-C)
   :=
-    ( ( ( contra-evid A a C) ,
-        ( contra-evid-yon A is-segal-A a C is-contravariant-C)) ,
-      ( ( contra-evid A a C) ,
-        ( contra-yon-evid A is-segal-A a C is-contravariant-C)))
+    ( ( ( contra-evid A a C)
+      , ( contra-evid-yon A is-segal-A a C is-contravariant-C))
+    , ( ( contra-evid A a C)
+      , ( contra-yon-evid A is-segal-A a C is-contravariant-C)))
 ```
 
 ## Contravariant naturality
@@ -786,9 +786,9 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( ψ : (z : A) → C z → D z)
   ( φ : (z : A) → hom A z a → C z)
   : ( comp ((z : A) → hom A z a → C z) (C a) (D a)
-      ( ψ a) (contra-evid A a C)) φ =
-    ( comp ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z) (D a)
-      ( contra-evid A a D) ( \ α z g → ψ z (α z g))) φ
+      ( ψ a) (contra-evid A a C)) φ
+  = ( comp ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z) (D a)
+      ( contra-evid A a D) (\ α z g → ψ z (α z g))) φ
   := refl
 ```
 
@@ -805,8 +805,8 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( x : A)
   ( f : hom A x a)
   : ( comp (C a) (D a) ((z : A) → hom A z a → D z)
-      ( contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x f =
-    ( comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
+      ( contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x f
+  = ( comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
       ( \ α z g → ψ z (α z g))
       ( contra-yon A is-segal-A a C is-contravariant-C)) u x f
   :=
@@ -824,10 +824,10 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( u : C a)
   ( x : A)
   : ( comp (C a) (D a) ((z : A) → hom A z a → D z)
-      (contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x =
-    ( comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
-      (\ α z g → ψ z (α z g))
-      (contra-yon A is-segal-A a C is-contravariant-C)) u x
+      ( contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x
+  = ( comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
+      ( \ α z g → ψ z (α z g))
+      ( contra-yon A is-segal-A a C is-contravariant-C)) u x
   :=
     eq-htpy funext
       ( hom A x a)
@@ -853,8 +853,8 @@ Naturality in `#!rzk C` is not automatic but can be proven easily:
   ( ψ : (z : A) → C z → D z)
   ( u : C a)
   : ( comp (C a) (D a) ((z : A) → hom A z a → D z)
-      ( contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u =
-    ( comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
+      ( contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u
+  = ( comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
       ( \ α z g → ψ z (α z g))
       ( contra-yon A is-segal-A a C is-contravariant-C)) u
   :=
@@ -889,7 +889,7 @@ types are contractible.
   ( A : U)
   ( a : A)
   : U
-  := ( x : A) → is-contr (hom A a x)
+  := (x : A) → is-contr (hom A a x)
 ```
 
 Initial objects satisfy an induction principle relative to covariant families.
@@ -921,8 +921,8 @@ Initial objects satisfy an induction principle relative to covariant families.
 #def has-cov-section-ev-pt uses (is-initial-a)
   : has-section ((x : A) → C x) (C a) (ev-pt A a C)
   :=
-    ( ( ind-initial) ,
-      ( \ u →
+    ( ( ind-initial)
+    , ( \ u →
         concat
           ( C a)
           ( covariant-transport A a a
@@ -970,8 +970,8 @@ family defines an inverse equivalence to evaluation at the element.
   ( is-covariant-C : is-covariant A C)
   : is-equiv ((x : A) → C x) (C a) (ev-pt A a C)
   :=
-    ( ( ( ind-initial A a is-initial-a C is-covariant-C) ,
-        ( \ s → eq-htpy
+    ( ( ( ind-initial A a is-initial-a C is-covariant-C)
+      , ( \ s → eq-htpy
                   funext
                     ( A)
                     ( C)
@@ -979,8 +979,8 @@ family defines an inverse equivalence to evaluation at the element.
                         A a is-initial-a C is-covariant-C (ev-pt A a C s))
                     ( s)
                     ( ind-initial-ev-pt-pointwise
-                        A a is-initial-a C is-covariant-C s))) ,
-      ( has-cov-section-ev-pt A a is-initial-a C is-covariant-C))
+                        A a is-initial-a C is-covariant-C s)))
+    , ( has-cov-section-ev-pt A a is-initial-a C is-covariant-C))
 ```
 
 ## Initial objects in slice categories
@@ -999,13 +999,13 @@ following equivalence.
   ( f : hom A a x)
   : Equiv
     ( hom (coslice A a) (a , id-hom A a) (x , f))
-    ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
+    ( ( t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
   :=
-    ( \ h t s → (second (h s)) t ,
-      (( \ k s → ( k 1₂ s , \ t → k t s) ,
-        \ h → refl) ,
-      ( \ k s → ( k 1₂ s , \ t → k t s) ,
-        \ k → refl)))
+    ( \ h t s → (second (h s)) t
+    , ( ( \ k s → (k 1₂ s , \ t → k t s)
+      , \ h → refl)
+    , ( \ k s → (k 1₂ s , \ t → k t s)
+      , \ k → refl)))
 ```
 
 Since `#!rzk hom A a` is covariant when `#!rzk A` is Segal, this latter type is
@@ -1017,7 +1017,7 @@ contractible.
   ( is-segal-A : is-segal A)
   ( a x : A)
   ( f : hom A a x)
-  : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
+  : is-contr ((t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
   :=
     ( second (has-unique-fixed-domain-lifts-iff-is-covariant
                 A (\ z → hom A a z)))
@@ -1040,7 +1040,7 @@ This proves the initiality of identity arrows in the coslice of a Segal type.
     \ (x , f) →
     is-contr-equiv-is-contr'
       ( hom (coslice A a) (a , id-hom A a) (x , f))
-      ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
+      ( ( t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
       ( equiv-hom-in-coslice A a x f)
       ( is-contr-is-segal-hom-in-coslice A is-segal-A a x f)
 ```
@@ -1054,7 +1054,7 @@ The dependent Yoneda lemma now follows by specializing these results.
   ( A : U)
   ( a : A)
   ( C : (coslice A a) → U)
-  : ( (p : coslice A a) → C p) → C (a , id-hom A a)
+  : ( ( p : coslice A a) → C p) → C (a , id-hom A a)
   := \ s → s (a , id-hom A a)
 
 #def dependent-yoneda-lemma' uses (funext)
@@ -1064,13 +1064,13 @@ The dependent Yoneda lemma now follows by specializing these results.
   ( C : (coslice A a) → U)
   ( is-covariant-C : is-covariant (coslice A a) C)
   : is-equiv
-      ( (p : coslice A a) → C p)
+      ( ( p : coslice A a) → C p)
       ( C (a , id-hom A a))
       ( dependent-evid A a C)
   :=
     is-equiv-covariant-ev-initial
       ( coslice A a)
-      ( (a , id-hom A a))
+      ( ( a , id-hom A a))
       ( is-initial-id-hom-is-segal A is-segal-A a)
       ( C)
       ( is-covariant-C)
@@ -1087,13 +1087,13 @@ an equivalent type in the domain of the evaluation map.
   ( C : (coslice A a) → U)
   ( is-covariant-C : is-covariant (coslice A a) C)
   : is-equiv
-      ( (x : A) → (f : hom A a x) → C (x , f))
+      ( ( x : A) → (f : hom A a x) → C (x , f))
       ( C (a , id-hom A a))
       ( \ s → s a (id-hom A a))
   :=
     is-equiv-left-factor
-      ( (p : coslice A a) → C p)
-      ( (x : A) → (f : hom A a x) → C (x , f))
+      ( ( p : coslice A a) → C p)
+      ( ( x : A) → (f : hom A a x) → C (x , f))
       ( C (a , id-hom A a))
       ( first (equiv-dependent-curry A (\ z → hom A a z) (\ x f → C (x , f))))
       ( second (equiv-dependent-curry A (\ z → hom A a z) (\ x f → C (x , f))))
@@ -1144,8 +1144,8 @@ Final objects satisfy an induction principle relative to contravariant families.
 #def has-contra-section-ev-pt uses (is-final-a)
   : has-section ((x : A) → C x) (C a) (ev-pt A a C)
   :=
-    ( ( ind-final) ,
-      ( \ u →
+    ( ( ind-final)
+    , ( \ u →
         concat
           ( C a)
           ( contravariant-transport A a a
@@ -1193,8 +1193,8 @@ family defines an inverse equivalence to evaluation at the element.
   ( is-contravariant-C : is-contravariant A C)
   : is-equiv ((x : A) → C x) (C a) (ev-pt A a C)
   :=
-    ( ( ( ind-final A a is-final-a C is-contravariant-C) ,
-        ( \ s → eq-htpy
+    ( ( ( ind-final A a is-final-a C is-contravariant-C)
+      , ( \ s → eq-htpy
                   funext
                     ( A)
                     ( C)
@@ -1202,8 +1202,8 @@ family defines an inverse equivalence to evaluation at the element.
                         A a is-final-a C is-contravariant-C (ev-pt A a C s))
                     ( s)
                     ( ind-final-ev-pt-pointwise
-                        A a is-final-a C is-contravariant-C s))) ,
-      ( has-contra-section-ev-pt A a is-final-a C is-contravariant-C))
+                        A a is-final-a C is-contravariant-C s)))
+    , ( has-contra-section-ev-pt A a is-final-a C is-contravariant-C))
 ```
 
 ## Final objects in slice categories
@@ -1222,13 +1222,13 @@ equivalence.
   ( f : hom A x a)
   : Equiv
     ( hom (slice A a) (x , f) (a , id-hom A a))
-    ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
+    ( ( t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
   :=
-    ( \ h t s → (second (h s)) t ,
-      (( \ k s → ( k 0₂ s , \ t → k t s) ,
-        \ h → refl) ,
-      ( \ k s → ( k 0₂ s , \ t → k t s) ,
-        \ k → refl)))
+    ( \ h t s → (second (h s)) t
+    , ( ( \ k s → (k 0₂ s , \ t → k t s)
+      , \ h → refl)
+    , ( \ k s → (k 0₂ s , \ t → k t s)
+      , \ k → refl)))
 ```
 
 Since `#!rzk \ z → hom A z a` is contravariant when `#!rzk A` is Segal, this
@@ -1240,7 +1240,7 @@ latter type is contractible.
   ( is-segal-A : is-segal A)
   ( a x : A)
   ( f : hom A x a)
-  : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
+  : is-contr ((t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
   :=
     ( second (has-unique-fixed-codomain-lifts-iff-is-contravariant
                 A (\ z → hom A z a)))
@@ -1263,7 +1263,7 @@ This proves the finality of identity arrows in the slice of a Segal type.
     \ (x , f) →
     is-contr-equiv-is-contr'
       ( hom (slice A a) (x , f) (a , id-hom A a))
-      ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
+      ( ( t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
       ( equiv-hom-in-slice A a x f)
       ( is-contr-is-segal-hom-in-slice A is-segal-A a x f)
 ```
@@ -1278,7 +1278,7 @@ specializing these results.
   ( A : U)
   ( a : A)
   ( C : (slice A a) → U)
-  : ((p : slice A a) → C p) → C (a , id-hom A a)
+  : ( ( p : slice A a) → C p) → C (a , id-hom A a)
   := \ s → s (a , id-hom A a)
 
 #def contra-dependent-yoneda-lemma' uses (funext)
@@ -1288,13 +1288,13 @@ specializing these results.
   ( C : (slice A a) → U)
   ( is-contravariant-C : is-contravariant (slice A a) C)
   : is-equiv
-      ( (p : slice A a) → C p)
+      ( ( p : slice A a) → C p)
       ( C (a , id-hom A a))
       ( contra-dependent-evid A a C)
   :=
     is-equiv-contravariant-ev-final
       ( slice A a)
-      ( (a , id-hom A a))
+      ( ( a , id-hom A a))
       ( is-final-id-hom-is-segal A is-segal-A a)
       ( C)
       ( is-contravariant-C)
@@ -1311,13 +1311,13 @@ proven, just with an equivalent type in the domain of the evaluation map.
   ( C : (slice A a) → U)
   ( is-contravariant-C : is-contravariant (slice A a) C)
   : is-equiv
-      ( (x : A) → (f : hom A x a) → C (x , f))
+      ( ( x : A) → (f : hom A x a) → C (x , f))
       ( C (a , id-hom A a))
       ( \ s → s a (id-hom A a))
   :=
     is-equiv-left-factor
-      ( (p : slice A a) → C p)
-      ( (x : A) → (f : hom A x a) → C (x , f))
+      ( ( p : slice A a) → C p)
+      ( ( x : A) → (f : hom A x a) → C (x , f))
       ( C (a , id-hom A a))
       ( first (equiv-dependent-curry A (\ z → hom A z a) (\ x f → C (x , f))))
       ( second (equiv-dependent-curry A (\ z → hom A z a) (\ x f → C (x , f))))
@@ -1348,7 +1348,7 @@ give a helper function.
   ( A : U)
   ( C : A → U)
   ( is-rep-C : is-representable-family A C)
-  : (x : A) → (hom A (first is-rep-C) x) → (C x)
+  : ( x : A) → (hom A (first is-rep-C) x) → (C x)
   := \ x → first((second (is-rep-C)) x)
 ```
 

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -25,7 +25,7 @@ extensionality and weak function extensionality:
   ( f : hom A x y)
   ( g : hom A y x)
   : U
-  := ( comp-is-segal A is-segal-A x y x f g) =_{hom A x x} (id-hom A x)
+  := (comp-is-segal A is-segal-A x y x f g) =_{hom A x x} (id-hom A x)
 
 #def Retraction-arrow
   ( A : U)
@@ -33,7 +33,7 @@ extensionality and weak function extensionality:
   ( x y : A)
   ( f : hom A x y)
   : U
-  := Σ ( g : hom A y x) , ( has-retraction-arrow A is-segal-A x y f g)
+  := Σ (g : hom A y x) , (has-retraction-arrow A is-segal-A x y f g)
 
 #def has-section-arrow
   ( A : U)
@@ -42,13 +42,13 @@ extensionality and weak function extensionality:
   ( f : hom A x y)
   ( h : hom A y x)
   : U
-  := ( comp-is-segal A is-segal-A y x y h f) =_{hom A y y} (id-hom A y)
+  := (comp-is-segal A is-segal-A y x y h f) =_{hom A y y} (id-hom A y)
 
 #def Section-arrow
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
   : U
   := Σ (h : hom A y x) , (has-section-arrow A is-segal-A x y f h)
 
@@ -68,7 +68,7 @@ extensionality and weak function extensionality:
   ( is-segal-A : is-segal A)
   ( x y : A)
   : U
-  := Σ ( f : hom A x y) , is-iso-arrow A is-segal-A x y f
+  := Σ (f : hom A x y) , is-iso-arrow A is-segal-A x y f
 ```
 
 ## Invertible arrows
@@ -85,8 +85,8 @@ invertible, meaning `#!rzk f` has a two-sided composition inverse
   ( f : hom A x y)
   : U
   :=
-    Σ ( g : hom A y x) ,
-      product
+    Σ ( g : hom A y x)
+    , product
       ( has-retraction-arrow A is-segal-A x y f g)
       ( has-section-arrow A is-segal-A x y f g)
 
@@ -104,12 +104,12 @@ invertible, meaning `#!rzk f` has a two-sided composition inverse
   ( is-segal-A : is-segal A)
   ( x y : A)
   ( f : hom A x y)
-  : (is-iso-arrow A is-segal-A x y f) → (has-inverse-arrow A is-segal-A x y f)
+  : ( is-iso-arrow A is-segal-A x y f) → (has-inverse-arrow A is-segal-A x y f)
   :=
     ( \ ((g , p) , (h , q)) →
-      ( g ,
-        ( p ,
-          ( concat
+      ( g
+      , ( p
+        , ( concat
             ( hom A y y)
             ( comp-is-segal A is-segal-A y x y g f)
             ( comp-is-segal A is-segal-A y x y h f)
@@ -125,7 +125,7 @@ invertible, meaning `#!rzk f` has a two-sided composition inverse
                   ( g)
                   ( id-comp-is-segal A is-segal-A y x g))
                 ( comp-is-segal A is-segal-A y y x
-                  ( comp-is-segal A is-segal-A y x y h f) ( g))
+                  ( comp-is-segal A is-segal-A y x y h f) (g))
                 ( postwhisker-homotopy-is-segal A is-segal-A y y x
                   ( id-hom A y)
                   ( comp-is-segal A is-segal-A y x y h f)
@@ -156,8 +156,8 @@ invertible, meaning `#!rzk f` has a two-sided composition inverse
   ( f : hom A x y)
   : iff (has-inverse-arrow A is-segal-A x y f) (is-iso-arrow A is-segal-A x y f)
   :=
-    ( is-iso-arrow-has-inverse-arrow A is-segal-A x y f ,
-      has-inverse-arrow-is-iso-arrow A is-segal-A x y f)
+    ( is-iso-arrow-has-inverse-arrow A is-segal-A x y f
+    , has-inverse-arrow-is-iso-arrow A is-segal-A x y f)
 ```
 
 ## Being an isomorphism is a proposition
@@ -172,19 +172,19 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( f : hom A x y)
   ( g : hom A y x)
   ( gg : has-retraction-arrow A is-segal-A x y f g)
-  : ( z : A) →
-    has-retraction (hom A z x) (hom A z y)
+  : ( z : A)
+  → has-retraction (hom A z x) (hom A z y)
       ( postcomp-is-segal A is-segal-A x y f z)
   :=
     \ z →
-    ( ( postcomp-is-segal A is-segal-A y x g z) ,
-        \ k →
+    ( ( postcomp-is-segal A is-segal-A y x g z)
+      , \ k →
       ( triple-concat
         ( hom A z x)
         ( comp-is-segal A is-segal-A z y x
           ( comp-is-segal A is-segal-A z x y k f) g)
         ( comp-is-segal A is-segal-A z x x
-          k ( comp-is-segal A is-segal-A x y x f g))
+          k (comp-is-segal A is-segal-A x y x f g))
         ( comp-is-segal A is-segal-A z x x k (id-hom A x))
         ( k)
         ( associative-is-segal extext A is-segal-A z x y x k f g)
@@ -199,12 +199,12 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( f : hom A x y)
   ( h : hom A y x)
   ( hh : has-section-arrow A is-segal-A x y f h)
-  : ( z : A) →
-    has-section (hom A z x) (hom A z y) (postcomp-is-segal A is-segal-A x y f z)
+  : ( z : A)
+  → has-section (hom A z x) (hom A z y) (postcomp-is-segal A is-segal-A x y f z)
   :=
     \ z →
-    ( ( postcomp-is-segal A is-segal-A y x h z) ,
-        \ k →
+    ( ( postcomp-is-segal A is-segal-A y x h z)
+      , \ k →
         ( triple-concat
           ( hom A z y)
           ( comp-is-segal A is-segal-A z x y
@@ -227,12 +227,12 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( gg : has-retraction-arrow A is-segal-A x y f g)
   ( h : hom A y x)
   ( hh : has-section-arrow A is-segal-A x y f h)
-  : (z : A) →
-    is-equiv (hom A z x) (hom A z y) (postcomp-is-segal A is-segal-A x y f z)
+  : ( z : A)
+  → is-equiv (hom A z x) (hom A z y) (postcomp-is-segal A is-segal-A x y f z)
   :=
     \ z →
-    ( ( has-retraction-postcomp-has-retraction A is-segal-A x y f g gg z) ,
-      ( has-section-postcomp-has-section A is-segal-A x y f h hh z))
+    ( ( has-retraction-postcomp-has-retraction A is-segal-A x y f g gg z)
+    , ( has-section-postcomp-has-section A is-segal-A x y f h hh z))
 
 #def has-retraction-precomp-has-section uses (extext)
   ( A : U)
@@ -241,13 +241,13 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( f : hom A x y)
   ( h : hom A y x)
   ( hh : has-section-arrow A is-segal-A x y f h)
-  : (z : A) →
-    has-retraction (hom A y z) (hom A x z)
+  : ( z : A)
+  → has-retraction (hom A y z) (hom A x z)
       ( precomp-is-segal A is-segal-A x y f z)
   :=
     \ z →
-    ( ( precomp-is-segal A is-segal-A y x h z) ,
-        \ k →
+    ( ( precomp-is-segal A is-segal-A y x h z)
+      , \ k →
         ( triple-concat
           ( hom A y z)
           ( comp-is-segal A is-segal-A y x z
@@ -277,12 +277,12 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( f : hom A x y)
   ( g : hom A y x)
   ( gg : has-retraction-arrow A is-segal-A x y f g)
-  : (z : A) →
-    has-section (hom A y z) (hom A x z) (precomp-is-segal A is-segal-A x y f z)
+  : ( z : A)
+  → has-section (hom A y z) (hom A x z) (precomp-is-segal A is-segal-A x y f z)
   :=
     \ z →
-    ( ( precomp-is-segal A is-segal-A y x g z) ,
-        \ k →
+    ( ( precomp-is-segal A is-segal-A y x g z)
+      , \ k →
         ( triple-concat
           ( hom A x z)
           ( comp-is-segal A is-segal-A x y z
@@ -315,12 +315,12 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( gg : has-retraction-arrow A is-segal-A x y f g)
   ( h : hom A y x)
   ( hh : has-section-arrow A is-segal-A x y f h)
-  : (z : A) →
-    is-equiv (hom A y z) (hom A x z) (precomp-is-segal A is-segal-A x y f z)
+  : ( z : A)
+  → is-equiv (hom A y z) (hom A x z) (precomp-is-segal A is-segal-A x y f z)
   :=
     \ z →
-      ( ( has-retraction-precomp-has-section A is-segal-A x y f h hh z) ,
-        ( has-section-precomp-has-retraction A is-segal-A x y f g gg z))
+      ( ( has-retraction-precomp-has-section A is-segal-A x y f h hh z)
+      , ( has-section-precomp-has-retraction A is-segal-A x y f g gg z))
 
 #def is-contr-Retraction-arrow-is-iso uses (extext)
   ( A : U)
@@ -382,7 +382,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( is-segal-A : is-segal A)
   ( x y : A)
   ( f : hom A x y)
-  : (is-prop (is-iso-arrow A is-segal-A x y f))
+  : ( is-prop (is-iso-arrow A is-segal-A x y f))
   :=
     ( is-prop-is-contr-is-inhabited
       ( is-iso-arrow A is-segal-A x y f)
@@ -404,23 +404,23 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( f g : (x : X) → A x)
   ( α : nat-trans X A f g)
   : ( is-iso-arrow
-      ( (x : X) → A x)
-      ( is-segal-function-type funext X A is-segal-A) f g α) →
-    ( x : X) →
-    ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
+      ( ( x : X) → A x)
+      ( is-segal-function-type funext X A is-segal-A) f g α)
+  → ( x : X)
+  → ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
       ( ev-components-nat-trans X A f g α x))
   :=
     \ ((β , p) , (γ , q)) →
     \ x →
-    ( ( ( ev-components-nat-trans X A g f β x) ,
-        ( triple-concat
+    ( ( ( ev-components-nat-trans X A g f β x)
+      , ( triple-concat
           ( hom (A x) (f x) (f x))
           ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
             ( ev-components-nat-trans X A f g α x)
             ( ev-components-nat-trans X A g f β x))
           ( ev-components-nat-trans X A f f
             ( comp-is-segal
-              ( (x' : X) → (A x'))
+              ( ( x' : X) → (A x'))
               ( is-segal-function-type funext X A is-segal-A) f g f α β)
             ( x))
           ( ev-components-nat-trans X A f f (id-hom ((x' : X) → (A x')) f) x)
@@ -431,21 +431,21 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
             ( nat-trans X A f f)
             ( hom (A x) (f x) (f x))
             ( comp-is-segal
-              ( (x' : X) → (A x'))
+              ( ( x' : X) → (A x'))
               ( is-segal-function-type funext X A is-segal-A) f g f α β)
             ( id-hom ((x' : X) → (A x')) f)
-            (\ α' → ev-components-nat-trans X A f f α' x)
+            ( \ α' → ev-components-nat-trans X A f f α' x)
             ( p))
-          ( id-arr-components-id-nat-trans X A f x))) ,
-      ( ( ev-components-nat-trans X A g f γ x) ,
-        ( triple-concat
-          (hom (A x) (g x) (g x))
+          ( id-arr-components-id-nat-trans X A f x)))
+    , ( ( ev-components-nat-trans X A g f γ x)
+      , ( triple-concat
+          ( hom (A x) (g x) (g x))
           ( comp-is-segal (A x) (is-segal-A x) (g x) (f x) (g x)
             ( ev-components-nat-trans X A g f γ x)
             ( ev-components-nat-trans X A f g α x))
           ( ev-components-nat-trans X A g g
             ( comp-is-segal
-              ( (x' : X) → (A x'))
+              ( ( x' : X) → (A x'))
               ( is-segal-function-type funext X A is-segal-A) g f g γ α)
             ( x))
           ( ev-components-nat-trans X A g g (id-hom ((x' : X) → (A x')) g) x)
@@ -456,7 +456,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
             ( nat-trans X A g g)
             ( hom (A x) (g x) (g x))
             ( comp-is-segal
-              ( (x' : X) → (A x'))
+              ( ( x' : X) → (A x'))
               ( is-segal-function-type funext X A is-segal-A) g f g γ α)
             ( id-hom ((x' : X) → (A x')) g)
             ( \ α' → ev-components-nat-trans X A g g α' x)
@@ -470,16 +470,16 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( f g : (x : X) → A x)
   ( α : nat-trans X A f g)
   ( β : nat-trans X A g f)
-  : ( ( x : X) →
-      ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
+  : ( ( x : X)
+    → ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
         ( ev-components-nat-trans X A f g α x)
-        ( ev-components-nat-trans X A g f β x)) =
-      (id-hom (A x) (f x))) →
-    ( comp-is-segal
-      ( (x' : X) → A x')
+        ( ev-components-nat-trans X A g f β x))
+    = ( id-hom (A x) (f x)))
+  → ( comp-is-segal
+      ( ( x' : X) → A x')
       ( is-segal-function-type funext X A is-segal-A)
-      f g f α β) =
-    (id-hom ((x' : X) → A x') f)
+      f g f α β)
+  = ( id-hom ((x' : X) → A x') f)
   :=
     \ H →
     ap
@@ -488,7 +488,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
       ( \ x →
         ev-components-nat-trans X A f f
           ( comp-is-segal
-            ( (x' : X) → A x')
+            ( ( x' : X) → A x')
             ( is-segal-function-type funext X A is-segal-A)
             f g f α β)
           ( x))
@@ -496,7 +496,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
       ( first
         ( has-inverse-is-equiv
           ( hom ((x' : X) → A x') f f)
-          ( (x : X) → hom (A x) (f x) (f x))
+          ( ( x : X) → hom (A x) (f x) (f x))
           ( ev-components-nat-trans X A f f)
           ( is-equiv-ev-components-nat-trans X A f f)))
       ( eq-htpy funext X
@@ -504,7 +504,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
         ( \ x →
           ( ev-components-nat-trans X A f f
             ( comp-is-segal
-              ( (x' : X) → A x')
+              ( ( x' : X) → A x')
               ( is-segal-function-type funext X A is-segal-A)
               f g f α β)
             ( x)))
@@ -514,7 +514,7 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
             ( hom (A x) (f x) (f x))
             ( ev-components-nat-trans X A f f
               ( comp-is-segal
-                ( (x' : X) → A x')
+                ( ( x' : X) → A x')
                 ( is-segal-function-type funext X A is-segal-A)
                 f g f α β)
               ( x))
@@ -524,13 +524,13 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
             ( id-hom (A x) (f x))
             ( ev-components-nat-trans X A f f (id-hom ((x' : X) → A x') f) x)
             ( rev
-              (hom (A x) (f x) (f x))
+              ( hom (A x) (f x) (f x))
               ( comp-is-segal (A x) (is-segal-A x) (f x) (g x) (f x)
                 ( ev-components-nat-trans X A f g α x)
                 ( ev-components-nat-trans X A g f β x))
               ( ev-components-nat-trans X A f f
                 ( comp-is-segal
-                  ( (x' : X) → A x')
+                  ( ( x' : X) → A x')
                   ( is-segal-function-type funext X A is-segal-A)
                   f g f α β)
                 ( x))
@@ -549,21 +549,21 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( is-segal-A : (x : X) → is-segal (A x))
   ( f g : (x : X) → A x)
   ( α : nat-trans X A f g)
-  : ( ( x : X) →
-      ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
-        ( ev-components-nat-trans X A f g α x))) →
-    ( is-iso-arrow
-      ( (x' : X) → A x')
+  : ( ( x : X)
+    → ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
+        ( ev-components-nat-trans X A f g α x)))
+  → ( is-iso-arrow
+      ( ( x' : X) → A x')
       ( is-segal-function-type funext X A is-segal-A) f g α)
   :=
     \ H →
-    ( ( \ t x → (first (first (H x))) t ,
-        nat-trans-nat-trans-components-preserves-iso-helper X A is-segal-A f g
+    ( ( \ t x → (first (first (H x))) t
+      , nat-trans-nat-trans-components-preserves-iso-helper X A is-segal-A f g
           ( α)
           ( \ t x → (first (first (H x))) t)
-          ( \ x → (second (first (H x))))) ,
-      ( \ t x → (first (second (H x))) t ,
-        nat-trans-nat-trans-components-preserves-iso-helper X A is-segal-A g f
+          ( \ x → (second (first (H x)))))
+    , ( \ t x → (first (second (H x))) t
+      , nat-trans-nat-trans-components-preserves-iso-helper X A is-segal-A g f
           ( \ t x → (first (second (H x))) t)
           ( α)
           ( \ x → (second (second (H x))))))
@@ -576,18 +576,18 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( α : nat-trans X A f g)
   : iff
     ( is-iso-arrow
-      ( (x : X) → A x)
+      ( ( x : X) → A x)
       ( is-segal-function-type funext X A is-segal-A) f g α)
-    ( ( x : X) →
-        ( is-iso-arrow
+    ( ( x : X)
+      → ( is-iso-arrow
           ( A x)
           ( is-segal-A x)
           ( f x)
           ( g x)
           ( ev-components-nat-trans X A f g α x)))
   :=
-    ( ev-components-nat-trans-preserves-iso X A is-segal-A f g α,
-      nat-trans-nat-trans-components-preserves-iso X A is-segal-A f g α)
+    ( ev-components-nat-trans-preserves-iso X A is-segal-A f g α
+    , nat-trans-nat-trans-components-preserves-iso X A is-segal-A f g α)
 
 #def equiv-is-iso-pointwise-is-iso uses (extext funext weakfunext)
   ( X : U)
@@ -597,10 +597,10 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   ( α : nat-trans X A f g)
   : Equiv
     ( is-iso-arrow
-      ( (x : X) → A x)
+      ( ( x : X) → A x)
       ( is-segal-function-type funext X A is-segal-A) f g α)
-    ( ( x : X) →
-        ( is-iso-arrow
+    ( ( x : X)
+      → ( is-iso-arrow
           ( A x)
           ( is-segal-A x)
           ( f x)
@@ -609,17 +609,17 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   :=
     equiv-iff-is-prop-is-prop
       ( is-iso-arrow
-        ( (x : X) → A x)
+        ( ( x : X) → A x)
         ( is-segal-function-type funext X A is-segal-A) f g α)
-      ( ( x : X) →
-        ( is-iso-arrow
+      ( ( x : X)
+      → ( is-iso-arrow
           ( A x)
           ( is-segal-A x)
           ( f x)
           ( g x)
           ( ev-components-nat-trans X A f g α x)))
       ( is-prop-is-iso-arrow
-        ( (x : X) → A x)
+        ( ( x : X) → A x)
         ( is-segal-function-type funext X A is-segal-A)
         ( f)
         ( g)
@@ -655,23 +655,23 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
   :=
     equiv-triple-comp
       ( Iso ((x : X) → A x) (is-segal-function-type funext X A is-segal-A) f g)
-      ( Σ ( α : nat-trans X A f g) ,
-        ( x : X) →
-        ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
+      ( Σ ( α : nat-trans X A f g)
+      , ( x : X)
+      → ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
           ( ev-components-nat-trans X A f g α x)))
-      ( Σ ( α' : nat-trans-components X A f g) ,
-        ( x : X) → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) (α' x))
-      ( (x : X) → Iso (A x) (is-segal-A x) (f x) (g x))
+      ( Σ ( α' : nat-trans-components X A f g)
+      , ( x : X) → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) (α' x))
+      ( ( x : X) → Iso (A x) (is-segal-A x) (f x) (g x))
       ( total-equiv-family-of-equiv
         ( nat-trans X A f g)
         ( \ α →
           ( is-iso-arrow
-            ( (x : X) → A x)
+            ( ( x : X) → A x)
             ( is-segal-function-type funext X A is-segal-A)
             f g α))
         ( \ α →
-          ( x : X) →
-          ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
+          ( x : X)
+        → ( is-iso-arrow (A x) (is-segal-A x) (f x) (g x)
             ( ev-components-nat-trans X A f g α x)))
         ( \ α → equiv-is-iso-pointwise-is-iso X A is-segal-A f g α))
       ( equiv-total-pullback-is-equiv
@@ -682,9 +682,9 @@ The predicate `#!rzk is-iso-arrow` is a proposition.
         ( \ α' →
           ( x : X) → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) (α' x)))
       ( inv-equiv
-        ( (x : X) → Iso (A x) (is-segal-A x) (f x) (g x))
-        ( Σ ( α' : nat-trans-components X A f g) ,
-          ( x : X) → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) (α' x))
+        ( ( x : X) → Iso (A x) (is-segal-A x) (f x) (g x))
+        ( Σ ( α' : nat-trans-components X A f g)
+        , ( x : X) → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) (α' x))
         ( equiv-choice X
           ( \ x → hom (A x) (f x) (g x))
           ( \ x αₓ → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) αₓ)))
@@ -708,8 +708,8 @@ isomorphism.
 #def iso-id-arrow
   ( A : U)
   ( is-segal-A : is-segal A)
-  : (x : A) → Iso A is-segal-A x x
-  := \ x → ( id-hom A x , is-iso-arrow-id-hom A is-segal-A x)
+  : ( x : A) → Iso A is-segal-A x x
+  := \ x → (id-hom A x , is-iso-arrow-id-hom A is-segal-A x)
 ```
 
 More generally, every path induces an isomorphism.
@@ -731,7 +731,7 @@ More generally, every path induces an isomorphism.
   ( A : U)
   ( is-segal-A : is-segal A)
   ( x y : A)
-  : (x = y) → Iso A is-segal-A x y
+  : ( x = y) → Iso A is-segal-A x y
   := \ p → (hom-eq A x y p , is-iso-arrow-hom-eq A is-segal-A x y p)
 ```
 
@@ -744,8 +744,8 @@ map from `#!rzk x = y` to `#!rzk Iso A is-segal-A x y` is an equivalence.
   : U
   :=
     Σ ( is-segal-A : is-segal A)
-    , ( (x : A)
-      → (y : A)
+    , ( ( x : A)
+      → ( y : A)
       → is-equiv (x = y) (Iso A is-segal-A x y) (iso-eq A is-segal-A x y))
 ```
 
@@ -766,19 +766,19 @@ The inverse to `#!rzk iso-eq` for a Rezk type.
   ( A : U)
   ( is-rezk-A : is-rezk A)
   ( x y : A)
-  ( (e, is-iso-e) : Iso A (first is-rezk-A) x y)
-  : first (iso-eq A (first is-rezk-A) x y (eq-iso-is-rezk A is-rezk-A x y (e, is-iso-e))) = e
+  ( ( e , is-iso-e) : Iso A (first is-rezk-A) x y)
+  : first (iso-eq A (first is-rezk-A) x y (eq-iso-is-rezk A is-rezk-A x y (e , is-iso-e))) = e
   :=
     first-path-Σ
     ( hom A x y)
     ( is-iso-arrow A (first is-rezk-A) x y)
     ( iso-eq A (first is-rezk-A) x y
-      ( eq-iso-is-rezk A is-rezk-A x y (e, is-iso-e)))
-    ( (e, is-iso-e))
+      ( eq-iso-is-rezk A is-rezk-A x y (e , is-iso-e)))
+    ( ( e , is-iso-e))
     ( ( second
       ( has-section-is-equiv (x = y) (Iso A (first is-rezk-A) x y)
         ( iso-eq A (first is-rezk-A) x y)
-        ( ( second is-rezk-A) x y))) (e, is-iso-e))
+        ( ( second is-rezk-A) x y))) (e , is-iso-e))
 ```
 
 The following results show how `#!rzk iso-eq` mediates between the
@@ -830,15 +830,15 @@ arrows.
   ( f : A → B)
   ( x y : A)
   ( e : x = y)
-  : ( ap-hom A B f x y (first (iso-eq A is-segal-A x y e))) =
-    ( first ( iso-eq B is-segal-B (f x) (f y) (ap A B x y f e)))
+  : ( ap-hom A B f x y (first (iso-eq A is-segal-A x y e)))
+  = ( first (iso-eq B is-segal-B (f x) (f y) (ap A B x y f e)))
   :=
     ind-path
       ( A)
       ( x)
       ( \ y' e' →
-        ( ap-hom A B f x y' (first (iso-eq A is-segal-A x y' e'))) =
-        ( first (iso-eq B is-segal-B (f x) (f y') (ap A B x y' f e'))))
+        ( ap-hom A B f x y' (first (iso-eq A is-segal-A x y' e')))
+      = ( first (iso-eq B is-segal-B (f x) (f y') (ap A B x y' f e'))))
       ( refl)
       ( y)
       ( e)

--- a/src/simplicial-hott/11-adjunctions.rzk.md
+++ b/src/simplicial-hott/11-adjunctions.rzk.md
@@ -30,7 +30,7 @@ appropriate hom types.
 #def transposing-adj
   ( A B : U)
   : U
-  := Σ (f : A → B), Σ (u : B → A), is-transposing-adj A B f u
+  := Σ (f : A → B) , Σ (u : B → A) , is-transposing-adj A B f u
 ```
 
 A functor `#!rzk f : A → B` is a transposing left adjoint if it has a
@@ -43,13 +43,13 @@ and `#!rzk B` is Segal.
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (u : B → A), is-transposing-adj A B f u
+  := Σ (u : B → A) , is-transposing-adj A B f u
 
 #def is-transposing-right-adj
   ( A B : U)
   ( u : B → A)
   : U
-  := Σ (f : A → B), is-transposing-adj A B f u
+  := Σ (f : A → B) , is-transposing-adj A B f u
 ```
 
 ## Quasi-diagrammatic adjunctions
@@ -69,18 +69,18 @@ transformations, and a pair of witnesses to the triangle identities.
   , Σ ( ϵ : nat-trans B (\ _ → B) (comp B A B f u) (identity B))
     , product
       ( hom2 (B → A) u (triple-comp B A B A u f u) u
-        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
         ( id-hom (B → A) u))
       ( hom2 (A → B) f (triple-comp A B A B f u f) f
-        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
+        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
         ( id-hom (A → B) f))
 
 #def quasi-diagrammatic-adj
   ( A B : U)
   : U
-  := Σ (f : A → B), Σ (u : B → A), has-quasi-diagrammatic-adj A B f u
+  := Σ (f : A → B) , Σ (u : B → A) , has-quasi-diagrammatic-adj A B f u
 ```
 
 Quasi-diagrammatic adjunctions have left and right adjoints, but being the left
@@ -92,13 +92,13 @@ Thus, we assign slightly different names to the following types.
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (u : B → A), has-quasi-diagrammatic-adj A B f u
+  := Σ (u : B → A) , has-quasi-diagrammatic-adj A B f u
 
 #def has-quasi-diagrammatic-left-adj
   ( A B : U)
   ( u : B → A)
   : U
-  := Σ (f : A → B), has-quasi-diagrammatic-adj A B f u
+  := Σ (f : A → B) , has-quasi-diagrammatic-adj A B f u
 ```
 
 The following projection functions extract the core data of a quasi-diagrammatic
@@ -178,11 +178,11 @@ boundary data of a 3-simplex in lexicographic order.
   ( α₀ : hom2 A x y z g h hg)
   : U
   :=
-  ( ((t₁ , t₂ ) , t₃ ) : Δ³)
-  → A [ t₃ ≡ 0₂ ↦ α₃ (t₁ , t₂ ),
-        t₂ ≡ t₃ ↦ α₂ (t₁ , t₃ ),
-        t₁ ≡ t₂ ↦ α₁ (t₁ , t₃ ),
-        t₁ ≡ 1₂ ↦ α₀ (t₂ , t₃ )]
+  ( ( ( t₁ , t₂) , t₃) : Δ³)
+  → A [ t₃ ≡ 0₂ ↦ α₃ (t₁ , t₂)
+      , t₂ ≡ t₃ ↦ α₂ (t₁ , t₃)
+      , t₁ ≡ t₂ ↦ α₁ (t₁ , t₃)
+      , t₁ ≡ 1₂ ↦ α₀ (t₂ , t₃)]
 ```
 
 ```rzk title="RS17, Definition 11.3"
@@ -192,15 +192,15 @@ boundary data of a 3-simplex in lexicographic order.
   ( u : B → A)
   : U
   :=
-  Σ ( (η , (ϵ , (α , β))) : has-quasi-diagrammatic-adj A B f u)
-  , Σ ( μ : hom2 ( B → B)
+  Σ ( ( η , (ϵ , (α , β))) : has-quasi-diagrammatic-adj A B f u)
+  , Σ ( μ : hom2 (B → B)
             ( comp B A B f u)
             ( quadruple-comp B A B A B f u f u)
             ( identity B)
             ( whisker-nat-trans B A A B u (identity A) (comp A B A u f) f η)
             ( horizontal-comp-nat-trans B B B
               ( comp B A B f u) (identity B) (comp B A B f u) (identity B)
-              ( ϵ) ( ϵ))
+              ( ϵ) (ϵ))
             ( ϵ))
     , product
       ( hom3 (B → B)
@@ -243,7 +243,7 @@ boundary data of a 3-simplex in lexicographic order.
 #def half-adjoint-diagrammatic-adj
   ( A B : U)
   : U
-  := Σ (f : A → B), Σ (u : B → A), is-half-adjoint-diagrammatic-adj A B f u
+  := Σ (f : A → B) , Σ (u : B → A) , is-half-adjoint-diagrammatic-adj A B f u
 ```
 
 ## Bi-diagrammatic adjunction
@@ -260,35 +260,35 @@ triangle identities, one involving each counit.
   ( u : B → A)
   : U
   :=
-  Σ (η : nat-trans A (\ _ → A) (identity A) (comp A B A u f))
-  , Σ (ϵ : nat-trans B (\ _ → B) (comp B A B f u) (identity B))
-    , Σ (ϵ' : nat-trans B (\ _ → B) (comp B A B f u) (identity B))
+  Σ ( η : nat-trans A (\ _ → A) (identity A) (comp A B A u f))
+  , Σ ( ϵ : nat-trans B (\ _ → B) (comp B A B f u) (identity B))
+    , Σ ( ϵ' : nat-trans B (\ _ → B) (comp B A B f u) (identity B))
       , product
         ( hom2 (B → A) u (triple-comp B A B A u f u) u
-          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
           ( id-hom (B → A) u))
         ( hom2 (A → B) f (triple-comp A B A B f u f) f
-          ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-          ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ' )
+          ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+          ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ')
           ( id-hom (A → B) f))
 
 #def bi-diagrammatic-adj
-  (A B : U)
+  ( A B : U)
   : U
-  := Σ (f : A → B), Σ (u : B → A), is-bi-diagrammatic-adj A B f u
+  := Σ (f : A → B) , Σ (u : B → A) , is-bi-diagrammatic-adj A B f u
 
 #def is-bi-diagrammatic-left-adj
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (u : B → A), is-bi-diagrammatic-adj A B f u
+  := Σ (u : B → A) , is-bi-diagrammatic-adj A B f u
 
 #def is-bi-diagrammatic-right-adj
   ( A B : U)
   ( u : B → A)
   : U
-  := Σ (f : A → B), is-bi-diagrammatic-adj A B f u
+  := Σ (f : A → B) , is-bi-diagrammatic-adj A B f u
 ```
 
 ## Quasi-transposing adjunction
@@ -304,7 +304,7 @@ where "quasi-equivalence" is another name for "invertible map."
   ( u : B → A)
   : U
   :=
-  (a : A)
+  ( a : A)
   → ( b : B)
   → Σ ( ϕ : (hom B (f a) b) → (hom A a (u b)))
     , has-inverse (hom B (f a) b) (hom A a (u b)) ϕ
@@ -312,19 +312,19 @@ where "quasi-equivalence" is another name for "invertible map."
 #def quasi-transposing-adj
   ( A B : U)
   : U
-  := Σ (f : A → B), Σ (u : B → A), has-quasi-transposing-adj A B f u
+  := Σ (f : A → B) , Σ (u : B → A) , has-quasi-transposing-adj A B f u
 
 #def has-quasi-transposing-right-adj
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (u : B → A), has-quasi-transposing-adj A B f u
+  := Σ (u : B → A) , has-quasi-transposing-adj A B f u
 
 #def has-quasi-transposing-left-adj
   ( A B : U)
   ( u : B → A)
   : U
-  := Σ (f : A → B), has-quasi-transposing-adj A B f u
+  := Σ (f : A → B) , has-quasi-transposing-adj A B f u
 ```
 
 ## Equivalence of quasi-transposing and quasi-diagrammatic adjunctions
@@ -345,12 +345,12 @@ in the usual way, as an application of the Yoneda lemma.
 #variable u : B → A
 
 #def equiv-transposition-unit-component uses (funext)
-  (a : A)
+  ( a : A)
   : Equiv ((b : B) → (hom B (f a) b) → (hom A a (u b))) (hom A a (u (f a)))
   :=
   ( evid B (f a) (\ b → hom A a (u b))
-    ,
-    yoneda-lemma funext B is-segal-B
+
+  , yoneda-lemma funext B is-segal-B
     ( f a)
     ( \ b → hom A a (u b))
     ( is-covariant-substitution-is-covariant A B
@@ -360,24 +360,24 @@ in the usual way, as an application of the Yoneda lemma.
 
 #def equiv-unit-components
   : Equiv
-    ( (a : A) → hom A a (u (f a)))
+    ( ( a : A) → hom A a (u (f a)))
     ( nat-trans A (\ _ → A) (identity A) (comp A B A u f))
   :=
   inv-equiv
   ( nat-trans A (\ _ → A) (identity A) (comp A B A u f))
-  ( (a : A) → hom A a (u (f a)))
-  ( equiv-components-nat-trans A ( \ _ → A)
+  ( ( a : A) → hom A a (u (f a)))
+  ( equiv-components-nat-trans A (\ _ → A)
     ( identity A)
     ( comp A B A u f))
 
 #def equiv-transposition-unit uses (is-segal-A is-segal-B funext)
   : Equiv
-    ( (a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
+    ( ( a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
     ( nat-trans A (\ _ → A) (identity A) (comp A B A u f))
   :=
   equiv-comp
-  ( (a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
-  ( (a : A) → hom A a (u (f a)))
+  ( ( a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
+  ( ( a : A) → hom A a (u (f a)))
   ( nat-trans A (\ _ → A) (identity A) (comp A B A u f))
   ( equiv-function-equiv-family funext A
     ( \ a → (b : B) → (hom B (f a) b) → (hom A a (u b)))
@@ -391,7 +391,7 @@ defining the transposition function associated to a unit natural transformation.
 
 ```rzk
 #def is-equiv-unit-component-transposition uses (funext)
-  (a : A)
+  ( a : A)
   : is-equiv (hom A a (u (f a))) ((b : B) → (hom B (f a) b) → (hom A a (u b)))
     ( \ ηa b k →
       comp-is-segal A is-segal-A a (u (f a)) (u b) ηa (ap-hom B A u (f a) b k))
@@ -407,16 +407,16 @@ defining the transposition function associated to a unit natural transformation.
 #def is-equiv-unit-transposition uses (is-segal-A is-segal-B funext)
   : is-equiv
     ( nat-trans A (\ _ → A) (identity A) (comp A B A u f))
-    ( (a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
+    ( ( a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
     ( \ η a b k →
       comp-is-segal A is-segal-A a (u (f a)) (u b)
-      ( \ t -> η t a)
+      ( \ t → η t a)
       ( ap-hom B A u (f a) b k))
   :=
   is-equiv-comp
   ( nat-trans A (\ _ → A) (identity A) (comp A B A u f))
-  ( (a : A) → hom A a (u (f a)))
-  ( (a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
+  ( ( a : A) → hom A a (u (f a)))
+  ( ( a : A) → (b : B) → (hom B (f a) b) → (hom A a (u b)))
   ( ev-components-nat-trans A (\ _ → A) (identity A) (comp A B A u f))
   ( is-equiv-ev-components-nat-trans A (\ _ → A)(identity A)(comp A B A u f))
   ( \ η a b k →
@@ -437,39 +437,39 @@ The results for counits are dual.
 
 ```rzk
 #def equiv-transposition-counit-component uses (funext)
-  (b : B)
+  ( b : B)
   : Equiv ((a : A) → (hom A a (u b)) → (hom B (f a) b)) (hom B (f (u b)) b)
   :=
   ( contra-evid A (u b) (\ a → hom B (f a) b)
-  ,
-    contra-yoneda-lemma funext A is-segal-A
+
+  , contra-yoneda-lemma funext A is-segal-A
     ( u b)
     ( \ a → hom B (f a) b)
     ( is-contravariant-substitution-is-contravariant B A
-      ( \ x -> hom B x b)
+      ( \ x → hom B x b)
       ( is-contravariant-representable-is-segal B is-segal-B b)
       ( f)))
 
 #def equiv-counit-components
   : Equiv
-    ( (b : B) → hom B (f (u b)) b)
+    ( ( b : B) → hom B (f (u b)) b)
     ( nat-trans B (\ _ → B) (comp B A B f u) (identity B))
   :=
   inv-equiv
   ( nat-trans B (\ _ → B) (comp B A B f u) (identity B))
-  ( (b : B) → hom B (f (u b)) b)
-  ( equiv-components-nat-trans B ( \ _ → B)
+  ( ( b : B) → hom B (f (u b)) b)
+  ( equiv-components-nat-trans B (\ _ → B)
     ( comp B A B f u)
     ( identity B))
 
 #def equiv-transposition-counit uses (is-segal-A is-segal-B funext)
   : Equiv
-    ( (b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
+    ( ( b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
     ( nat-trans B (\ _ → B) (comp B A B f u) (identity B))
   :=
   equiv-comp
-  ( (b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
-  ( (b : B) → hom B (f (u b)) b)
+  ( ( b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
+  ( ( b : B) → hom B (f (u b)) b)
   ( nat-trans B (\ _ → B) (comp B A B f u) (identity B))
   ( equiv-function-equiv-family funext B
     ( \ b → (a : A) → (hom A a (u b)) → (hom B (f a) b))
@@ -484,9 +484,9 @@ transformation.
 
 ```rzk
 #def is-equiv-counit-component-transposition uses (funext)
-  (b : B)
+  ( b : B)
   : is-equiv (hom B (f (u b)) b)
-    ( (a : A) → (hom A a (u b)) → (hom B (f a) b))
+    ( ( a : A) → (hom A a (u b)) → (hom B (f a) b))
     ( \ ϵb a k →
       comp-is-segal B is-segal-B (f a) (f (u b)) b (ap-hom A B f a (u b) k) ϵb)
   :=
@@ -501,16 +501,16 @@ transformation.
 #def is-equiv-counit-transposition uses (is-segal-A is-segal-B funext)
   : is-equiv
     ( nat-trans B (\ _ → B) (comp B A B f u) (identity B))
-    ( (b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
+    ( ( b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
     ( \ ϵ b a k →
       comp-is-segal B is-segal-B (f a) (f (u b)) b
       ( ap-hom A B f a (u b) k)
-      ( \ t -> ϵ t b))
+      ( \ t → ϵ t b))
   :=
   is-equiv-comp
   ( nat-trans B (\ _ → B) (comp B A B f u) (identity B))
-  ( (b : B) → hom B (f (u b)) b)
-  ( (b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
+  ( ( b : B) → hom B (f (u b)) b)
+  ( ( b : B) → (a : A) → (hom A a (u b)) → (hom B (f a) b))
   ( ev-components-nat-trans B (\ _ → B) (comp B A B f u) (identity B))
   ( is-equiv-ev-components-nat-trans B (\ _ → B)(comp B A B f u) (identity B))
   ( \ ϵ b a k →
@@ -546,8 +546,8 @@ as an application of the dependent Yoneda lemma.
 #def equiv-radj-triangle uses (funext)
   : Equiv
     ( hom2 (B → A) u (triple-comp B A B A u f u) u
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
       ( id-hom (B → A) u))
     ( ( comp-is-segal
         ( B → A)
@@ -555,33 +555,33 @@ as an application of the dependent Yoneda lemma.
           ( funext)
           ( B)
           ( \ _ → A)
-          ( \ _ → is-segal-A ))
+          ( \ _ → is-segal-A))
         ( u)
-        (triple-comp B A B A u f u)
+        ( triple-comp B A B A u f u)
         ( u)
-        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
-      =
-      ( id-hom (B → A) u))
+        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
+
+    = ( id-hom (B → A) u))
   :=
   inv-equiv
   ( ( comp-is-segal
       ( B → A)
-      ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+      ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
       ( u) (triple-comp B A B A u f u) (u)
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )) =
-    ( id-hom (B → A) u))
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
+  = ( id-hom (B → A) u))
   ( hom2 (B → A) u (triple-comp B A B A u f u) u
-    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
     ( id-hom (B → A) u))
   ( equiv-hom2-eq-comp-is-segal
     ( B → A)
-    ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+    ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
     ( u) (triple-comp B A B A u f u) (u)
-    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
     ( id-hom (B → A) u))
 
 #def equiv-ev-components-radj-triangle
@@ -592,14 +592,14 @@ as an application of the dependent Yoneda lemma.
           ( funext)
           ( B)
           ( \ _ → A)
-          ( \ _ → is-segal-A ))
+          ( \ _ → is-segal-A))
         ( u)
-        (triple-comp B A B A u f u)
+        ( triple-comp B A B A u f u)
         ( u)
-        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
-      =
-      ( id-hom (B → A) u))
+        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
+
+    = ( id-hom (B → A) u))
     ( ( ev-components-nat-trans B (\ _ → A) u u
         ( comp-is-segal
           ( B → A)
@@ -607,14 +607,14 @@ as an application of the dependent Yoneda lemma.
             ( funext)
             ( B)
             ( \ _ → A)
-            ( \ _ → is-segal-A ))
+            ( \ _ → is-segal-A))
           ( u)
-          (triple-comp B A B A u f u)
+          ( triple-comp B A B A u f u)
           ( u)
-          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )))
-      =
-      ( \ b → id-hom A ( u b)))
+          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)))
+
+    = ( \ b → id-hom A (u b)))
   :=
   equiv-ap-is-equiv
   ( nat-trans B (\ _ → A) u u)
@@ -622,161 +622,161 @@ as an application of the dependent Yoneda lemma.
   ( ev-components-nat-trans B (\ _ → A) u u)
   ( is-equiv-ev-components-nat-trans B (\ _ → A) u u)
   ( comp-is-segal (B → A)
-    ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+    ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
     ( u) (triple-comp B A B A u f u) (u)
-    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
+    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
   ( id-hom (B → A) u)
 
 #def equiv-components-radj-triangle-funext uses (funext)
   : Equiv
     ( ev-components-nat-trans B (\ _ → A) u u
       ( comp-is-segal (B → A)
-        ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A ))
+        ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
         ( u) (triple-comp B A B A u f u) (u)
-        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
-      =
-      ( \ b → id-hom A ( u b)))
-    ( ( b : B) →
-      ( ev-components-nat-trans B (\ _ → A) u u
+        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
+
+    = ( \ b → id-hom A (u b)))
+    ( ( b : B)
+    → ( ev-components-nat-trans B (\ _ → A) u u
         ( comp-is-segal (B → A)
-          ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A ))
+          ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
           ( u) (triple-comp B A B A u f u) (u)
-          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
+          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
         ( b)
-        =
-        id-hom A ( u b)))
+
+      = id-hom A (u b)))
   :=
   equiv-FunExt funext B
   ( \ b → (hom A (u b) (u b)))
   ( ev-components-nat-trans B (\ _ → A) u u
     ( comp-is-segal (B → A)
-      ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A ))
+      ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
       ( u) (triple-comp B A B A u f u) (u)
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )))
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)))
   ( \ b → id-hom A (u b))
 
 #def eq-ladj-triangle-comp-components-comp-nat-trans-is-segal uses (funext)
-  (b : B)
+  ( b : B)
   : comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-    ( \ t → η t (u b) )
+    ( \ t → η t (u b))
     ( ap-hom B A u (f (u b)) b (\ t → ϵ t b))
-    =
-    ev-components-nat-trans B (\ _ → A) u u
+
+  = ev-components-nat-trans B (\ _ → A) u u
     ( comp-is-segal (B → A)
       ( is-segal-function-type (funext) (B) (\ _ → A) (\ _ → is-segal-A))
       ( u) (triple-comp B A B A u f u) (u)
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
     ( b)
   :=
   comp-components-comp-nat-trans-is-segal funext B (\ _ → A) (\ _ → is-segal-A)
   ( u) (triple-comp B A B A u f u) (u)
-  ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-  ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+  ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+  ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
   ( b)
 
 #def equiv-preconcat-radj-triangle uses (funext)
-  (b : B)
+  ( b : B)
   : Equiv
     ( ev-components-nat-trans B (\ _ → A) u u
       ( comp-is-segal (B → A)
-        ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A ))
+        ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
         ( u) (triple-comp B A B A u f u) (u)
-        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
+        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
       ( b)
-      =
-      id-hom A ( u b))
+
+    = id-hom A (u b))
     ( ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-        ( \ t → η t (u b) )
+        ( \ t → η t (u b))
         ( ap-hom B A u (f (u b)) b (\ t → ϵ t b)))
-      =
-      ( id-hom A ( u b)))
+
+    = ( id-hom A (u b)))
   :=
-  equiv-preconcat ( hom A (u b) (u b))
+  equiv-preconcat (hom A (u b) (u b))
   ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-    ( \ t → η t (u b) )
+    ( \ t → η t (u b))
     ( ap-hom B A u (f (u b)) b (\ t → ϵ t b)))
   ( ev-components-nat-trans B (\ _ → A) u u
     ( comp-is-segal (B → A)
       ( is-segal-function-type (funext) (B) (\ _ → A) (\ _ → is-segal-A))
       ( u) (triple-comp B A B A u f u) (u)
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
     ( b))
   ( id-hom A (u b))
   ( eq-ladj-triangle-comp-components-comp-nat-trans-is-segal b)
 
 #def equiv-component-comp-segal-comp-radj-triangle uses (funext)
   : Equiv
-    ( comp-is-segal ( B → A)
-      ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+    ( comp-is-segal (B → A)
+      ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
       ( u) (triple-comp B A B A u f u) (u)
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
-      =
-      id-hom (B → A) u)
-    ( ( b : B) →
-      ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-        ( \ t → η t (u b) )
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
+
+    = id-hom (B → A) u)
+    ( ( b : B)
+    → ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
+        ( \ t → η t (u b))
         ( ap-hom B A u (f (u b)) b (\ t → ϵ t b)))
-      =
-      ( id-hom A ( u b)))
+
+    = ( id-hom A (u b)))
   :=
   equiv-triple-comp
   ( ( comp-is-segal (B → A)
-      ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+      ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
       ( u) (triple-comp B A B A u f u) (u)
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )) =
-    ( id-hom (B → A) u))
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
+  = ( id-hom (B → A) u))
   ( ( ev-components-nat-trans B (\ _ → A) u u
       ( comp-is-segal (B → A)
-        ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+        ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
         ( u) (triple-comp B A B A u f u) (u)
-        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )))
-    =
-    ( \ b → id-hom A ( u b)))
+        ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+        ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)))
+
+  = ( \ b → id-hom A (u b)))
   ( ( b : B)
     → ( ( ev-components-nat-trans B (\ _ → A) u u
-          ( comp-is-segal ( B → A)
-            ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+          ( comp-is-segal (B → A)
+            ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
             ( u) (triple-comp B A B A u f u) (u)
-            ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-            ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
+            ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+            ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
           ( b))
-        =
-        ( id-hom A ( u b))))
+
+      = ( id-hom A (u b))))
   ( ( b : B)
     → ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-        ( \ t → η t (u b) )
+        ( \ t → η t (u b))
         ( ap-hom B A u (f (u b)) b (\ t → ϵ t b)))
-      =
-      ( id-hom A ( u b)))
+
+    = ( id-hom A (u b)))
   ( equiv-ev-components-radj-triangle)
   ( equiv-components-radj-triangle-funext)
   ( equiv-function-equiv-family funext B
     ( \ b →
       ( ev-components-nat-trans B (\ _ → A) u u
-        ( comp-is-segal ( B → A)
-          ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+        ( comp-is-segal (B → A)
+          ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
           ( u) (triple-comp B A B A u f u) (u)
-          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
+          ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+          ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
         ( b))
-      =
-      ( id-hom A ( u b)))
+
+    = ( id-hom A (u b)))
     ( \ b →
       ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-        ( \ t → η t (u b) )
+        ( \ t → η t (u b))
         ( ap-hom B A u (f (u b)) b (\ t → ϵ t b)))
-      =
-      ( id-hom A ( u b)))
+
+    = ( id-hom A (u b)))
     ( equiv-preconcat-radj-triangle))
 ```
 
@@ -786,33 +786,33 @@ We finally arrive at the desired equivalence.
 #def equiv-components-radj-triangle uses (funext)
   : Equiv
     ( hom2 (B → A) u (triple-comp B A B A u f u) u
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
       ( id-hom (B → A) u))
     ( ( b : B)
       → ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-          ( \ t → η t (u b) )
-          ( ap-hom B A u (f (u b)) b (\ t → ϵ t b))) =
-        ( id-hom A ( u b)))
+          ( \ t → η t (u b))
+          ( ap-hom B A u (f (u b)) b (\ t → ϵ t b)))
+      = ( id-hom A (u b)))
   :=
   equiv-comp
   ( hom2 (B → A) u (triple-comp B A B A u f u) u
-    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ )
+    ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+    ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ)
     ( id-hom (B → A) u))
-  ( ( comp-is-segal ( B → A)
-      ( is-segal-function-type funext B ( \ _ → A) ( \ _ → is-segal-A ))
+  ( ( comp-is-segal (B → A)
+      ( is-segal-function-type funext B (\ _ → A) (\ _ → is-segal-A))
       ( u) (triple-comp B A B A u f u) (u)
-      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η )
-      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ ))
-    =
-    ( id-hom (B → A) u))
+      ( prewhisker-nat-trans B A A u (identity A) (comp A B A u f) η)
+      ( postwhisker-nat-trans B B A (comp B A B f u) (identity B) u ϵ))
+
+  = ( id-hom (B → A) u))
   ( ( b : B)
     → ( comp-is-segal A is-segal-A (u b) (u (f (u b))) (u b)
-        ( \ t → η t (u b) )
+        ( \ t → η t (u b))
         ( ap-hom B A u (f (u b)) b (\ t → ϵ t b)))
-      =
-      ( id-hom A ( u b)))
+
+    = ( id-hom A (u b)))
   ( equiv-radj-triangle)
   ( equiv-component-comp-segal-comp-radj-triangle)
 ```
@@ -823,111 +823,111 @@ The calculation for the other triangle identity is dual.
 #def equiv-ladj-triangle uses (funext)
   : Equiv
     ( hom2 (A → B) f (triple-comp A B A B f u f) f
-      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
+      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
       ( id-hom (A → B) f))
-    ( comp-is-segal ( A → B)
-      ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+    ( comp-is-segal (A → B)
+      ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
       ( f) (triple-comp A B A B f u f) (f)
-      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
-      =
-      id-hom (A → B) f)
+      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
+
+    = id-hom (A → B) f)
   :=
   inv-equiv
-  ( comp-is-segal ( A → B)
-    ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+  ( comp-is-segal (A → B)
+    ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
     ( f) (triple-comp A B A B f u f) (f)
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
-    =
-    id-hom (A → B) f)
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
+
+  = id-hom (A → B) f)
   ( hom2 (A → B) f (triple-comp A B A B f u f) f
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
     ( id-hom (A → B) f))
-  ( equiv-hom2-eq-comp-is-segal ( A → B)
-    ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+  ( equiv-hom2-eq-comp-is-segal (A → B)
+    ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
     ( f) (triple-comp A B A B f u f) (f)
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
     ( id-hom (A → B) f))
 
 #def equiv-ev-components-ladj-triangle
   : Equiv
-    ( comp-is-segal ( A → B)
-      ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+    ( comp-is-segal (A → B)
+      ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
       ( f) (triple-comp A B A B f u f) (f)
-      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
-      =
-      id-hom (A → B) f)
+      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
+
+    = id-hom (A → B) f)
     ( ev-components-nat-trans A (\ _ → B) f f
       ( comp-is-segal (A → B)
-        ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+        ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
         ( f) (triple-comp A B A B f u f) (f)
-        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
-      =
-      ( \ a → id-hom B ( f a)))
+        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
+
+    = ( \ a → id-hom B (f a)))
   :=
   equiv-ap-is-equiv
   ( nat-trans A (\ _ → B) f f)
   ( nat-trans-components A (\ _ → B) f f)
   ( ev-components-nat-trans A (\ _ → B) f f)
   ( is-equiv-ev-components-nat-trans A (\ _ → B) f f)
-  ( comp-is-segal ( A → B)
-    ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+  ( comp-is-segal (A → B)
+    ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
     ( f) (triple-comp A B A B f u f) (f)
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
   ( id-hom (A → B) f)
 
 #def equiv-components-ladj-triangle-funext uses (funext)
   : Equiv
     ( ev-components-nat-trans A (\ _ → B) f f
       ( comp-is-segal (A → B)
-        ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+        ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
         ( f) (triple-comp A B A B f u f) (f)
-        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
-      =
-      ( \ a → id-hom B ( f a)))
+        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
+
+    = ( \ a → id-hom B (f a)))
     ( ( a : A)
       → ( ev-components-nat-trans A (\ _ → B) f f
           ( comp-is-segal (A → B)
-            ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+            ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
             ( f) (triple-comp A B A B f u f) (f)
-            ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-            ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
+            ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+            ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
           ( a)
-        =
-        id-hom B ( f a)))
+
+      = id-hom B (f a)))
   :=
   equiv-FunExt funext A
   ( \ a → (hom B (f a) (f a)))
   ( ev-components-nat-trans A (\ _ → B) f f
     ( comp-is-segal (A → B)
-      ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+      ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
       ( f) (triple-comp A B A B f u f) (f)
-      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )))
+      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)))
   ( \ a → id-hom B (f a))
 
 #def eq-radj-triangle-comp-components-comp-nat-trans-is-segal uses (funext)
-  (a : A)
+  ( a : A)
   : ( comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
       ( ap-hom A B f a (u (f a)) (\ t → η t a))
-      ( \ t → ϵ t (f a))) =
-    ( ev-components-nat-trans A (\ _ → B) f f
+      ( \ t → ϵ t (f a)))
+  = ( ev-components-nat-trans A (\ _ → B) f f
       ( comp-is-segal
         ( A → B)
         ( is-segal-function-type (funext) (A) (\ _ → B) (\ _ → is-segal-B))
         ( f)
-        (triple-comp A B A B f u f)
+        ( triple-comp A B A B f u f)
         ( f)
-        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
+        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
       ( a))
   :=
     comp-components-comp-nat-trans-is-segal
@@ -936,29 +936,29 @@ The calculation for the other triangle identity is dual.
     ( \ _ → B)
     ( \ _ → is-segal-B)
     ( f)
-    (triple-comp A B A B f u f)
+    ( triple-comp A B A B f u f)
     ( f)
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
     ( a)
 
 #def equiv-preconcat-ladj-triangle uses (funext)
-  (a : A)
+  ( a : A)
   : Equiv
     ( ev-components-nat-trans A (\ _ → B) f f
       ( comp-is-segal (A → B)
-        ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+        ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
         ( f) (triple-comp A B A B f u f) (f)
-        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
+        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
       ( a)
-      =
-      id-hom B ( f a))
+
+    = id-hom B (f a))
     ( comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
       ( ap-hom A B f a (u (f a)) (\ t → η t a))
       ( \ t → ϵ t (f a))
-      =
-      id-hom B ( f a))
+
+    = id-hom B (f a))
   :=
   equiv-preconcat (hom B (f a) (f a))
   ( comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
@@ -966,112 +966,112 @@ The calculation for the other triangle identity is dual.
     ( \ t → ϵ t (f a)))
   ( ev-components-nat-trans A (\ _ → B) f f
     ( comp-is-segal (A → B)
-      ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+      ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
       ( f) (triple-comp A B A B f u f) (f)
-      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
+      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
     ( a))
   ( id-hom B (f a))
-  (eq-radj-triangle-comp-components-comp-nat-trans-is-segal a)
+  ( eq-radj-triangle-comp-components-comp-nat-trans-is-segal a)
 
 #def equiv-component-comp-segal-comp-ladj-triangle uses (funext)
   : Equiv
     ( comp-is-segal (A → B)
-      ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+      ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
       ( f) (triple-comp A B A B f u f) (f)
-      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
-      =
-      id-hom (A → B) f)
+      ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+      ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
+
+    = id-hom (A → B) f)
     ( ( a : A)
       → comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
         ( ap-hom A B f a (u (f a)) (\ t → η t a))
         ( \ t → ϵ t (f a))
-        =
-        id-hom B ( f a))
+
+      = id-hom B (f a))
   :=
   equiv-triple-comp
   ( comp-is-segal (A → B)
-    ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+    ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
     ( f) (triple-comp A B A B f u f) (f)
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
-    =
-    id-hom (A → B) f)
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
+
+  = id-hom (A → B) f)
   ( ( ev-components-nat-trans A (\ _ → B) f f
       ( comp-is-segal (A → B)
-        ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+        ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
         ( f) (triple-comp A B A B f u f) (f)
-        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )))
-    =
-    ( \ a → id-hom B ( f a)))
+        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)))
+
+  = ( \ a → id-hom B (f a)))
   ( ( a : A)
     → ( ev-components-nat-trans A (\ _ → B) f f
-        ( comp-is-segal ( A → B)
-          ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+        ( comp-is-segal (A → B)
+          ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
           ( f) (triple-comp A B A B f u f) (f)
-          ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )            ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
+          ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)            (prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
         ( a)
-        =
-        id-hom B ( f a)))
+
+      = id-hom B (f a)))
     ( ( a : A)
       → comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
         ( ap-hom A B f a (u (f a)) (\ t → η t a))
         ( \ t → ϵ t (f a))
-        =
-        id-hom B ( f a))
+
+      = id-hom B (f a))
     ( equiv-ev-components-ladj-triangle)
     ( equiv-components-ladj-triangle-funext)
     ( equiv-function-equiv-family funext A
       ( \ a →
         ev-components-nat-trans A (\ _ → B) f f
-        ( comp-is-segal ( A → B)
-          ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+        ( comp-is-segal (A → B)
+          ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
           ( f) (triple-comp A B A B f u f) (f)
-          ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )            ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ ))
+          ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)            (prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ))
         ( a)
-        =
-        id-hom B ( f a))
+
+      = id-hom B (f a))
       ( \ a →
         comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
           ( ap-hom A B f a (u (f a)) (\ t → η t a))
           ( \ t → ϵ t (f a))
-        =
-        id-hom B ( f a))
+
+      = id-hom B (f a))
       ( equiv-preconcat-ladj-triangle))
 
 #def equiv-components-ladj-triangle uses (funext)
   : Equiv
     ( hom2 (A → B) f (triple-comp A B A B f u f) f
-        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
+        ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+        ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
         ( id-hom (A → B) f))
     ( ( a : A)
       → comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
         ( ap-hom A B f a (u (f a)) (\ t → η t a))
         ( \ t → ϵ t (f a))
-        =
-        id-hom B ( f a))
+
+      = id-hom B (f a))
   :=
   equiv-comp
   ( hom2 (A → B) f (triple-comp A B A B f u f) f
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
     ( id-hom (A → B) f))
   ( comp-is-segal (A → B)
-    ( is-segal-function-type funext A ( \ _ → B) ( \ _ → is-segal-B ))
+    ( is-segal-function-type funext A (\ _ → B) (\ _ → is-segal-B))
     ( f) (triple-comp A B A B f u f) (f)
-    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η )
-    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ )
-    =
-    id-hom (A → B) f)
+    ( postwhisker-nat-trans A A B (identity A) (comp A B A u f) f η)
+    ( prewhisker-nat-trans A B B f (comp B A B f u) (identity B) ϵ)
+
+  = id-hom (A → B) f)
   ( ( a : A)
     → comp-is-segal B is-segal-B (f a) (f (u (f a))) (f a)
       ( ap-hom A B f a (u (f a)) (\ t → η t a))
       ( \ t → ϵ t (f a))
-       =
-      id-hom B ( f a))
+
+    = id-hom B (f a))
   ( equiv-ladj-triangle)
   ( equiv-component-comp-segal-comp-ladj-triangle)
 
@@ -1100,20 +1100,20 @@ of `#!rzk is-transposing-right-adj A B u`
 #def ηa-transposition
   ( b : B)
   ( k : hom B fa b)
-  : (hom A a (u b))
+  : ( hom A a (u b))
   := comp-is-segal A is-segal-A a (u fa) (u b) ηa (ap-hom B A u fa b k)
 
 #def ηa'-transposition
   ( b : B)
   ( k : hom B fa' b)
-  : (hom A a (u b))
+  : ( hom A a (u b))
   := comp-is-segal A is-segal-A a (u fa') (u b) ηa' (ap-hom B A u fa' b k)
 
 #variable ω
-  : (b : B) → is-equiv (hom B fa b) (hom A a (u b)) (ηa-transposition b)
+ : ( b : B) → is-equiv (hom B fa b) (hom A a (u b)) (ηa-transposition b)
 
 #variable ω'
-  : (b : B) → is-equiv (hom B fa' b) (hom A a (u b)) (ηa'-transposition b)
+ : ( b : B) → is-equiv (hom B fa' b) (hom A a (u b)) (ηa'-transposition b)
 
 #def to-left-adjoint-components-is-rezk-is-segal uses (A is-segal-A u a ηa)
   : hom B fa fa'
@@ -1126,8 +1126,8 @@ of `#!rzk is-transposing-right-adj A B u`
   : comp-is-segal A is-segal-A a (u fa) (u fa')
     ( ηa)
     ( ap-hom B A u fa fa' to-left-adjoint-components-is-rezk-is-segal)
-    =
-    ηa'
+
+  = ηa'
   :=
   ( second
     ( has-section-is-equiv (hom B fa fa') (hom A a (u fa'))
@@ -1145,8 +1145,8 @@ of `#!rzk is-transposing-right-adj A B u`
   : comp-is-segal A is-segal-A a (u fa') (u fa)
     ( ηa')
     ( ap-hom B A u fa' fa from-left-adjoint-components-is-rezk-is-segal)
-    =
-    ηa
+
+  = ηa
   :=
   ( second
     ( has-section-is-equiv (hom B fa' fa) (hom A a (u fa))
@@ -1160,8 +1160,8 @@ of `#!rzk is-transposing-right-adj A B u`
       ( comp-is-segal B (first is-rezk-B) fa fa' fa
         ( to-left-adjoint-components-is-rezk-is-segal)
         ( from-left-adjoint-components-is-rezk-is-segal)))
-    =
-    ηa
+
+  = ηa
   :=
   quadruple-concat (hom A a (u fa))
   ( comp-is-segal A is-segal-A a (u fa) (u fa)
@@ -1216,8 +1216,8 @@ of `#!rzk is-transposing-right-adj A B u`
       ( comp-is-segal B (first is-rezk-B) fa' fa fa'
         ( from-left-adjoint-components-is-rezk-is-segal)
         ( to-left-adjoint-components-is-rezk-is-segal)))
-    =
-    ηa'
+
+  = ηa'
   :=
   quadruple-concat (hom A a (u fa'))
   ( comp-is-segal A is-segal-A a (u fa') (u fa')
@@ -1252,7 +1252,7 @@ of `#!rzk is-transposing-right-adj A B u`
     ( rev-functors-pres-comp B A (first is-rezk-B) is-segal-A u fa' fa fa'
       ( from-left-adjoint-components-is-rezk-is-segal)
       ( to-left-adjoint-components-is-rezk-is-segal)))
-  ( rev-associative-is-segal extext A is-segal-A a ( u fa') (u fa) (u fa')
+  ( rev-associative-is-segal extext A is-segal-A a (u fa') (u fa) (u fa')
     ( ηa')
     ( ap-hom B A u fa' fa from-left-adjoint-components-is-rezk-is-segal)
     ( ap-hom B A u fa fa' to-left-adjoint-components-is-rezk-is-segal))
@@ -1269,8 +1269,8 @@ of `#!rzk is-transposing-right-adj A B u`
   : comp-is-segal B (first is-rezk-B) fa fa' fa
     ( to-left-adjoint-components-is-rezk-is-segal)
     ( from-left-adjoint-components-is-rezk-is-segal)
-    =
-    id-hom B fa
+
+  = id-hom B fa
   :=
   inv-ap-is-emb (hom B fa fa) (hom A a (u fa))
   ( ηa-transposition fa)
@@ -1296,15 +1296,15 @@ of `#!rzk is-transposing-right-adj A B u`
       ( prewhisker-homotopy-is-segal A is-segal-A a (u fa) (u fa) ηa
         ( ap-hom B A u fa fa (id-hom B fa))
         ( id-hom A (u fa))
-        (functors-pres-id extext B A u fa))
+        ( functors-pres-id extext B A u fa))
       ( comp-id-is-segal A is-segal-A a (u fa) ηa)))
 
 #def eq-id-to-from-left-adjoint-components-is-rezk-is-segal uses (extext ηa ω ω')
   : comp-is-segal B (first is-rezk-B) fa' fa fa'
     ( from-left-adjoint-components-is-rezk-is-segal)
     ( to-left-adjoint-components-is-rezk-is-segal)
-    =
-    id-hom B fa'
+
+  = id-hom B fa'
   :=
   inv-ap-is-emb (hom B fa' fa') (hom A a (u fa'))
   ( ηa'-transposition fa')
@@ -1332,7 +1332,7 @@ of `#!rzk is-transposing-right-adj A B u`
       ( prewhisker-homotopy-is-segal A is-segal-A a (u fa') (u fa') ηa'
         ( ap-hom B A u fa' fa' (id-hom B fa'))
         ( id-hom A (u fa'))
-        (functors-pres-id extext B A u fa'))
+        ( functors-pres-id extext B A u fa'))
       ( comp-id-is-segal A is-segal-A a (u fa') ηa')))
 
 #def all-left-adjoint-components-equal-is-rezk-is-segal uses (extext A is-segal-A u a ηa ηa' ω ω')
@@ -1340,14 +1340,14 @@ of `#!rzk is-transposing-right-adj A B u`
   :=
   eq-iso-is-rezk B is-rezk-B fa fa'
   ( to-left-adjoint-components-is-rezk-is-segal
-    ,
-    ( ( from-left-adjoint-components-is-rezk-is-segal
-        ,
-        eq-id-from-to-left-adjoint-components-is-rezk-is-segal)
-      ,
-      ( from-left-adjoint-components-is-rezk-is-segal
-        ,
-        eq-id-to-from-left-adjoint-components-is-rezk-is-segal)))
+
+  , ( ( from-left-adjoint-components-is-rezk-is-segal
+
+      , eq-id-from-to-left-adjoint-components-is-rezk-is-segal)
+
+    , ( from-left-adjoint-components-is-rezk-is-segal
+
+      , eq-id-to-from-left-adjoint-components-is-rezk-is-segal)))
 
 #def iso-eq-iso-to-left-adjoint-components-is-rezk uses (extext A is-segal-A u a ηa ηa' ω ω')
   : first (iso-eq B (first is-rezk-B) fa fa'
@@ -1356,23 +1356,23 @@ of `#!rzk is-transposing-right-adj A B u`
   :=
   iso-eq-iso-is-rezk B is-rezk-B fa fa'
   ( to-left-adjoint-components-is-rezk-is-segal
-    ,
-    ( ( from-left-adjoint-components-is-rezk-is-segal
-        ,
-        eq-id-from-to-left-adjoint-components-is-rezk-is-segal)
-      ,
-      ( from-left-adjoint-components-is-rezk-is-segal
-        ,
-        eq-id-to-from-left-adjoint-components-is-rezk-is-segal)))
+
+  , ( ( from-left-adjoint-components-is-rezk-is-segal
+
+      , eq-id-from-to-left-adjoint-components-is-rezk-is-segal)
+
+    , ( from-left-adjoint-components-is-rezk-is-segal
+
+      , eq-id-to-from-left-adjoint-components-is-rezk-is-segal)))
 
 #def compute-transport-all-left-adjoint-components-equal-is-rezk-is-segal uses (extext ηa' ω ω')
-  : transport B ( \ b → hom A a (u b)) fa fa'
+  : transport B (\ b → hom A a (u b)) fa fa'
     ( all-left-adjoint-components-equal-is-rezk-is-segal) ηa
-    =
-    ηa'
+
+  = ηa'
   :=
   quintuple-concat (hom A a (u fa'))
-  ( transport B ( \ b → hom A a (u b)) fa fa'
+  ( transport B (\ b → hom A a (u b)) fa fa'
     ( all-left-adjoint-components-equal-is-rezk-is-segal) ηa)
   ( covariant-transport B fa fa'
     ( first
@@ -1405,7 +1405,7 @@ of `#!rzk is-transposing-right-adj A B u`
       ( is-covariant-substitution-is-covariant A B (hom A a)
         ( is-covariant-representable-is-segal A is-segal-A a) u)
       ( ηa))
-    ( transport B ( \ b → hom A a (u b)) fa fa'
+    ( transport B (\ b → hom A a (u b)) fa fa'
       ( all-left-adjoint-components-equal-is-rezk-is-segal) ηa)
     ( compute-covariant-transport-of-hom-family-iso-eq-is-segal B
       ( first is-rezk-B)
@@ -1423,7 +1423,7 @@ of `#!rzk is-transposing-right-adj A B u`
     ( ηa-transposition fa')
     ( iso-eq-iso-to-left-adjoint-components-is-rezk))
   ( compute-covariant-transport-of-hom-family-is-segal A is-segal-A
-    ( a) (u fa) (u fa') ( ηa)
+    ( a) (u fa) (u fa') (ηa)
     ( ap-hom B A u fa fa' to-left-adjoint-components-is-rezk-is-segal))
   ( compute-covariant-transport-of-substitution A B (hom A a)
     ( is-covariant-representable-is-segal A is-segal-A a) u (fa) (fa')
@@ -1432,11 +1432,11 @@ of `#!rzk is-transposing-right-adj A B u`
   ( triangle-to-left-adjoint-components-is-rezk-is-segal)
 
 #def all-unit-components-equal-is-rezk-is-segal uses (extext A is-segal-A u a ω ω')
-  : (fa, ηa) =_{Σ (b : B), hom A a (u b)} (fa', ηa')
+  : ( fa , ηa) =_{Σ (b : B) , hom A a (u b)} (fa' , ηa')
   :=
   path-of-pairs-pair-of-paths B (\ b → hom A a (u b)) (fa) (fa')
   ( all-left-adjoint-components-equal-is-rezk-is-segal)
-  ( ηa) ( ηa')
+  ( ηa) (ηa')
   ( compute-transport-all-left-adjoint-components-equal-is-rezk-is-segal)
 
 #end all-unit-arrows-equal-is-rezk-is-segal
@@ -1476,10 +1476,10 @@ of `#!rzk is-transposing-right-adj A B u`
   ( is-segal-A : is-segal A)
   ( u : B → A)
   : Equiv
-    ( Σ (f : A → B)
+    ( Σ ( f : A → B)
       , Σ ( η : nat-trans A (\ _ → A) (identity A) (comp A B A u f))
         , is-transposing-unit B A is-segal-A u f η)
-    ( Σ (f : A → B)
+    ( Σ ( f : A → B)
       , Σ ( η : nat-trans-components A (\ _ → A) (identity A) (comp A B A u f))
         , is-transposing-unit-components B A is-segal-A u f η)
   :=
@@ -1505,11 +1505,11 @@ of `#!rzk is-transposing-right-adj A B u`
   ( is-segal-A : is-segal A)
   ( u : B → A)
   : Equiv
-    ( Σ (f : A → B)
+    ( Σ ( f : A → B)
       , Σ ( η : nat-trans-components A (\ _ → A) (identity A) (comp A B A u f))
         , is-transposing-unit-components B A is-segal-A u f η)
-    ( (a : A)
-      → Σ (fa : B)
+    ( ( a : A)
+      → Σ ( fa : B)
         , Σ ( ηa : hom A a (u fa))
           , ( b : B)
             → is-equiv (hom B fa b) (hom A a (u b))
@@ -1518,19 +1518,19 @@ of `#!rzk is-transposing-right-adj A B u`
                 ( ηa) (ap-hom B A u fa b k)))
   :=
   equiv-comp
-  ( Σ (f : A → B)
+  ( Σ ( f : A → B)
     , Σ ( η : nat-trans-components A (\ _ → A) (identity A) (comp A B A u f))
       , is-transposing-unit-components B A is-segal-A u f η)
-  ( Σ (f : A → B)
-    , (a : A) →
-      Σ ( ηa : hom A a (u (f a)))
+  ( Σ ( f : A → B)
+    , ( a : A)
+    → Σ ( ηa : hom A a (u (f a)))
       , ( b : B)
         → is-equiv (hom B (f a) b) (hom A a (u b))
           ( \ k →
             comp-is-segal A is-segal-A a (u (f a)) (u b)
             ( ηa) (ap-hom B A u (f a) b k)))
   ( ( a : A)
-      → Σ (fa : B)
+      → Σ ( fa : B)
         , Σ ( ηa : hom A a (u fa))
           , ( b : B)
             → is-equiv (hom B fa b) (hom A a (u b))
@@ -1543,7 +1543,7 @@ of `#!rzk is-transposing-right-adj A B u`
       Σ ( η : nat-trans-components A (\ _ → A) (identity A) (comp A B A u f))
           , is-transposing-unit-components B A is-segal-A u f η)
     ( \ f →
-      (a : A)
+      ( a : A)
         → Σ ( ηa : hom A a (u (f a)))
           , ( b : B)
             → is-equiv (hom B (f a) b) (hom A a (u b))
@@ -1552,14 +1552,14 @@ of `#!rzk is-transposing-right-adj A B u`
                 ( ηa)
                 ( ap-hom B A u (f a) b k)))
     ( \ f →
-      inv-equiv-choice A ( \ a → hom A a (u (f a)))
+      inv-equiv-choice A (\ a → hom A a (u (f a)))
       ( \ a ηa →
         ( b : B)
           → is-equiv (hom B (f a) b) (hom A a (u b))
             ( \ k →
               comp-is-segal A is-segal-A a (u (f a)) (u b)
               ( ηa) (ap-hom B A u (f a) b k)))))
-  ( inv-equiv-choice A ( \ _ → B)
+  ( inv-equiv-choice A (\ _ → B)
     ( \ a fa →
       Σ ( ηa : hom A a (u fa))
           , ( b : B)
@@ -1573,11 +1573,11 @@ of `#!rzk is-transposing-right-adj A B u`
   ( is-segal-A : is-segal A)
   ( u : B → A)
   : Equiv
-    ( Σ (f : A → B)
+    ( Σ ( f : A → B)
       , Σ ( η : nat-trans A (\ _ → A) (identity A) (comp A B A u f))
         , is-transposing-unit B A is-segal-A u f η)
-    ( (a : A)
-      → Σ (fa : B)
+    ( ( a : A)
+      → Σ ( fa : B)
         , Σ ( ηa : hom A a (u fa))
           , ( b : B)
             → is-equiv (hom B fa b) (hom A a (u b))
@@ -1586,14 +1586,14 @@ of `#!rzk is-transposing-right-adj A B u`
                 ( ηa) (ap-hom B A u fa b k)))
   :=
   equiv-comp
-  ( Σ (f : A → B)
+  ( Σ ( f : A → B)
     , Σ ( η : nat-trans A (\ _ → A) (identity A) (comp A B A u f))
       , is-transposing-unit B A is-segal-A u f η)
-  ( Σ (f : A → B)
+  ( Σ ( f : A → B)
     , Σ ( η : nat-trans-components A (\ _ → A) (identity A) (comp A B A u f))
       , is-transposing-unit-components B A is-segal-A u f η)
-  ( (a : A)
-    → Σ (fa : B)
+  ( ( a : A)
+    → Σ ( fa : B)
       , Σ ( ηa : hom A a (u fa))
         , ( b : B)
           → is-equiv (hom B fa b) (hom A a (u b))

--- a/src/simplicial-hott/12-cocartesian.rzk.md
+++ b/src/simplicial-hott/12-cocartesian.rzk.md
@@ -37,7 +37,7 @@ families.
   :=
     product
     ( product (is-segal B) (is-segal (Σ (b : B) , P b)))
-    ( (b : B) → (is-segal (P b)))
+    ( ( b : B) → (is-segal (P b)))
 
 #def is-isoinner-family
   ( B : U)
@@ -46,7 +46,7 @@ families.
   :=
     product
     ( product (is-rezk B) (is-rezk (Σ (b : B) , P b)))
-    ( (b : B) → (is-rezk (P b)))
+    ( ( b : B) → (is-rezk (P b)))
 ```
 
 ## Cocartesian arrows
@@ -66,12 +66,12 @@ this is preferred for usage.
   ( f : dhom B b b' u P e e')
   : U
   :=
-    (b'' : B) → (v : hom B b' b'') → (w : hom B b b'') →
-      (sigma : hom2 B b b' b'' u v w) → (e'' : P b'') →
-      (h : dhom B b b'' w P e e'') →
-      is-contr
-        ( Σ ( g : dhom B b' b'' v P e' e'') ,
-          ( dhom2 B b b' b'' u v w sigma P e e' e'' f g h))
+    ( b'' : B) → (v : hom B b' b'') → (w : hom B b b'')
+    → ( sigma : hom2 B b b' b'' u v w) → (e'' : P b'')
+    → ( h : dhom B b b'' w P e e'')
+    → is-contr
+        ( Σ ( g : dhom B b' b'' v P e' e'')
+        , ( dhom2 B b b' b'' u v w sigma P e e' e'' f g h))
 ```
 
 ## Cocartesian lifts
@@ -88,8 +88,8 @@ a given starting point in the fiber.
   ( e : P b)
   : U
   :=
-    Σ (e' : P b') ,
-      Σ (f : dhom B b b' u P e e') , is-cocartesian-arrow B b b' u P e e' f
+    Σ ( e' : P b')
+    , Σ ( f : dhom B b b' u P e e') , is-cocartesian-arrow B b b' u P e e' f
 ```
 
 ## Cocartesian family
@@ -103,9 +103,9 @@ cocartesian lift, given a point in the fiber over the domain.
   ( P : B → U)
   : U
   :=
-    ( b : B) → ( b' : B) → ( u : hom B b b') →
-      ( e : P b) → ( Σ (e' : P b'),
-        ( Σ (f : dhom B b b' u P e e'), is-cocartesian-arrow B b b' u P e e' f))
+    ( b : B) → (b' : B) → (u : hom B b b')
+    → ( e : P b) → (Σ (e' : P b')
+      , ( Σ ( f : dhom B b b' u P e e') , is-cocartesian-arrow B b b' u P e e' f))
 ```
 
 ```rzk title="BW23, Definition 5.2.2"

--- a/src/simplicial-hott/13-limits.rzk.md
+++ b/src/simplicial-hott/13-limits.rzk.md
@@ -26,7 +26,7 @@ over `#!rzk f`.
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (b : B), hom (A → B) (constant A B b) f
+  := Σ (b : B) , hom (A → B) (constant A B b) f
 ```
 
 Given a function `#!rzk f : A → B` and `#!rzk b:B` we define the type of cocones
@@ -37,27 +37,27 @@ under `#!rzk f`.
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (b : B), hom ( A → B) f (constant A B b)
+  := Σ (b : B) , hom (A → B) f (constant A B b)
 ```
 
 We define a colimit for `#!rzk f : A → B` as an initial cocone under `#!rzk f`.
 
 ```rzk
 #def colimit
-  ( A B : U )
-  ( f : A → B )
+  ( A B : U)
+  ( f : A → B)
   : U
-  := Σ ( x : cocone A B f) , is-initial ( cocone A B f) x
+  := Σ (x : cocone A B f) , is-initial (cocone A B f) x
 ```
 
 We define a limit of `#!rzk f : A → B` as a final cone over `#!rzk f`.
 
 ```rzk
 #def limit
-  ( A B : U )
-  ( f : A → B )
+  ( A B : U)
+  ( f : A → B)
   : U
-  :=  Σ ( x : cone A B f) , is-final ( cone A B f) x
+  := Σ (x : cone A B f) , is-final (cone A B f) x
 ```
 
 We give a second definition of limits, we eventually want to prove both
@@ -65,27 +65,27 @@ definitions coincide. Define cone as a family.
 
 ```rzk
 #def family-cone
-  (A B : U)
-  : (A → B) → (B) → U
+  ( A B : U)
+  : ( A → B) → (B) → U
   := \ f → \ b → (hom (A → B) (constant A B b) f)
 
 #def constant-nat-trans
-  (A B : U)
-  ( x y : B )
+  ( A B : U)
+  ( x y : B)
   ( k : hom B x y)
   : hom (A → B) (constant A B x) (constant A B y)
-  := \ t a → ( constant A ( hom B x y ) k ) a t
+  := \ t a → (constant A (hom B x y) k) a t
 
 #def cone-precomposition
   ( A B : U)
   ( is-segal-B : is-segal B)
-  ( f : A → B )
-  ( b x : B )
+  ( f : A → B)
+  ( b x : B)
   ( k : hom B b x)
-  : ( family-cone A B f x) →  ( family-cone A B f b)
+  : ( family-cone A B f x) → (family-cone A B f b)
   :=
-  \ α
-  → vertical-comp-nat-trans
+  \ α →
+  vertical-comp-nat-trans
     ( A)
     ( \ _ → B)
     ( \ _ → is-segal-B)
@@ -104,9 +104,9 @@ Another definition of limit.
   ( is-segal-B : is-segal B)
   ( f : A → B)
   : U
-  := Σ (b : B),
-  Σ ( c : family-cone A B f b)
-    , ( x : B) → ( k : hom B b x)
+  := Σ (b : B)
+  , Σ ( c : family-cone A B f b)
+    , ( x : B) → (k : hom B b x)
       → is-equiv
         ( family-cone A B f x)
         ( family-cone A B f b)
@@ -118,8 +118,8 @@ definitions coincide. Define cocone as a family.
 
 ```rzk
 #def family-cocone
-  (A B : U)
-  : ( A → B) → ( B) → U
+  ( A B : U)
+  : ( A → B) → (B) → U
   := \ f → \ b → (hom (A → B) f (constant A B b))
 
 #def cocone-postcomposition
@@ -128,10 +128,10 @@ definitions coincide. Define cocone as a family.
   ( f : A → B)
   ( x b : B)
   ( k : hom B x b)
-  : ( family-cocone A B f x) → ( family-cocone A B f b)
+  : ( family-cocone A B f x) → (family-cocone A B f b)
   :=
-  \ α
-  → vertical-comp-nat-trans
+  \ α →
+  vertical-comp-nat-trans
     ( A)
     ( \ _ → B)
     ( \ _ → is-segal-B)
@@ -139,7 +139,7 @@ definitions coincide. Define cocone as a family.
     ( constant A B x)
     ( constant A B b)
     ( α)
-    ( constant-nat-trans A B x b k )
+    ( constant-nat-trans A B x b k)
 ```
 
 Another definition of colimit.
@@ -150,9 +150,9 @@ Another definition of colimit.
   ( is-segal-B : is-segal B)
   ( f : A → B)
   : U
-  := Σ (b : B),
-  Σ ( c : family-cocone A B f b)
-    , ( x : B) → ( k : hom B x b)
+  := Σ (b : B)
+  , Σ ( c : family-cocone A B f b)
+    , ( x : B) → (k : hom B x b)
     → is-equiv
       ( family-cocone A B f x)
       ( family-cocone A B f b)
@@ -167,13 +167,13 @@ When `#!rzk is-segal B` then definitions 1 and 3 coincide.
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ ( b : B),( x : B) → Equiv ( hom B b x) ( family-cone A B f x)
+  := Σ (b : B) , (x : B) → Equiv (hom B b x) (family-cone A B f x)
 
 #def colimit3
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ ( b : B), ( x : B) → Equiv ( hom B x b) ( family-cocone A B f x)
+  := Σ (b : B) , (x : B) → Equiv (hom B x b) (family-cocone A B f x)
 ```
 
 ## Uniqueness of initial and final objects.
@@ -189,17 +189,17 @@ In a Segal type, initial objects are isomorphic.
   ( is-initial-b : is-initial A b)
   : Iso A is-segal-A a b
   :=
-    ( first (is-initial-a b) ,
-      ( ( first (is-initial-b a) ,
-          all-elements-equal-is-contr
+    ( first (is-initial-a b)
+    , ( ( first (is-initial-b a)
+        , all-elements-equal-is-contr
             ( hom A a a)
             ( is-initial-a a)
             ( comp-is-segal A is-segal-A a b a
               ( first (is-initial-a b))
               ( first (is-initial-b a)))
-            ( id-hom A a)) ,
-        ( first (is-initial-b a) ,
-          all-elements-equal-is-contr
+            ( id-hom A a))
+      , ( first (is-initial-b a)
+        , all-elements-equal-is-contr
             ( hom A b b)
             ( is-initial-b b)
             ( comp-is-segal A is-segal-A b a b
@@ -219,17 +219,17 @@ In a Segal type, final objects are isomorphic.
   ( is-final-b : is-final A b)
   : Iso A is-segal-A a b
   :=
-    ( first (is-final-b a) ,
-      ( ( first (is-final-a b) ,
-          all-elements-equal-is-contr
+    ( first (is-final-b a)
+    , ( ( first (is-final-a b)
+        , all-elements-equal-is-contr
             ( hom A a a)
             ( is-final-a a)
             ( comp-is-segal A is-segal-A a b a
               ( first (is-final-b a))
               ( first (is-final-a b)))
-            ( id-hom A a)) ,
-        ( first (is-final-a b) ,
-          all-elements-equal-is-contr
+            ( id-hom A a))
+      , ( first (is-final-a b)
+        , all-elements-equal-is-contr
             ( hom A b b)
             ( is-final-b b)
             ( comp-is-segal A is-segal-A b a b
@@ -247,12 +247,12 @@ The type of cocones of a function with codomain a Segal type is a Segal type.
   ( A B : U)
   ( is-segal-B : is-segal B)
   ( f : A → B)
-  : is-covariant B ( \ b → family-cocone A B f b)
+  : is-covariant B (\ b → family-cocone A B f b)
   :=
     is-covariant-substitution-is-covariant
     ( A → B)
     ( B)
-    ( hom ( A → B) f)
+    ( hom (A → B) f)
     ( is-covariant-representable-is-segal
         ( A → B)
         ( is-segal-function-type
@@ -267,7 +267,7 @@ The type of cocones of a function with codomain a Segal type is a Segal type.
   ( A B : U)
   ( is-segal-B : is-segal B)
   ( f : A → B)
-  : is-segal ( cocone A B f)
+  : is-segal (cocone A B f)
   :=
     is-segal-total-type-covariant-family-is-segal-base
     ( extext)
@@ -284,7 +284,7 @@ The type of cocones of a function with codomain a Segal type is a Segal type.
 Colimits are unique up to isomorphism.
 
 ```rzk title="BM, Corollary 1 (i)"
-#def iso-colimit-is-segal uses ( extext funext)
+#def iso-colimit-is-segal uses (extext funext)
   ( A B : U)
   ( is-segal-B : is-segal B)
   ( f : A → B)


### PR DESCRIPTION
This PR runs the new auto-formatter for Rzk that implements the [style guide](https://github.com/rzk-lang/sHoTT/blob/main/src/STYLEGUIDE.md). It is currently still under work in https://github.com/rzk-lang/rzk/pull/144, so before it is merged and released, I'd like to make sure that it works as expected, so I ran it on all files in this project (using `rzk format --write`). This should help find implementation mistakes in the formatter and/or inconsistencies in the style guide (the hopeful best-case scenario would be that it aligns all formalizations with the current style guide 🙂).

Please review these changes and point out any problems or possible improvements.
