### PR TITLE
Tope disjunction elimination along propositional equality

### DIFF
--- a/src/hott/12-sets.rzk.md
+++ b/src/hott/12-sets.rzk.md
@@ -1,4 +1,4 @@
-# 12. Propositions
+# 12. Sets
 
 This is a literate `rzk` file:
 

--- a/src/hott/12-sets.rzk.md
+++ b/src/hott/12-sets.rzk.md
@@ -1,0 +1,18 @@
+# 12. Propositions
+
+This is a literate `rzk` file:
+
+```rzk
+#lang rzk-1
+```
+
+## Sets
+
+A type is a set when its identity types are propositions.
+
+```rzk
+#def is-set
+  ( A : U)
+  : U
+  := (x : A) → (y : A) → (p : x = y) → (q : x = y) → p = q
+```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1827,14 +1827,14 @@ equivalent to extending the fiber.
 
 ## Tope disjunction elimination along identity paths
 
-\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a_\phi)\) (written
-`recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a_\psi\) and
-\(a_\phi\) are _definitionally_ equal on \(\psi \land \phi\). Sometimes this is
+\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a*\phi)\) (written
+`recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a*\psi\) and
+\(a*\phi\) are \_definitionally* equal on \(\psi \land \phi\). Sometimes this is
 too strong since many terms are not _definitionally_ equal, but only equal up to
 a path. Luckily, assuming relative function extensionality, we can define a
-weaker version of \(rec_{\lor}\) (`recOR`), which we call `rec-path`, that can work
-in presence of a witness of type \(\prod_{t : I \mid \psi \land \phi} a_\psi =
-a_\phi\).
+weaker version of \(rec*{\lor}\) (`recOR`), which we call `rec-path`, that can
+work in presence of a witness of type \(\prod*{t : I \mid \psi \land \phi}
+a*\psi = a*\phi\).
 
 ### Construction of `rec-path`
 
@@ -1937,8 +1937,8 @@ Finally, we bring everything together into `rec-path`:
 
 ### Gluing extension types
 
-An application of `rec-path` is gluing together extension types, whenever
-we can show that they are equal on the intersection of shapes.
+An application of `rec-path` is gluing together extension types, whenever we can
+show that they are equal on the intersection of shapes.
 
 The latter can be easily shown when the intersection maps to a set:
 

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1827,14 +1827,14 @@ equivalent to extending the fiber.
 
 ## Tope disjuction elimination along identity paths
 
-\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a*\phi)\) (written
-`recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a*\psi\) and
-\(a*\phi\) are \_definitionally equal* on \(\psi \land \phi\). Sometimes this is
+\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a_\phi)\) (written
+`recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a_\psi\) and
+\(a_\phi\) are \_definitionally equal* on \(\psi \land \phi\). Sometimes this is
 too strong since many terms are not _definitionally_ equal, but only equal up to
 a path. Luckily, assuming relative function extensionality, we can define a
-weaker version of \(rec*{\lor}\) (`recOR`), which we call `recId`, that can work
-in presence of a witness of type \(\prod*{t : I \mid \psi \land \phi} a*\psi =
-a*\phi\).
+weaker version of \(rec_{\lor}\) (`recOR`), which we call `recId`, that can work
+in presence of a witness of type \(\prod_{t : I \mid \psi \land \phi} a_\psi =
+a_\phi\).
 
 ### Construction of `recId`
 
@@ -1854,13 +1854,15 @@ First, we define how to restrict an extension type to a subshape:
 #variable A : (t : I | ψ t ∨ φ t) → U
 
 -- Restrict extension type to a subshape.
-#define restrict_phi
+-- TODO: should be a local-only definition (use let-binding when it exists)
+#define restrict-phi
   ( a : (t : φ) → A t)
   : ( t : I | ψ t ∧ φ t) → A t
   := \ t → a t
 
 -- Restrict extension type to a subshape.
-#define restrict_psi
+-- TODO: should be a local-only definition (use let-binding when it exists)
+#define restrict-psi
   ( a : (t : ψ) → A t)
   : ( t : I | ψ t ∧ φ t) → A t
   := \ t → a t
