### PR TITLE
Add isomorphism extensionality for shapes (Corollary 10.4b)

### DIFF
--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -202,6 +202,18 @@ transformation** from `#!rzk f` to `#!rzk g` is an arrow
   := hom ((x : A) → (B x)) f g
 ```
 
+The same definition applies to extension types.
+
+```rzk title="RS17, Definition 6.2, for extension types"
+#def nat-trans-extension-type
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( f g : (s : ψ) → A s)
+  : U
+  := hom ((s : ψ) → A s) f g
+```
+
 Equivalently , natural transformations can be determined by their **components**
 , i.e. as a family of arrows `#!rzk (x : A) → hom (B x) (f x) (g x)`.
 
@@ -232,15 +244,35 @@ Equivalently , natural transformations can be determined by their **components**
   := \ t x → η x t
 ```
 
-```rzk title="A version of ev-components-nat-trans for extension types"
+In the same way, natural transformations of extension types can be defined via
+their components.
+
+```rzk
+#def nat-trans-components-extension-type
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( f g : (s : ψ) → A s)
+  : U
+  := (s : ψ) → hom (A s) (f s) (g s)
+
 #def ev-components-nat-trans-extension-type
   ( I : CUBE)
   ( ψ : I → TOPE)
   ( A : ψ → U)
   ( f g : (s : ψ) → A s)
-  ( α : hom ((s : ψ) → A s) f g)
-  : ( s : ψ) → hom (A s) (f s) (g s)
-  := \ s t → α t s
+  ( η : nat-trans-extension-type I ψ A f g)
+  : nat-trans-components-extension-type I ψ A f g
+  := \ s t → η t s
+
+#def nat-trans-nat-trans-components-extension-type
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( f g : (s : ψ) → A s)
+  ( η : nat-trans-components-extension-type I ψ A f g)
+  : nat-trans-extension-type I ψ A f g
+  := \ t x → η x t
 ```
 
 ### Natural transformation extensionality
@@ -266,6 +298,33 @@ Equivalently , natural transformations can be determined by their **components**
   :=
     ( ev-components-nat-trans A B f g
     , is-equiv-ev-components-nat-trans A B f g)
+```
+
+```rzk title="RS17, Proposition 6.3, for extension types"
+#def is-equiv-ev-components-nat-trans-extension-type
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( f g : (s : ψ) → A s)
+  : is-equiv
+      ( nat-trans-extension-type I ψ A f g)
+      ( nat-trans-components-extension-type I ψ A f g)
+      ( ev-components-nat-trans-extension-type I ψ A f g)
+  :=
+    ( ( \ η t s → η s t , \ _ → refl)
+    , ( \ η t s → η s t , \ _ → refl))
+
+#def equiv-components-nat-trans-extension-type
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( f g : (s : ψ) → A s)
+  : Equiv
+      ( nat-trans-extension-type I ψ A f g)
+      ( nat-trans-components-extension-type I ψ A f g)
+  :=
+    ( ev-components-nat-trans-extension-type I ψ A f g
+    , is-equiv-ev-components-nat-trans-extension-type I ψ A f g)
 ```
 
 ### Naturality square
@@ -455,8 +514,8 @@ The same statements hold for extension types.
   ( A : ψ → U)
   ( is-segal-A : (s : ψ) → is-segal (A s))
   ( f g h : (s : ψ) → A s)
-  ( α : hom ((s : ψ) → A s) f g)
-  ( β : hom ((s : ψ) → A s) g h)
+  ( α : nat-trans-extension-type I ψ A f g)
+  ( β : nat-trans-extension-type I ψ A g h)
   ( s : ψ)
   : ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (h s)
       ( ev-components-nat-trans-extension-type I ψ A f g α s)

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -704,7 +704,7 @@ equal.
   ( A : ψ → U)
   ( is-segal-A : (s : ψ) → is-segal (A s))
   ( f g : (s : ψ) → A s)
-  ( α : hom ((s : ψ) → A s) f g)
+  ( α : nat-trans-extension-type I ψ A f g)
   : ( is-iso-arrow
       ( ( s : ψ) → A s)
       ( is-segal-extension-type extext I ψ A is-segal-A) f g α)
@@ -776,8 +776,8 @@ equal.
   ( A : ψ → U)
   ( is-segal-A : (s : ψ) → is-segal (A s))
   ( f g : (s : ψ) → A s)
-  ( α : hom ((s : ψ) → A s) f g)
-  ( β : hom ((s : ψ) → A s) g f)
+  ( α : nat-trans-extension-type I ψ A f g)
+  ( β : nat-trans-extension-type I ψ A g f)
   : ( ( s : ψ)
     → ( comp-is-segal (A s) (is-segal-A s) (f s) (g s) (f s)
         ( ev-components-nat-trans-extension-type I ψ A f g α s)
@@ -841,7 +841,7 @@ equal.
   ( A : ψ → U)
   ( is-segal-A : (s : ψ) → is-segal (A s))
   ( f g : (s : ψ) → A s)
-  ( α : hom ((s : ψ) → A s) f g)
+  ( α : nat-trans-extension-type I ψ A f g)
   : ( ( s : ψ)
     → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
         ( ev-components-nat-trans-extension-type I ψ A f g α s)))
@@ -868,7 +868,7 @@ equal.
   ( A : ψ → U)
   ( is-segal-A : (s : ψ) → is-segal (A s))
   ( f g : (s : ψ) → A s)
-  ( α : hom ((s : ψ) → A s) f g)
+  ( α : nat-trans-extension-type I ψ A f g)
   : iff
     ( is-iso-arrow
       ( ( s : ψ) → A s)
@@ -888,7 +888,7 @@ equal.
   ( A : ψ → U)
   ( is-segal-A : (s : ψ) → is-segal (A s))
   ( f g : (s : ψ) → A s)
-  ( α : hom ((s : ψ) → A s) f g)
+  ( α : nat-trans-extension-type I ψ A f g)
   : Equiv
     ( is-iso-arrow
       ( ( s : ψ) → A s)

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -969,6 +969,58 @@ equal.
           ( \ x αₓ → is-iso-arrow (A x) (is-segal-A x) (f x) (g x) αₓ)))
 ```
 
