### PR TITLE
Proposition 4.12 (extension types preserve n-type)

### DIFF
--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -953,6 +953,42 @@ extension extensionality that we get by extracting the fiberwise equivalence.
   := extext-weakextext'
 ```
 
+### RS17 Proposition 4.12 (extension types preserve n-types)
+
+Assuming Axiom 4.6 (weak extension extensionality), if `A : (t : ψ) → U` and
+`a : (t : ϕ) → A t` are such that each `A(t)` is an n-type, then the extension
+type `(t : ψ) → A t [ϕ t ↦ a t]` is also an n-type. We formalize the cases **n =
+−2 (contractible)** and **n = −1 (proposition)**.
+
+```rzk title="RS17 Proposition 4.12 (contractible case)"
+#def is-contr-extension-type-is-fiberwise-contr
+  ( weakextext : WeakExtExt)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : ψ → U)
+  ( is-fiberwise-contr-A : (t : ψ) → is-contr (A t))
+  ( a : (t : ϕ) → A t)
+  : is-contr ((t : ψ) → A t [ϕ t ↦ a t])
+  := weakextext I ψ ϕ A is-fiberwise-contr-A a
+```
+
+```rzk title="RS17 Proposition 4.12 (proposition case)"
+#def is-prop-extension-type-is-fiberwise-prop
+  ( weakextext : WeakExtExt)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : ψ → U)
+  ( is-fiberwise-prop-A : (t : ψ) → is-prop (A t))
+  ( a : (t : ϕ) → A t)
+  : is-prop ((t : ψ) → A t [ϕ t ↦ a t])
+  :=
+    is-prop-extension-type-is-locally-prop
+      ( naiveextext-extext (extext-weakextext weakextext))
+      ( I) (ψ) (ϕ) (A) (is-fiberwise-prop-A) (a)
+```
+
 ## Homotopy extension property
 
 The homotopy extension property has the following signature. We state this


### PR DESCRIPTION
Completes https://github.com/rzk-lang/sHoTT/issues/5.

I've noticed that we only have `is-contr` and `is-prop` in sHoTT. Should we add more n-types (sets, groupoids, etc.)? Can we call 1-type a groupoid regardless of the simplicial structure?

- [x] proposition (n = -2)
- [x] contractible (n = -1)
- [ ] set (n = 0)
- [ ] groupoid (n = 1)