@@ -1870,17 +1872,19 @@ Then, how to reformulate an `a` (or `b`) as an extension of its restriction:
 
 ```rzk
 -- Reformulate extension type as an extension of a restriction.
-#define ext-of-restrict_psi
+-- TODO: should be a local-only definition (use let-binding when it exists)
+#define ext-of-restrict-psi
   ( a : (t : ψ) → A t)
   : ( t : ψ)
-  → A t [ ψ t ∧ φ t ↦ restrict_psi a t ]
+  → A t [ ψ t ∧ φ t ↦ restrict-psi a t ]
   := a  -- type is coerced automatically here
 
 -- Reformulate extension type as an extension of a restriction.
-#define ext-of-restrict_phi
+-- TODO: should be a local-only definition (use let-binding when it exists)
+#define ext-of-restrict-phi
   ( a : (t : φ) → A t)
   : ( t : φ)
-  → A t [ ψ t ∧ φ t ↦ restrict_phi a t ]
+  → A t [ ψ t ∧ φ t ↦ restrict-phi a t ]
   := a  -- type is coerced automatically here
 ```
 
@@ -1889,11 +1893,12 @@ restrictions:
 
 ```rzk
 -- Transform extension of an identity into an identity of restrictions.
+-- TODO: should be a local-only definition (use let-binding when it exists)
 #define restricts-path
-  ( a_psi : (t : ψ) → A t)
-  ( a_phi : (t : φ) → A t)
-  : ( e : (t : I | ψ t ∧ φ t) → a_psi t = a_phi t)
-  → restrict_psi a_psi = restrict_phi a_phi
+  ( a-in-ψ : (t : ψ) → A t)
+  ( a-in-φ : (t : φ) → A t)
+  : ( e : (t : I | ψ t ∧ φ t) → a-in-ψ t = a-in-φ t)
+  → restrict-psi a-in-ψ = restrict-phi a-in-φ
   :=
   first
   ( second
@@ -1902,33 +1907,34 @@ restrictions:
       ( \ t → BOT)
       ( \ t → A t)
       ( \ t → recBOT)
-      ( \ t → a_psi t)
-      ( \ t → a_phi t)))
+      ( \ t → a-in-ψ t)
+      ( \ t → a-in-φ t)))
 ```
 
-Finally, we bring everything together into `recId`:
+Finally, we bring everything together into `rec-path`:
 
 ```rzk
 -- A weaker version of recOR, demanding only a path between a and b:
 -- recOR(ψ, φ, a, b) demands that for ψ ∧ φ we have a == b (definitionally)
--- (recId ψ φ a b e) demands that e is the proof that a = b (intensionally) for ψ ∧ φ
-#define recId uses (extext) -- we declare that recId is using extext on purpose
-  ( a_psi : (t : ψ) → A t)
-  ( a_phi : (t : φ) → A t)
-  ( e : (t : I | ψ t ∧ φ t) → a_psi t = a_phi t)
+-- (rec-path ψ φ a b e) demands that
+-- e is the proof that a = b (intensionally) for ψ ∧ φ
+#define rec-path uses (extext)
+  ( a-in-ψ : (t : ψ) → A t)
+  ( a-in-φ : (t : φ) → A t)
+  ( e : (t : I | ψ t ∧ φ t) → a-in-ψ t = a-in-φ t)
   : ( t : I | ψ t ∨ φ t) → A t
   := \ t → recOR(
         ψ t ↦
           transport
           ( ( s : I | ψ s ∧ φ s) → A s)
           ( \ ra → (s : ψ) → A s [ ψ s ∧ φ s ↦ ra s ])
-          ( restrict_psi a_psi)
-          ( restrict_phi a_phi)
-          ( restricts-path a_psi a_phi e)
-          ( ext-of-restrict_psi a_psi)
+          ( restrict-psi a-in-ψ)
+          ( restrict-phi a-in-φ)
+          ( restricts-path a-in-ψ a-in-φ e)
+          ( ext-of-restrict-psi a-in-ψ)
           ( t)
       , φ t ↦
-          ext-of-restrict_phi a_phi t
+          ext-of-restrict-phi a-in-φ t
       )
 
 #end construction-of-recId
@@ -1936,7 +1942,7 @@ Finally, we bring everything together into `recId`:
 
 ### Gluing extension types
 
-An application of of `recId` is gluing together extension types, whenever we can
+An application of of `rec-path` is gluing together extension types, whenever we can
 show that they are equal on the intersection of shapes.
 
 The latter can be easily shown when the intersection maps to a set:
@@ -1944,20 +1950,20 @@ The latter can be easily shown when the intersection maps to a set:
 ```rzk
 -- If two extension types are equal along two subshapes,
 -- then they are also equal along their union.
