### PR TITLE
Prove Prop 10.3 of RS17 and add supporting lemmas for extension types

### DIFF
--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -232,6 +232,18 @@ Equivalently , natural transformations can be determined by their **components**
   := \ t x → η x t
 ```
 
+```rzk
+#def ev-components-nat-trans-extension-type
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( f g : (s : ψ) → A s)
+  ( α : hom ((s : ψ) → A s) f g)
+  : ( s : ψ) → hom (A s) (f s) (g s)
+  := \ s t → α t s
+
+```
+
 ### Natural transformation extensionality
 
 ```rzk title="RS17, Proposition 6.3"
@@ -420,6 +432,44 @@ components of the natural transformation defined by composing in the Segal type
     ( ( x : A) → (B x)) (B a)
     ( is-segal-function-type (funext) (A) (B) (is-segal-B)) (is-segal-B a)
     ( \ s → s a) (f) (g) (h) (α) (β)
+```
+
+The same statements hold for extension types.
+
+```rzk title="RS17, Proposition 6.5, extension type case"
+#def id-arr-components-id-nat-trans-extension-type
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( f : (s : ψ) → A s)
+  ( s : ψ)
+  : ( ev-components-nat-trans-extension-type I ψ A f f
+      ( id-hom ((s : ψ) → A s) f)) s
+  = id-hom (A s) (f s)
+  := refl
+
+#def comp-components-comp-nat-trans-is-segal-extension-type uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-segal-A : (s : ψ) → is-segal (A s))
+  ( f g h : (s : ψ) → A s)
+  ( α : hom ((s : ψ) → A s) f g)
+  ( β : hom ((s : ψ) → A s) g h)
+  ( s : ψ)
+  : ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (h s)
+      ( ev-components-nat-trans-extension-type I ψ A f g α s)
+      ( ev-components-nat-trans-extension-type I ψ A g h β s))
+  = ( ev-components-nat-trans-extension-type I ψ A f h
+      ( comp-is-segal
+        ( ( s' : ψ) → A s')
+        ( is-segal-extension-type extext I ψ A is-segal-A)
+        ( f) (g) (h) (α) (β)) s)
+  :=
+    functors-pres-comp
+    ( ( s' : ψ) → A s') (A s)
+    ( is-segal-extension-type extext I ψ A is-segal-A) (is-segal-A s)
+    ( \ σ → σ s) (f) (g) (h) (α) (β)
 ```
 
 ### Horizontal composition

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -232,7 +232,7 @@ Equivalently , natural transformations can be determined by their **components**
   := \ t x → η x t
 ```
 
-```rzk
+```rzk title="A version of ev-components-nat-trans for extension types"
 #def ev-components-nat-trans-extension-type
   ( I : CUBE)
   ( ψ : I → TOPE)
@@ -241,7 +241,6 @@ Equivalently , natural transformations can be determined by their **components**
   ( α : hom ((s : ψ) → A s) f g)
   : ( s : ψ) → hom (A s) (f s) (g s)
   := \ s t → α t s
-
 ```
 
 ### Natural transformation extensionality
@@ -436,7 +435,7 @@ components of the natural transformation defined by composing in the Segal type
 
 The same statements hold for extension types.
 
-```rzk title="RS17, Proposition 6.5, extension type case"
+```rzk title="RS17, Proposition 6.5(ii), extension type case"
 #def id-arr-components-id-nat-trans-extension-type
   ( I : CUBE)
   ( ψ : I → TOPE)
@@ -447,7 +446,9 @@ The same statements hold for extension types.
       ( id-hom ((s : ψ) → A s) f)) s
   = id-hom (A s) (f s)
   := refl
+```
 
+```rzk title="RS17, Proposition 6.5(i), extension type case"
 #def comp-components-comp-nat-trans-is-segal-extension-type uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -697,6 +697,229 @@ equal.
       ( iff-is-iso-pointwise-is-iso X A is-segal-A f g α)
 ```
 
+```rzk title="RS17, Proposition 10.3b (for shapes)"
+#def ev-components-nat-trans-preserves-iso-extension-type uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-segal-A : (s : ψ) → is-segal (A s))
+  ( f g : (s : ψ) → A s)
+  ( α : hom ((s : ψ) → A s) f g)
+  : ( is-iso-arrow
+      ( ( s : ψ) → A s)
+      ( is-segal-extension-type extext I ψ A is-segal-A) f g α)
+  → ( s : ψ)
+  → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+      ( ev-components-nat-trans-extension-type I ψ A f g α s))
+  :=
+    \ ((β , p) , (γ , q)) →
+    \ s →
+    ( ( ( \ t → β t s)
+      , ( triple-concat
+          ( hom (A s) (f s) (f s))
+          ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (f s)
+            ( \ t → α t s)
+            ( \ t → β t s))
+          ( \ t →
+            comp-is-segal
+              ( ( s' : ψ) → A s')
+              ( is-segal-extension-type extext I ψ A is-segal-A)
+              ( f) (g) (f) (α) (β) t s)
+          ( \ t → id-hom ((s' : ψ) → A s') f t s)
+          ( id-hom (A s) (f s))
+          ( comp-components-comp-nat-trans-is-segal-extension-type
+            extext I ψ A is-segal-A f g f α β s)
+          ( ap
+            ( hom ((s' : ψ) → A s') f f)
+            ( hom (A s) (f s) (f s))
+            ( comp-is-segal
+              ( ( s' : ψ) → A s')
+              ( is-segal-extension-type extext I ψ A is-segal-A)
+              ( f) (g) (f) (α) (β))
+            ( id-hom ((s' : ψ) → A s') f)
+            ( \ c → \ t → c t s)
+            ( p))
+          ( refl)))
+    , ( ( \ t → γ t s)
+      , ( triple-concat
+          ( hom (A s) (g s) (g s))
+          ( comp-is-segal (A s) (is-segal-A s) (g s) (f s) (g s)
+            ( \ t → γ t s)
+            ( \ t → α t s))
+          ( \ t →
+            comp-is-segal
+              ( ( s' : ψ) → A s')
+              ( is-segal-extension-type extext I ψ A is-segal-A)
+              ( g) (f) (g) (γ) (α) t s)
+          ( \ t → id-hom ((s' : ψ) → A s') g t s)
+          ( id-hom (A s) (g s))
+          ( comp-components-comp-nat-trans-is-segal-extension-type
+            extext I ψ A is-segal-A g f g γ α s)
+          ( ap
+            ( hom ((s' : ψ) → A s') g g)
+            ( hom (A s) (g s) (g s))
+            ( comp-is-segal
+              ( ( s' : ψ) → A s')
+              ( is-segal-extension-type extext I ψ A is-segal-A)
+              ( g) (f) (g) (γ) (α))
+            ( id-hom ((s' : ψ) → A s') g)
+            ( \ c → \ t → c t s)
+            ( q))
+          ( refl))))
+
+#def nat-trans-nat-trans-components-preserves-iso-helper-extension-type
+  uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-segal-A : (s : ψ) → is-segal (A s))
+  ( f g : (s : ψ) → A s)
+  ( α : hom ((s : ψ) → A s) f g)
+  ( β : hom ((s : ψ) → A s) g f)
+  : ( ( s : ψ)
+    → ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (f s)
+        ( ev-components-nat-trans-extension-type I ψ A f g α s)
+        ( ev-components-nat-trans-extension-type I ψ A g f β s))
+    = ( id-hom (A s) (f s)))
+  → ( comp-is-segal
+      ( ( s : ψ) → A s)
+      ( is-segal-extension-type extext I ψ A is-segal-A)
+      f g f α β)
+  = ( id-hom ((s : ψ) → A s) f)
+  :=
+    \ H →
+    ap
+      ( ( s : ψ) → hom (A s) (f s) (f s))
+      ( hom ((s : ψ) → A s) f f)
+      ( \ s → \ t →
+        comp-is-segal
+          ( ( s' : ψ) → A s')
+          ( is-segal-extension-type extext I ψ A is-segal-A)
+          ( f) (g) (f) (α) (β) t s)
+      ( \ s → id-hom (A s) (f s))
+      ( \ ξ → \ t s → ξ s t)
+      ( naiveextext-extext extext I ψ (\ _ → ⊥)
+        ( \ s → hom (A s) (f s) (f s))
+        ( \ _ → recBOT)
+        ( \ s → \ t →
+          comp-is-segal
+            ( ( s' : ψ) → A s')
+            ( is-segal-extension-type extext I ψ A is-segal-A)
+            ( f) (g) (f) (α) (β) t s)
+        ( \ s → id-hom (A s) (f s))
+        ( \ s →
+          concat
+            ( hom (A s) (f s) (f s))
+            ( \ t →
+              comp-is-segal
+                ( ( s' : ψ) → A s')
+                ( is-segal-extension-type extext I ψ A is-segal-A)
+                ( f) (g) (f) (α) (β) t s)
+            ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (f s)
+              ( \ t → α t s)
+              ( \ t → β t s))
+            ( id-hom (A s) (f s))
+            ( rev
+              ( hom (A s) (f s) (f s))
+              ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (f s)
+                ( \ t → α t s)
+                ( \ t → β t s))
+              ( \ t →
+                comp-is-segal
+                  ( ( s' : ψ) → A s')
+                  ( is-segal-extension-type extext I ψ A is-segal-A)
+                  ( f) (g) (f) (α) (β) t s)
+              ( comp-components-comp-nat-trans-is-segal-extension-type
+                extext I ψ A is-segal-A f g f α β s))
+            ( H s)))
+
+#def nat-trans-nat-trans-components-preserves-iso-extension-type uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-segal-A : (s : ψ) → is-segal (A s))
+  ( f g : (s : ψ) → A s)
+  ( α : hom ((s : ψ) → A s) f g)
+  : ( ( s : ψ)
+    → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+        ( ev-components-nat-trans-extension-type I ψ A f g α s)))
+  → ( is-iso-arrow
+      ( ( s : ψ) → A s)
+      ( is-segal-extension-type extext I ψ A is-segal-A) f g α)
+  :=
+    \ H →
+    ( ( \ t s → first (first (H s)) t
+      , nat-trans-nat-trans-components-preserves-iso-helper-extension-type
+          I ψ A is-segal-A f g α
+          ( \ t s → first (first (H s)) t)
+          ( \ s → second (first (H s))))
+    , ( \ t s → first (second (H s)) t
+      , nat-trans-nat-trans-components-preserves-iso-helper-extension-type
+          I ψ A is-segal-A g f
+          ( \ t s → first (second (H s)) t)
+          ( α)
+          ( \ s → second (second (H s)))))
+
+#def iff-is-iso-pointwise-is-iso-extension-type uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-segal-A : (s : ψ) → is-segal (A s))
+  ( f g : (s : ψ) → A s)
+  ( α : hom ((s : ψ) → A s) f g)
+  : iff
+    ( is-iso-arrow
+      ( ( s : ψ) → A s)
+      ( is-segal-extension-type extext I ψ A is-segal-A) f g α)
+    ( ( s : ψ)
+    → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+        ( ev-components-nat-trans-extension-type I ψ A f g α s)))
+  :=
+    ( ev-components-nat-trans-preserves-iso-extension-type
+        I ψ A is-segal-A f g α
+    , nat-trans-nat-trans-components-preserves-iso-extension-type
+        I ψ A is-segal-A f g α)
+
+#def equiv-is-iso-pointwise-is-iso-extension-type uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-segal-A : (s : ψ) → is-segal (A s))
+  ( f g : (s : ψ) → A s)
+  ( α : hom ((s : ψ) → A s) f g)
+  : Equiv
+    ( is-iso-arrow
+      ( ( s : ψ) → A s)
+      ( is-segal-extension-type extext I ψ A is-segal-A) f g α)
+    ( ( s : ψ)
+    → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+        ( ev-components-nat-trans-extension-type I ψ A f g α s)))
+  :=
+    equiv-iff-is-prop-is-prop
+      ( is-iso-arrow
+        ( ( s : ψ) → A s)
+        ( is-segal-extension-type extext I ψ A is-segal-A)
+        ( f) (g) (α))
+      ( ( s : ψ)
+      → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+          ( ev-components-nat-trans-extension-type I ψ A f g α s)))
+      ( is-prop-is-iso-arrow
+        ( ( s : ψ) → A s)
+        ( is-segal-extension-type extext I ψ A is-segal-A)
+        ( f) (g) (α))
+      ( is-prop-shape-type-is-locally-prop
+        ( naiveextext-extext extext)
+        ( I) (ψ)
+        ( \ s →
+          is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+          ( ev-components-nat-trans-extension-type I ψ A f g α s))
+        ( \ s →
+          is-prop-is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+          ( ev-components-nat-trans-extension-type I ψ A f g α s)))
+      ( iff-is-iso-pointwise-is-iso-extension-type
+          I ψ A is-segal-A f g α)
+```
+
 ```rzk title="RS17, Corollary 10.4a (isomorphism extensionality)"
 #def iso-extensionality uses (extext funext)
   ( X : U)

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -715,33 +715,37 @@ equal.
     \ ((β , p) , (γ , q)) →
     \ s →
     ( ( ( \ t → β t s)
-      , ( triple-concat
-          ( hom (A s) (f s) (f s))
-          ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (f s)
+    -- we prove
+    -- αₛ ∘ βₛ = (α ∘ β)ₛ = id_(f s) = (id_f)ₛ
+    -- the last equality is automatic (refl), so we omit it in the formalization
+    , ( concat
+        ( hom (A s) (f s) (f s))
+        ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (f s)
             ( \ t → α t s)
             ( \ t → β t s))
-          ( \ t →
-            comp-is-segal
-              ( ( s' : ψ) → A s')
-              ( is-segal-extension-type extext I ψ A is-segal-A)
-              ( f) (g) (f) (α) (β) t s)
-          ( \ t → id-hom ((s' : ψ) → A s') f t s)
-          ( id-hom (A s) (f s))
-          ( comp-components-comp-nat-trans-is-segal-extension-type
-            extext I ψ A is-segal-A f g f α β s)
-          ( ap
-            ( hom ((s' : ψ) → A s') f f)
-            ( hom (A s) (f s) (f s))
-            ( comp-is-segal
-              ( ( s' : ψ) → A s')
-              ( is-segal-extension-type extext I ψ A is-segal-A)
-              ( f) (g) (f) (α) (β))
-            ( id-hom ((s' : ψ) → A s') f)
-            ( \ c → \ t → c t s)
-            ( p))
-          ( refl)))
+        ( \ t →
+          comp-is-segal
+            ( ( s' : ψ) → A s')
+            ( is-segal-extension-type extext I ψ A is-segal-A)
+            ( f) (g) (f) (α) (β) t s)
+        ( id-hom (A s) (f s))
+        ( comp-components-comp-nat-trans-is-segal-extension-type
+          extext I ψ A is-segal-A f g f α β s)
+        ( ap
+          ( hom ((s : ψ) → A s) f f)
+          ( hom (A s) (f s) (f s))
+          ( comp-is-segal
+                ( ( s' : ψ) → A s')
+                ( is-segal-extension-type extext I ψ A is-segal-A)
+                ( f) (g) (f) (α) (β))
+          ( id-hom ((s : ψ) → A s) f)
+          ( \ c t → c t s)
+          p)))
     , ( ( \ t → γ t s)
-      , ( triple-concat
+    -- we prove
+    -- γₛ ∘ αₛ ≡ (γ ∘ α)ₛ ≡ id_(g s) ≡ (id_g)ₛ
+    -- the last equality is automatic (refl), so we omit it in the formalization
+      , ( concat
           ( hom (A s) (g s) (g s))
           ( comp-is-segal (A s) (is-segal-A s) (g s) (f s) (g s)
             ( \ t → γ t s)
@@ -751,7 +755,6 @@ equal.
               ( ( s' : ψ) → A s')
               ( is-segal-extension-type extext I ψ A is-segal-A)
               ( g) (f) (g) (γ) (α) t s)
-          ( \ t → id-hom ((s' : ψ) → A s') g t s)
           ( id-hom (A s) (g s))
           ( comp-components-comp-nat-trans-is-segal-extension-type
             extext I ψ A is-segal-A g f g γ α s)
@@ -764,8 +767,7 @@ equal.
               ( g) (f) (g) (γ) (α))
             ( id-hom ((s' : ψ) → A s') g)
             ( \ c → \ t → c t s)
-            ( q))
-          ( refl))))
+            ( q)))))
 
 #def nat-trans-nat-trans-components-preserves-iso-helper-extension-type
   uses (extext)


### PR DESCRIPTION
Closes https://github.com/rzk-lang/sHoTT/issues/22

Extends Prop 10.3 of RS17 (isomorphism iff pointwise isomorphism) to the case where the base is a shape.

- Add `ev-components-nat-trans-extension-type` to 06
- Add `id-arr-components-id-nat-trans-extension-type` to 06 (Prop 6.5)
- Add `comp-components-comp-nat-trans-is-segal-extension-type` to 06 (Prop 6.5)
- Add proof for extension type case of Prop 10.3 to 10
