### PR TITLE
Update 06-contractible.rzk.md

### DIFF
--- a/src/CONTRIBUTORS.md
+++ b/src/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ Formalizations were contributed by the following people (listed alphabetically):
 - [Fredrik Bakke](https://github.com/fredrik-bakke),
 - [César Bardomiano Martínez](https://github.com/cesarbm03),
 - [Jonathan Campbell](https://github.com/jonalfcam),
+- [Theofanis Chatzidiamantis-Christoforidis](https://github.com/thchatzidiamantis),
 - [Aras Ergus](https://www.aergus.net/),
 - [Matthias Hutzler](https://github.com/MatthiasHu),
 - [Nikolai Kudasov](https://fizruk.github.io/),

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -556,8 +556,8 @@ together the two identifications to the out and back path.
 
 ## Total type over a contractible type
 
-We show that a ∑-type with contractible base is equivalent to the dependent
-type evaluated at the point of contraction.
+We show that a ∑-type with contractible base is equivalent to the dependent type
+evaluated at the point of contraction.
 
 ```rzk
 #def second-center-to-total-type-is-contr-base

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -564,9 +564,8 @@ type evaluated at the point of contraction.
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
-  :
-    ( C (center-contraction A is-contr-A))
-  → ( Σ ( x : A) , C x)
+  : ( C (center-contraction A is-contr-A))
+    → ( Σ ( x : A) , C x)
   :=
     \ v → ((center-contraction A is-contr-A) , v)
 ```
@@ -576,9 +575,8 @@ type evaluated at the point of contraction.
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
-  :
-    ( Σ ( x : A) , C x)
-  → ( C (center-contraction A is-contr-A))
+  : ( Σ ( x : A) , C x)
+    → ( C (center-contraction A is-contr-A))
   :=
     \ (x , u) →
       transport

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -224,10 +224,6 @@ A retract of contractible types is contractible.
 #end is-contr-is-retract-of-is-contr
 ```
 
-```rzk
-
-```
-
 ## Functions between contractible types
 
 ```rzk title="Any function between contractible types is an equivalence"
@@ -680,4 +676,30 @@ evaluated at the point of contraction.
             A is-contr-A C)
       , ( has-section-total-type-to-second-center-is-contr-base
             A is-contr-A C))))
+```
+
+Any two elements in a contractible type are equal, so we extend the equivalence
+to the dependent type evaluated at any given term in the base.
+
+```rzk
+#def transport-equiv-total-type-second-center-is-contr-base
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  ( C : A → U)
+  ( x : A)
+  : Equiv
+    ( Σ ( x : A) , C x)
+    ( C x)
+  :=
+    equiv-comp
+      ( Σ ( x : A) , C x)
+      ( C (center-contraction A is-contr-A))
+      ( C x)
+      ( equiv-total-type-second-center-is-contr-base A is-contr-A C)
+      ( equiv-transport
+        ( A)
+        ( C)
+        ( center-contraction A is-contr-A)
+        ( x)
+        ( homotopy-contraction A is-contr-A x))
 ```

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -557,7 +557,7 @@ We show that a ∑-type with contractible base is equivalent to the dependent ty
 evaluated at the point of contraction.
 
 ```rzk
-#def second-center-to-total-type-is-contr-base
+#def total-type-center-fiber-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
@@ -566,7 +566,7 @@ evaluated at the point of contraction.
   :=
     \ v → ((center-contraction A is-contr-A) , v)
 
-#def total-type-to-second-center-is-contr-base
+#def center-fiber-total-type-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
@@ -586,22 +586,22 @@ evaluated at the point of contraction.
           ( homotopy-contraction A is-contr-A x))
         ( u)
 
-#def has-retraction-total-type-to-second-center-is-contr-base
+#def has-retraction-center-fiber-total-type-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
   : has-retraction
     ( Σ ( x : A) , C x)
     ( C (center-contraction A is-contr-A))
-    ( total-type-to-second-center-is-contr-base A is-contr-A C)
+    ( center-fiber-total-type-is-contr-base A is-contr-A C)
   :=
-    ( ( second-center-to-total-type-is-contr-base A is-contr-A C)
+    ( ( total-type-center-fiber-is-contr-base A is-contr-A C)
     , \ (x , u) →
         ( rev
           ( Σ ( x : A) , C x)
           ( x , u)
-          ( second-center-to-total-type-is-contr-base A is-contr-A C
-            ( total-type-to-second-center-is-contr-base A is-contr-A C (x , u)))
+          ( total-type-center-fiber-is-contr-base A is-contr-A C
+            ( center-fiber-total-type-is-contr-base A is-contr-A C (x , u)))
           ( transport-lift A C
               ( x)
               ( center-contraction A is-contr-A)
@@ -612,16 +612,16 @@ evaluated at the point of contraction.
                 ( homotopy-contraction A is-contr-A x))
               ( u))))
 
-#def has-section-total-type-to-second-center-is-contr-base
+#def has-section-center-fiber-total-type-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
   : has-section
     ( Σ ( x : A) , C x)
     ( C (center-contraction A is-contr-A))
-    ( total-type-to-second-center-is-contr-base A is-contr-A C)
+    ( center-fiber-total-type-is-contr-base A is-contr-A C)
   :=
-    ( ( second-center-to-total-type-is-contr-base A is-contr-A C)
+    ( ( total-type-center-fiber-is-contr-base A is-contr-A C)
     , \ u →
         ( transport2
           ( A)
@@ -649,7 +649,7 @@ evaluated at the point of contraction.
             ( refl))
           ( u)))
 
-#def equiv-total-type-second-center-is-contr-base
+#def equiv-center-fiber-total-type-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
@@ -657,10 +657,10 @@ evaluated at the point of contraction.
     ( Σ ( x : A) , C x)
     ( C (center-contraction A is-contr-A))
   :=
-    ( ( total-type-to-second-center-is-contr-base A is-contr-A C)
-    , ( ( ( has-retraction-total-type-to-second-center-is-contr-base
+    ( ( center-fiber-total-type-is-contr-base A is-contr-A C)
+    , ( ( ( has-retraction-center-fiber-total-type-is-contr-base
             A is-contr-A C)
-      , ( has-section-total-type-to-second-center-is-contr-base
+      , ( has-section-center-fiber-total-type-is-contr-base
             A is-contr-A C))))
 ```
 
@@ -668,7 +668,7 @@ Any two elements in a contractible type are equal, so we extend the equivalence
 to the dependent type evaluated at any given term in the base.
 
 ```rzk
-#def transport-equiv-total-type-second-center-is-contr-base
+#def transport-equiv-center-fiber-total-type-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
@@ -681,7 +681,7 @@ to the dependent type evaluated at any given term in the base.
       ( Σ ( x : A) , C x)
       ( C (center-contraction A is-contr-A))
       ( C a)
-      ( equiv-total-type-second-center-is-contr-base A is-contr-A C)
+      ( equiv-center-fiber-total-type-is-contr-base A is-contr-A C)
       ( equiv-transport
         ( A)
         ( C)

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -553,3 +553,141 @@ together the two identifications to the out and back path.
       ( path-eq-path-through-center-is-contr A is-contr-A x y p))
     ( path-eq-path-through-center-is-contr A is-contr-A x y q)
 ```
+
+## Total type over a contractible type
+
+We show that a ∑-type with contractible base is equivalent to the dependent
+type evaluated at the point of contraction.
+
+```rzk
+#def second-center-to-total-type-is-contr-base
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  ( C : A → U)
+  :
+    ( C (center-contraction A is-contr-A))
+  → ( Σ ( x : A) , C x)
+  :=
+    \ v → ((center-contraction A is-contr-A) , v)
+```
+
+```rzk
+#def total-type-to-second-center-is-contr-base
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  ( C : A → U)
+  :
+    ( Σ ( x : A) , C x)
+  → ( C (center-contraction A is-contr-A))
+  :=
+    \ (x , u) →
+      transport
+        ( A)
+        ( C)
+        ( x)
+        ( center-contraction A is-contr-A)
+        ( rev
+          ( A)
+          ( center-contraction A is-contr-A)
+          ( x)
+          ( homotopy-contraction A is-contr-A x))
+        ( u)
+```
+
+```rzk
+#def has-retraction-total-type-to-second-center-is-contr-base
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  ( C : A → U)
+  : has-retraction
+    ( Σ ( x : A) , C x)
+    ( C (center-contraction A is-contr-A))
+    ( total-type-to-second-center-is-contr-base A is-contr-A C)
+  :=
+    ( ( second-center-to-total-type-is-contr-base A is-contr-A C)
+    , \ (x , u) →
+    ( rev (Σ (x : A) , C x)
+        ( x , u)
+        ( second-center-to-total-type-is-contr-base A is-contr-A C
+          ( total-type-to-second-center-is-contr-base A is-contr-A C (x , u)))
+        ( transport-lift A C
+            ( x)
+            ( center-contraction A is-contr-A)
+            ( rev
+              ( A)
+              ( center-contraction A is-contr-A)
+              ( x)
+              ( homotopy-contraction A is-contr-A x))
+            ( u))))
+```
+
+```rzk
+#def has-section-total-type-to-second-center-is-contr-base
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  ( C : A → U)
+  : has-section
+    ( Σ ( x : A) , C x)
+    ( C (center-contraction A is-contr-A))
+    ( total-type-to-second-center-is-contr-base A is-contr-A C)
+  :=
+    ( ( second-center-to-total-type-is-contr-base A is-contr-A C)
+    , \ u →
+      ( concat
+        ( C (center-contraction A is-contr-A))
+        ( total-type-to-second-center-is-contr-base A is-contr-A C
+          ( second-center-to-total-type-is-contr-base A is-contr-A C u))
+        ( transport A C
+          ( center-contraction A is-contr-A)
+          ( center-contraction A is-contr-A)
+          ( first-path-Σ A C (center-contraction A is-contr-A , u)
+            ( center-contraction A is-contr-A , u)
+            ( refl))
+          ( u))
+        ( u)
+        ( transport2
+          ( A)
+          ( C)
+          ( center-contraction A is-contr-A)
+          ( center-contraction A is-contr-A)
+          ( rev
+            ( A)
+            ( center-contraction A is-contr-A)
+            ( center-contraction A is-contr-A)
+            ( homotopy-contraction A is-contr-A
+              ( center-contraction A is-contr-A)))
+          ( refl)
+          ( all-paths-equal-is-contr
+            ( A)
+            ( is-contr-A)
+            ( center-contraction A is-contr-A)
+            ( center-contraction A is-contr-A)
+            ( rev
+              ( A)
+              ( center-contraction A is-contr-A)
+              ( center-contraction A is-contr-A)
+              ( homotopy-contraction A is-contr-A
+                ( center-contraction A is-contr-A)))
+              ( refl))
+            ( u))
+        ( second-path-Σ A C
+          ( ( center-contraction A is-contr-A) , u)
+          ( ( center-contraction A is-contr-A) , u)
+          ( refl))))
+```
+
+```rzk
+#def equiv-total-type-second-center-is-contr-base
+  ( A : U)
+  ( is-contr-A : is-contr A)
+  ( C : A → U)
+  : Equiv
+    ( Σ ( x : A) , C x)
+    ( C (center-contraction A is-contr-A))
+  :=
+    ( ( total-type-to-second-center-is-contr-base A is-contr-A C)
+    , ( ( ( has-retraction-total-type-to-second-center-is-contr-base
+            A is-contr-A C)
+      , ( has-section-total-type-to-second-center-is-contr-base
+            A is-contr-A C))))
+```

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -565,7 +565,7 @@ type evaluated at the point of contraction.
   ( is-contr-A : is-contr A)
   ( C : A → U)
   : ( C (center-contraction A is-contr-A))
-    → ( Σ ( x : A) , C x)
+  → ( Σ ( x : A) , C x)
   :=
     \ v → ((center-contraction A is-contr-A) , v)
 ```
@@ -576,7 +576,7 @@ type evaluated at the point of contraction.
   ( is-contr-A : is-contr A)
   ( C : A → U)
   : ( Σ ( x : A) , C x)
-    → ( C (center-contraction A is-contr-A))
+  → ( C (center-contraction A is-contr-A))
   :=
     \ (x , u) →
       transport

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -686,20 +686,20 @@ to the dependent type evaluated at any given term in the base.
   ( A : U)
   ( is-contr-A : is-contr A)
   ( C : A → U)
-  ( x : A)
+  ( a : A)
   : Equiv
     ( Σ ( x : A) , C x)
-    ( C x)
+    ( C a)
   :=
     equiv-comp
       ( Σ ( x : A) , C x)
       ( C (center-contraction A is-contr-A))
-      ( C x)
+      ( C a)
       ( equiv-total-type-second-center-is-contr-base A is-contr-A C)
       ( equiv-transport
         ( A)
         ( C)
         ( center-contraction A is-contr-A)
-        ( x)
-        ( homotopy-contraction A is-contr-A x))
+        ( a)
+        ( homotopy-contraction A is-contr-A a))
 ```

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -568,9 +568,7 @@ type evaluated at the point of contraction.
   → ( Σ ( x : A) , C x)
   :=
     \ v → ((center-contraction A is-contr-A) , v)
-```
 
-```rzk
 #def total-type-to-second-center-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
@@ -590,9 +588,7 @@ type evaluated at the point of contraction.
           ( x)
           ( homotopy-contraction A is-contr-A x))
         ( u)
-```
 
-```rzk
 #def has-retraction-total-type-to-second-center-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
@@ -617,9 +613,7 @@ type evaluated at the point of contraction.
               ( x)
               ( homotopy-contraction A is-contr-A x))
             ( u))))
-```
 
-```rzk
 #def has-section-total-type-to-second-center-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)
@@ -672,9 +666,7 @@ type evaluated at the point of contraction.
           ( ( center-contraction A is-contr-A) , u)
           ( ( center-contraction A is-contr-A) , u)
           ( refl))))
-```
 
-```rzk
 #def equiv-total-type-second-center-is-contr-base
   ( A : U)
   ( is-contr-A : is-contr A)

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -518,7 +518,8 @@ In a contractible type any path $p : x = y$ is equal to the path constructed in
     ( A)
     ( x)
     ( \ y' p' → (all-elements-equal-is-contr A is-contr-A x y') = p')
-    ( left-inverse-concat A (center-contraction A is-contr-A) x (homotopy-contraction A is-contr-A x))
+    ( left-inverse-concat A (center-contraction A is-contr-A) x
+      ( homotopy-contraction A is-contr-A x))
     ( y)
     ( p)
 
@@ -596,19 +597,20 @@ evaluated at the point of contraction.
   :=
     ( ( second-center-to-total-type-is-contr-base A is-contr-A C)
     , \ (x , u) →
-    ( rev (Σ (x : A) , C x)
-        ( x , u)
-        ( second-center-to-total-type-is-contr-base A is-contr-A C
-          ( total-type-to-second-center-is-contr-base A is-contr-A C (x , u)))
-        ( transport-lift A C
-            ( x)
-            ( center-contraction A is-contr-A)
-            ( rev
-              ( A)
-              ( center-contraction A is-contr-A)
+        ( rev
+          ( Σ ( x : A) , C x)
+          ( x , u)
+          ( second-center-to-total-type-is-contr-base A is-contr-A C
+            ( total-type-to-second-center-is-contr-base A is-contr-A C (x , u)))
+          ( transport-lift A C
               ( x)
-              ( homotopy-contraction A is-contr-A x))
-            ( u))))
+              ( center-contraction A is-contr-A)
+              ( rev
+                ( A)
+                ( center-contraction A is-contr-A)
+                ( x)
+                ( homotopy-contraction A is-contr-A x))
+              ( u))))
 
 #def has-section-total-type-to-second-center-is-contr-base
   ( A : U)
@@ -621,18 +623,6 @@ evaluated at the point of contraction.
   :=
     ( ( second-center-to-total-type-is-contr-base A is-contr-A C)
     , \ u →
-      ( concat
-        ( C (center-contraction A is-contr-A))
-        ( total-type-to-second-center-is-contr-base A is-contr-A C
-          ( second-center-to-total-type-is-contr-base A is-contr-A C u))
-        ( transport A C
-          ( center-contraction A is-contr-A)
-          ( center-contraction A is-contr-A)
-          ( first-path-Σ A C (center-contraction A is-contr-A , u)
-            ( center-contraction A is-contr-A , u)
-            ( refl))
-          ( u))
-        ( u)
         ( transport2
           ( A)
           ( C)
@@ -656,12 +646,8 @@ evaluated at the point of contraction.
               ( center-contraction A is-contr-A)
               ( homotopy-contraction A is-contr-A
                 ( center-contraction A is-contr-A)))
-              ( refl))
-            ( u))
-        ( second-path-Σ A C
-          ( ( center-contraction A is-contr-A) , u)
-          ( ( center-contraction A is-contr-A) , u)
-          ( refl))))
+            ( refl))
+          ( u)))
 
 #def equiv-total-type-second-center-is-contr-base
   ( A : U)


### PR DESCRIPTION
Added proof that a Σ-type with contractible base is equivalent to the dependent type valued at the center of contraction.