-#define id-along-border uses (extext)
+#define id-along-set-border uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( φ : I → TOPE)
   ( A : (t : I | ψ t ∨ φ t) → U)
   ( a b : (t : I | ψ t ∨ φ t) → A t)
-  ( e_psi : (t : ψ) → a t = b t)
-  ( e_phi : (t : φ) → a t = b t)
+  ( e-in-ψ : (t : ψ) → a t = b t)
+  ( e-in-φ : (t : φ) → a t = b t)
   ( border-is-a-set : (t : I | ψ t ∧ φ t) → is-set (A t))
   : ( t : I | ψ t ∨ φ t) → a t = b t
   :=
-  recId I ψ φ
+  rec-path I ψ φ
   ( \ t → a t = b t)
-  ( e_psi)
-  ( e_phi)
-  ( \ t → border-is-a-set t (a t) (b t) (e_psi t) (e_phi t))
+  ( e-in-ψ)
+  ( e-in-φ)
+  ( \ t → border-is-a-set t (a t) (b t) (e-in-ψ t) (e-in-φ t))
 ```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1824,3 +1824,140 @@ equivalent to extending the fiber.
       ( equiv-based-paths-family (A t) (B t) (τ t)))
     ( \ t → (a t , refl)))
 ```
+
+## Tope disjuction elimination along identity paths
+
+\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a*\phi)\) (written
+`recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a*\psi\) and
+\(a*\phi\) are \_definitionally equal* on \(\psi \land \phi\). Sometimes this is
+too strong since many terms are not _definitionally_ equal, but only equal up to
+a path. Luckily, assuming relative function extensionality, we can define a
+weaker version of \(rec*{\lor}\) (`recOR`), which we call `recId`, that can work
+in presence of a witness of type \(\prod*{t : I \mid \psi \land \phi} a*\psi =
+a*\phi\).
+
+### Construction of `recId`
+
+The idea is straightforward. We ask for a proof that `a = b` for all points in
+`ψ ∧ φ`. Then, by relative function extensionality (`relfunext2`), we can show
+that restrictions of `a` and `b` to `ψ ∧ φ` are equal. If we reformulate `a` as
+extension of its restriction, then we can `transport` such reformulation along
+the path connecting two restrictions and apply `recOR`.
+
+First, we define how to restrict an extension type to a subshape:
+
+```rzk
+#section construction-of-recId
+
+#variable I : CUBE
+#variables ψ φ : I → TOPE
+#variable A : (t : I | ψ t ∨ φ t) → U
+
+-- Restrict extension type to a subshape.
+#define restrict_phi
+  ( a : (t : φ) → A t)
+  : ( t : I | ψ t ∧ φ t) → A t
+  := \ t → a t
+
+-- Restrict extension type to a subshape.
+#define restrict_psi
+  ( a : (t : ψ) → A t)
+  : ( t : I | ψ t ∧ φ t) → A t
+  := \ t → a t
+```
+
+Then, how to reformulate an `a` (or `b`) as an extension of its restriction:
+
+```rzk
+-- Reformulate extension type as an extension of a restriction.
+#define ext-of-restrict_psi
+  ( a : (t : ψ) → A t)
+  : ( t : ψ)
+  → A t [ ψ t ∧ φ t ↦ restrict_psi a t ]
+  := a  -- type is coerced automatically here
+
+-- Reformulate extension type as an extension of a restriction.
+#define ext-of-restrict_phi
+  ( a : (t : φ) → A t)
+  : ( t : φ)
+  → A t [ ψ t ∧ φ t ↦ restrict_phi a t ]
+  := a  -- type is coerced automatically here
+```
+
+Now, assuming relative function extensionality, we construct a path between
+restrictions:
+
+```rzk
+-- Transform extension of an identity into an identity of restrictions.
+#define restricts-path
+  ( a_psi : (t : ψ) → A t)
+  ( a_phi : (t : φ) → A t)
+  : ( e : (t : I | ψ t ∧ φ t) → a_psi t = a_phi t)
+  → restrict_psi a_psi = restrict_phi a_phi
+  :=
+  first
+  ( second
+    ( extext I
+      ( \ t → ψ t ∧ φ t)
+      ( \ t → BOT)
+      ( \ t → A t)
+      ( \ t → recBOT)
+      ( \ t → a_psi t)
+      ( \ t → a_phi t)))
+```
+
+Finally, we bring everything together into `recId`:
+
+```rzk
+-- A weaker version of recOR, demanding only a path between a and b:
+-- recOR(ψ, φ, a, b) demands that for ψ ∧ φ we have a == b (definitionally)
+-- (recId ψ φ a b e) demands that e is the proof that a = b (intensionally) for ψ ∧ φ
+#define recId uses (extext) -- we declare that recId is using extext on purpose
+  ( a_psi : (t : ψ) → A t)
+  ( a_phi : (t : φ) → A t)
+  ( e : (t : I | ψ t ∧ φ t) → a_psi t = a_phi t)
+  : ( t : I | ψ t ∨ φ t) → A t
+  := \ t → recOR(
+        ψ t ↦
+          transport
+          ( ( s : I | ψ s ∧ φ s) → A s)
+          ( \ ra → (s : ψ) → A s [ ψ s ∧ φ s ↦ ra s ])
+          ( restrict_psi a_psi)
+          ( restrict_phi a_phi)
+          ( restricts-path a_psi a_phi e)
+          ( ext-of-restrict_psi a_psi)
+          ( t)
+      , φ t ↦
+          ext-of-restrict_phi a_phi t
+      )
+
+#end construction-of-recId
+```
+
+### Gluing extension types
+
+An application of of `recId` is gluing together extension types, whenever we can
+show that they are equal on the intersection of shapes.
+
+The latter can be easily shown when the intersection maps to a set:
+
+```rzk
+-- If two extension types are equal along two subshapes,
+-- then they are also equal along their union.
+#define id-along-border uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( φ : I → TOPE)
+  ( A : (t : I | ψ t ∨ φ t) → U)
+  ( a b : (t : I | ψ t ∨ φ t) → A t)
+  ( e_psi : (t : ψ) → a t = b t)
+  ( e_phi : (t : φ) → a t = b t)
+  ( border-is-a-set : (t : I | ψ t ∧ φ t) → is-set (A t))
+  : ( t : I | ψ t ∨ φ t) → a t = b t
+  :=
+  recId I ψ φ
+  ( \ t → a t = b t)
+  ( e_psi)
+  ( e_phi)
+  ( \ t → border-is-a-set t (a t) (b t) (e_psi t) (e_phi t))
+```

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1825,18 +1825,18 @@ equivalent to extending the fiber.
     ( \ t → (a t , refl)))
 ```
 
-## Tope disjuction elimination along identity paths
+## Tope disjunction elimination along identity paths
 
 \(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a_\phi)\) (written
 `recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a_\psi\) and
-\(a_\phi\) are \_definitionally equal* on \(\psi \land \phi\). Sometimes this is
+\(a_\phi\) are _definitionally_ equal on \(\psi \land \phi\). Sometimes this is
 too strong since many terms are not _definitionally_ equal, but only equal up to
 a path. Luckily, assuming relative function extensionality, we can define a
-weaker version of \(rec_{\lor}\) (`recOR`), which we call `recId`, that can work
+weaker version of \(rec_{\lor}\) (`recOR`), which we call `rec-path`, that can work
 in presence of a witness of type \(\prod_{t : I \mid \psi \land \phi} a_\psi =
 a_\phi\).
 
-### Construction of `recId`
+### Construction of `rec-path`
 
 The idea is straightforward. We ask for a proof that `a = b` for all points in
 `ψ ∧ φ`. Then, by relative function extensionality (`relfunext2`), we can show
@@ -1847,21 +1847,19 @@ the path connecting two restrictions and apply `recOR`.
 First, we define how to restrict an extension type to a subshape:
 
 ```rzk
-#section construction-of-recId
+#section construction-of-rec-path
 
 #variable I : CUBE
 #variables ψ φ : I → TOPE
 #variable A : (t : I | ψ t ∨ φ t) → U
 
 -- Restrict extension type to a subshape.
--- TODO: should be a local-only definition (use let-binding when it exists)
 #define restrict-phi
   ( a : (t : φ) → A t)
   : ( t : I | ψ t ∧ φ t) → A t
   := \ t → a t
 
 -- Restrict extension type to a subshape.
--- TODO: should be a local-only definition (use let-binding when it exists)
 #define restrict-psi
   ( a : (t : ψ) → A t)
   : ( t : I | ψ t ∧ φ t) → A t
@@ -1872,7 +1870,6 @@ Then, how to reformulate an `a` (or `b`) as an extension of its restriction:
 
 ```rzk
 -- Reformulate extension type as an extension of a restriction.
--- TODO: should be a local-only definition (use let-binding when it exists)
 #define ext-of-restrict-psi
   ( a : (t : ψ) → A t)
   : ( t : ψ)
@@ -1880,7 +1877,6 @@ Then, how to reformulate an `a` (or `b`) as an extension of its restriction:
   := a  -- type is coerced automatically here
 
 -- Reformulate extension type as an extension of a restriction.
--- TODO: should be a local-only definition (use let-binding when it exists)
 #define ext-of-restrict-phi
   ( a : (t : φ) → A t)
   : ( t : φ)
@@ -1893,7 +1889,6 @@ restrictions:
 
 ```rzk
 -- Transform extension of an identity into an identity of restrictions.
--- TODO: should be a local-only definition (use let-binding when it exists)
 #define restricts-path
   ( a-in-ψ : (t : ψ) → A t)
   ( a-in-φ : (t : φ) → A t)
@@ -1937,13 +1932,13 @@ Finally, we bring everything together into `rec-path`:
           ext-of-restrict-phi a-in-φ t
       )
 