+```rzk title="RS17, Corollary 10.4b (isomorphism extensionality for shapes)"
+#def iso-extensionality-extension-type uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-segal-A : (s : ψ) → is-segal (A s))
+  ( f g : (s : ψ) → A s)
+  : Equiv
+      ( Iso
+          ( ( s : ψ) → A s)
+          ( is-segal-extension-type extext I ψ A is-segal-A)
+          f g)
+      ( ( s : ψ) → Iso (A s) (is-segal-A s) (f s) (g s))
+  :=
+    equiv-triple-comp
+      ( Iso
+          ( ( s : ψ) → A s)
+          ( is-segal-extension-type extext I ψ A is-segal-A)
+          f g)
+      ( Σ ( α : nat-trans-extension-type I ψ A f g)
+      , ( s : ψ)
+      → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+          ( ev-components-nat-trans-extension-type I ψ A f g α s)))
+      ( Σ ( α' : nat-trans-components-extension-type I ψ A f g)
+      , ( s : ψ) → is-iso-arrow (A s) (is-segal-A s) (f s) (g s) (α' s))
+      ( ( s : ψ) → Iso (A s) (is-segal-A s) (f s) (g s))
+      ( total-equiv-family-of-equiv
+        ( nat-trans-extension-type I ψ A f g)
+        ( \ α →
+          ( is-iso-arrow
+            ( ( s : ψ) → A s)
+            ( is-segal-extension-type extext I ψ A is-segal-A)
+            f g α))
+        ( \ α →
+          ( s : ψ)
+        → ( is-iso-arrow (A s) (is-segal-A s) (f s) (g s)
+            ( ev-components-nat-trans-extension-type I ψ A f g α s)))
+        ( equiv-is-iso-pointwise-is-iso-extension-type I ψ A is-segal-A f g))
+      ( equiv-total-pullback-is-equiv
+        ( nat-trans-extension-type I ψ A f g)
+        ( nat-trans-components-extension-type I ψ A f g)
+        ( ev-components-nat-trans-extension-type I ψ A f g)
+        ( is-equiv-ev-components-nat-trans-extension-type I ψ A f g)
+        ( \ α' →
+          ( s : ψ) → is-iso-arrow (A s) (is-segal-A s) (f s) (g s) (α' s)))
+      ( inv-equiv-axiom-choice I ψ (\ _ → ⊥)
+        ( \ s → hom (A s) (f s) (g s))
+        ( \ s αₛ → is-iso-arrow (A s) (is-segal-A s) (f s) (g s) αₛ)
+        ( \ _ → recBOT)
+        ( \ _ → recBOT))
+```
+
 ## Rezk types
 
 For every `x : A`, the identity arrow `id-hom A x : hom A x x` is an


### PR DESCRIPTION
This PR adds isomorphism extensionality for shapes (RS17, Corollary 10.4), similarly to the existing result for types. It also adds analogues of `nat-trans` definitions for the extension types.