### PR TITLE
Declare uses for assumptions hidden by current rzk

### DIFF
--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -151,7 +151,7 @@ We start over from a stronger hypothesis of a half adjoint equivalence.
   : ( projection-hae-inverse (first w)) = w
   := (first (second (first proj-B-to-A-is-half-adjoint-equivalence))) w
 
-#def projection-hae-fibered-htpy
+#def projection-hae-fibered-htpy uses (proj-B-to-A-is-half-adjoint-equivalence)
   : ( transport A B (first ((projection-hae-inverse (first w)))) (first w)
     ( first-path-Σ A B
       ( projection-hae-inverse (first w)) w
@@ -168,7 +168,7 @@ We start over from a stronger hypothesis of a half adjoint equivalence.
       ( projection-hae-total-htpy))
   := (second proj-B-to-A-is-half-adjoint-equivalence) w
 
-#def projection-hae-transport-coherence
+#def projection-hae-transport-coherence uses (proj-B-to-A-is-half-adjoint-equivalence)
   : ( projection-hae-section (first w))
   = ( transport A B (first ((projection-hae-inverse (first w)))) (first w)
       ( first-path-Σ A B
@@ -183,7 +183,7 @@ We start over from a stronger hypothesis of a half adjoint equivalence.
     ( projection-hae-base-coherence)
     ( second (projection-hae-inverse (first w)))
 
-#def projection-hae-fibered-homotopy-contraction
+#def projection-hae-fibered-homotopy-contraction uses (proj-B-to-A-is-half-adjoint-equivalence)
   : ( projection-hae-section (first w)) =_{B (first w)} (second w)
   :=
     concat (B (first w))

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -1480,11 +1480,11 @@ equivalence with no extra data, and then define some helpers.
   : ( x : A) → (hom A a' x) → (hom A a x)
   := \ x → first (inverse-representable-equiv x)
 
-#def arr-map-representable-equiv
+#def arr-map-representable-equiv uses (ψ)
   : hom A a' a
   := evid A a (hom A a') (map-representable-equiv)
 
-#def arr-inv-map-representable-equiv
+#def arr-inv-map-representable-equiv uses (ψ)
   : hom A a a'
   := evid A a' (hom A a) (inv-map-representable-equiv)
 ```
@@ -1610,7 +1610,7 @@ We compute the required paths for the section of
         ( a)
         ( id-hom A a)))
 
-#def compute-htpy-inv-map-fib-equiv-map-fib-equiv-id
+#def compute-htpy-inv-map-fib-equiv-map-fib-equiv-id uses (ψ a')
   : inv-map-representable-equiv a (map-representable-equiv a (id-hom A a))
   =_{ hom A a a}
     id-hom A a

--- a/src/simplicial-hott/11-adjunctions.rzk.md
+++ b/src/simplicial-hott/11-adjunctions.rzk.md
@@ -1446,7 +1446,7 @@ of `#!rzk is-transposing-right-adj A B u`
     ( ηa))
   ( triangle-to-left-adjoint-components-is-rezk-is-segal)
 
-#def all-unit-components-equal-is-rezk-is-segal uses (extext A is-segal-A u a ω ω')
+#def all-unit-components-equal-is-rezk-is-segal uses (extext A is-segal-A u a ω ω' is-rezk-B)
   : ( fa , ηa) =_{Σ (b : B) , hom A a (u b)} (fa' , ηa')
   :=
   path-of-pairs-pair-of-paths B (\ b → hom A a (u b)) (fa) (fa')


### PR DESCRIPTION
Current Rzk (rzk-0.8) decides which assumptions a definition uses from the term as written rather than from its weak head normal form (rzk-lang/rzk#255). This surfaces a few genuine dependencies that reduction had masked. For example, `projection-hae-fibered-htpy` builds its value from `projection-hae-total-htpy`, whose own value applies the section assumption `proj-B-to-A-is-half-adjoint-equivalence`:

```rzk
#def projection-hae-total-htpy uses (proj-B-to-A-is-half-adjoint-equivalence)
  : (projection-hae-inverse (first w)) = w
  := (first (second (first proj-B-to-A-is-half-adjoint-equivalence))) w

#def projection-hae-fibered-htpy uses (proj-B-to-A-is-half-adjoint-equivalence)  -- now required
  : ...
  := second-path-Σ A B (projection-hae-inverse (first w)) w projection-hae-total-htpy
```

Seven definitions across `10-trivial-fibrations`, `10-rezk-types` and `11-adjunctions` are in this position; each now declares the assumption it relies on. This is the companion to rzk-lang/rzk#255, and is needed for the corpus to keep checking when it is released.