-#end construction-of-recId
+#end construction-of-rec-path
 ```
 
 ### Gluing extension types
 
-An application of of `rec-path` is gluing together extension types, whenever we can
-show that they are equal on the intersection of shapes.
+An application of `rec-path` is gluing together extension types, whenever
+we can show that they are equal on the intersection of shapes.
 
 The latter can be easily shown when the intersection maps to a set:
 

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1836,20 +1836,20 @@ The idea is straightforward. We ask for a proof that `a = b` for all points in \
 First, we define how to restrict an extension type to a subshape:
 
 ```rzk
-#section construction-of-rec-path
+#section rec-path-construction
 
 #variable I : CUBE
 #variables ψ φ : I → TOPE
 #variable A : (t : I | ψ t ∨ φ t) → U
 
 -- Restrict extension type to a subshape.
-#define restrict-phi
+#define rec-path-restrict-phi
   ( a : (t : φ) → A t)
   : ( t : I | ψ t ∧ φ t) → A t
   := \ t → a t
 
 -- Restrict extension type to a subshape.
-#define restrict-psi
+#define rec-path-restrict-psi
   ( a : (t : ψ) → A t)
   : ( t : I | ψ t ∧ φ t) → A t
   := \ t → a t
@@ -1859,17 +1859,17 @@ Then, how to reformulate an `a` (or `b`) as an extension of its restriction:
 
 ```rzk
 -- Reformulate extension type as an extension of a restriction.
-#define ext-of-restrict-psi
+#define rec-path-ext-of-restrict-psi
   ( a : (t : ψ) → A t)
   : ( t : ψ)
-  → A t [ ψ t ∧ φ t ↦ restrict-psi a t ]
+  → A t [ ψ t ∧ φ t ↦ rec-path-restrict-psi a t ]
   := a  -- type is coerced automatically here
 
 -- Reformulate extension type as an extension of a restriction.
-#define ext-of-restrict-phi
+#define rec-path-ext-of-restrict-phi
   ( a : (t : φ) → A t)
   : ( t : φ)
-  → A t [ ψ t ∧ φ t ↦ restrict-phi a t ]
+  → A t [ ψ t ∧ φ t ↦ rec-path-restrict-phi a t ]
   := a  -- type is coerced automatically here
 ```
 
@@ -1878,11 +1878,11 @@ restrictions:
 
 ```rzk
 -- Transform extension of an identity into an identity of restrictions.
-#define restricts-path
+#define rec-path-restrict-eq
   ( a-in-ψ : (t : ψ) → A t)
   ( a-in-φ : (t : φ) → A t)
   : ( e : (t : I | ψ t ∧ φ t) → a-in-ψ t = a-in-φ t)
-  → restrict-psi a-in-ψ = restrict-phi a-in-φ
+  → rec-path-restrict-psi a-in-ψ = rec-path-restrict-phi a-in-φ
   :=
   first
   ( second
@@ -1912,16 +1912,16 @@ Finally, we bring everything together into `rec-path`:
           transport
           ( ( s : I | ψ s ∧ φ s) → A s)
           ( \ ra → (s : ψ) → A s [ ψ s ∧ φ s ↦ ra s ])
-          ( restrict-psi a-in-ψ)
-          ( restrict-phi a-in-φ)
-          ( restricts-path a-in-ψ a-in-φ e)
-          ( ext-of-restrict-psi a-in-ψ)
+          ( rec-path-restrict-psi a-in-ψ)
+          ( rec-path-restrict-phi a-in-φ)
+          ( rec-path-restrict-eq a-in-ψ a-in-φ e)
+          ( rec-path-ext-of-restrict-psi a-in-ψ)
           ( t)
       , φ t ↦
-          ext-of-restrict-phi a-in-φ t
+          rec-path-ext-of-restrict-phi a-in-φ t
       )
 
-#end construction-of-rec-path
+#end rec-path-construction
 ```
 
 ### Gluing extension types
@@ -1929,12 +1929,13 @@ Finally, we bring everything together into `rec-path`:
 An application of `rec-path` is gluing together extension types, whenever we can
 show that they are equal on the intersection of shapes.
 
-The latter can be easily shown when the intersection maps to a set:
+The latter can be easily shown when the intersection maps to a set; we record
+the resulting homotopy as `htpy-eq-eq-is-set-on-conjunction` below.
 
 ```rzk
 -- If two extension types are equal along two subshapes,
 -- then they are also equal along their union.
-#define id-along-set-border uses (extext)
+#define htpy-eq-eq-is-set-on-conjunction uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( φ : I → TOPE)

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1827,22 +1827,11 @@ equivalent to extending the fiber.
 
 ## Tope disjunction elimination along identity paths
 
-\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a*\phi)\) (written
-`recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a*\psi\) and
-\(a*\phi\) are \_definitionally* equal on \(\psi \land \phi\). Sometimes this is
-too strong since many terms are not _definitionally_ equal, but only equal up to
-a path. Luckily, assuming relative function extensionality, we can define a
-weaker version of \(rec*{\lor}\) (`recOR`), which we call `rec-path`, that can
-work in presence of a witness of type \(\prod*{t : I \mid \psi \land \phi}
-a*\psi = a*\phi\).
+\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a_\phi)\) (written `recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a_\psi\) and \(a_\phi\) are _definitionally_ equal on \(\psi \land \phi\). Sometimes this is too strong since many terms are not _definitionally_ equal, but only equal up to a path. Luckily, assuming relative function extensionality, we can define a weaker version of \(\mathsf{rec}_{\lor}\) (`recOR`), which we call `rec-path`, that can work in presence of a witness of type \(\prod_{t : I \mid \psi \land \phi} a_\psi(t) = a_\phi(t)\).
 
 ### Construction of `rec-path`
 
-The idea is straightforward. We ask for a proof that `a = b` for all points in
-`ψ ∧ φ`. Then, by relative function extensionality (`relfunext2`), we can show
-that restrictions of `a` and `b` to `ψ ∧ φ` are equal. If we reformulate `a` as
-extension of its restriction, then we can `transport` such reformulation along
-the path connecting two restrictions and apply `recOR`.
+The idea is straightforward. We ask for a proof that `a = b` for all points in \(\psi \land \phi\). Then, by relative function extensionality (`relfunext2`), we can show that restrictions of `a` and `b` to \(\psi \land \phi\) are equal. If we reformulate `a` as extension of its restriction, then we can `transport` this reformulation along the path connecting two restrictions and apply `recOR`.
 
 First, we define how to restrict an extension type to a subshape:
 

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -1827,11 +1827,22 @@ equivalent to extending the fiber.
 
 ## Tope disjunction elimination along identity paths
 
-\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a_\phi)\) (written `recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a_\psi\) and \(a_\phi\) are _definitionally_ equal on \(\psi \land \phi\). Sometimes this is too strong since many terms are not _definitionally_ equal, but only equal up to a path. Luckily, assuming relative function extensionality, we can define a weaker version of \(\mathsf{rec}_{\lor}\) (`recOR`), which we call `rec-path`, that can work in presence of a witness of type \(\prod_{t : I \mid \psi \land \phi} a_\psi(t) = a_\phi(t)\).
+\(\mathsf{rec}_{\lor}^{\psi,\phi}(a_\psi, a*\phi)\) (written
+`recOR(psi, phi, a_psi, a_phi)` in the code) is well-typed when \(a*\psi\) and
+\(a*\phi\) are \_definitionally* equal on \(\psi \land \phi\). Sometimes this is
+too strong since many terms are not _definitionally_ equal, but only equal up to
+a path. Luckily, assuming relative function extensionality, we can define a
+weaker version of \(\mathsf{rec}_{\lor}\) (`recOR`), which we call `rec-path`,
+that can work in presence of a witness of type \(\prod_{t : I \mid \psi \land
+\phi} a*\psi(t) = a*\phi(t)\).
 
 ### Construction of `rec-path`
 
-The idea is straightforward. We ask for a proof that `a = b` for all points in \(\psi \land \phi\). Then, by relative function extensionality (`relfunext2`), we can show that restrictions of `a` and `b` to \(\psi \land \phi\) are equal. If we reformulate `a` as extension of its restriction, then we can `transport` this reformulation along the path connecting two restrictions and apply `recOR`.
+The idea is straightforward. We ask for a proof that `a = b` for all points in
+\(\psi \land \phi\). Then, by relative function extensionality (`relfunext2`),
+we can show that restrictions of `a` and `b` to \(\psi \land \phi\) are equal.
+If we reformulate `a` as extension of its restriction, then we can `transport`
+this reformulation along the path connecting two restrictions and apply `recOR`.
 
 First, we define how to restrict an extension type to a subshape:
 


### PR DESCRIPTION
The proof of Proposition 8.21 (part about retraction) relies on a construction where two diagrams are glued using `recOR`, but additionally using transport, since the terms involved are not definitionally equal on the intersection of shapes. I've had a general definition for such gluing in Rzk repository for a long time as a demo, so I'm adding it here now, so that I can later use it to complete #163.

So, specifically, this PR introduces

- `rec-path` — a version of (binary) `recOR` that can be provided a propositional equality for the terms on the intersection of shapes.
- `htpy-eq-eq-is-set-on-conjunction` — a helper that allows to easily show the required equality when the types along the intersection of shapes are sets.

