### PR TITLE
Annotate identity types at their intended underlying types

### DIFF
--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -112,7 +112,7 @@ A path in a fiber defines a path in the total space.
   ( u v : B x)
   ( p : u = v)
   : ( x , u) =_{Σ (a : A) , B a} (x , v)
-  := ind-path (B x) (u) (\ v' p' → (x , u) = (x , v')) (refl) (v) (p)
+  := ind-path (B x) (u) (\ v' p' → (x , u) =_{Σ (a : A) , B a} (x , v')) (refl) (v) (p)
 ```
 
 The following is essentially `#!rzk eq-pair` but with explicit arguments.

--- a/src/simplicial-hott/02-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/02-simplicial-type-theory.rzk.md
@@ -787,7 +787,7 @@ We observe that we must have `ζ = χ ∧ ϕ`. Thus we have the following settin
       → ( α : A' → A)
       → ( σ' : (t : I | χ t ∧ ϕ t) → A')
       → ( ( \ (t : I | ϕ t) → α (s A' σ' t))
-        =_{ ϕ → A}
+        =_{ (t : ϕ) → A [χ t ∧ ϕ t ↦ α (σ' t)]}
           ( s A (\ t → α (σ' t)))))
     , ( ( A' : U)
       → ( A : U)
@@ -801,7 +801,7 @@ We observe that we must have `ζ = χ ∧ ϕ`. Thus we have the following settin
             ( \ t → s A (\ t' → α (σ' t')) t)
             ( h A' A α σ')
             ( \ t → α (S A' σ' τ' t)))
-        =_{ (t : ψ) → A [ϕ t ↦ s A (\ t' → α (τ' t')) t]}
+        =_{ (t : ψ) → A [χ t ↦ α (τ' t) , ϕ t ↦ s A (\ t' → α (σ' t')) t]}
           ( S A (\ t → α (σ' t)) (\ t → α (τ' t)))))
 
 #end retracts-shape-inclusions

--- a/src/simplicial-hott/03-extension-types.rzk.md
+++ b/src/simplicial-hott/03-extension-types.rzk.md
@@ -648,12 +648,12 @@ We refer to another form as an "extension extensionality" axiom.
   ( a : (t : ϕ) → A t)
   ( f g : (t : ψ) → A t [ϕ t ↦ a t])
   ( p : f = g)
-  : ( t : ψ) → (f t = g t) [ϕ t ↦ refl]
+  : ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl]
   :=
     ind-path
       ( ( t : ψ) → A t [ϕ t ↦ a t])
       ( f)
-      ( \ g' p' → (t : ψ) → (f t = g' t) [ϕ t ↦ refl])
+      ( \ g' p' → (t : ψ) → (f t =_{A t} g' t) [ϕ t ↦ refl])
       ( \ _ → refl)
       ( g)
       ( p)
@@ -672,7 +672,7 @@ We refer to another form as an "extension extensionality" axiom.
     → ( g : (t : ψ) → A t [ϕ t ↦ a t])
     → is-equiv
       ( f = g)
-      ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
+      ( ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])
       ( ext-htpy-eq I ψ ϕ A a f g))
 ```
 
@@ -685,7 +685,7 @@ We refer to another form as an "extension extensionality" axiom.
   ( A : ψ → U)
   ( a : (t : ϕ) → A t)
   ( f g : (t : ψ) → A t [ϕ t ↦ a t])
-  : Equiv (f = g) ((t : ψ) → (f t = g t) [ϕ t ↦ refl])
+  : Equiv (f = g) ((t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])
   := (ext-htpy-eq I ψ ϕ A a f g , extext I ψ ϕ A a f g)
 ```
 
@@ -706,7 +706,7 @@ fact, sometimes only this weaker form of the axiom is needed.
   → ( a : (t : ϕ) → A t)
   → ( f : (t : ψ) → A t [ϕ t ↦ a t])
   → ( g : (t : ψ) → A t [ϕ t ↦ a t])
-  → ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
+  → ( ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])
   → ( f = g))
 
 #def naiveextext-extext
@@ -833,37 +833,37 @@ cases an extension type to a function type.
 #define is-contr-ext-based-paths uses (weakextext f)
   : is-contr
     ( ( t : ψ)
-    → ( Σ ( y : A t) , ((ext-projection-temp) t = y))
+    → ( Σ ( y : A t) , ((ext-projection-temp) t =_{A t} y))
       [ ϕ t ↦ (a t , refl)])
   :=
     weakextext I ψ ϕ
-    ( \ t → (Σ (y : A t) , ((ext-projection-temp) t = y)))
+    ( \ t → (Σ (y : A t) , ((ext-projection-temp) t =_{A t} y)))
     ( \ t → is-contr-based-paths (A t) ((ext-projection-temp) t))
     ( \ t → (a t , refl))
 
 #define is-contr-ext-endpoint-based-paths uses (weakextext f)
   : is-contr
     ( ( t : ψ)
-    → ( Σ ( y : A t) , (y = ext-projection-temp t))
+    → ( Σ ( y : A t) , (y =_{A t} ext-projection-temp t))
       [ ϕ t ↦ (a t , refl)])
   :=
     weakextext I ψ ϕ
-    ( \ t → (Σ (y : A t) , y = ext-projection-temp t))
+    ( \ t → (Σ (y : A t) , y =_{A t} ext-projection-temp t))
     ( \ t → is-contr-endpoint-based-paths (A t) (ext-projection-temp t))
     ( \ t → (a t , refl))
 
 #define is-contr-based-paths-ext uses (weakextext)
   : is-contr
     ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
-      , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl]))
+      , ( ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl]))
   :=
     is-contr-equiv-is-contr
     ( ( t : ψ) → (Σ (y : A t)
-                   , ( ( ext-projection-temp) t = y)) [ϕ t ↦ (a t , refl)])
+                   , ( ( ext-projection-temp) t =_{A t} y)) [ϕ t ↦ (a t , refl)])
     ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
-              , ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
+              , ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])
     ( axiom-choice I ψ ϕ A
-      ( \ t y → (ext-projection-temp) t = y)
+      ( \ t y → (ext-projection-temp) t =_{A t} y)
       ( a)
       ( \ t → refl))
     ( is-contr-ext-based-paths)
@@ -883,12 +883,12 @@ The map that defines extension extensionality
   ( f : (t : ψ) → A t [ϕ t ↦ a t])
   : ( ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]) , (f = g))
     → ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
-      , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])))
+      , ( ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])))
   :=
     total-map
     ( ( t : ψ) → A t [ϕ t ↦ a t])
     ( \ g → (f = g))
-    ( \ g → (t : ψ) → (f t = g t) [ϕ t ↦ refl])
+    ( \ g → (t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])
     ( ext-htpy-eq I ψ ϕ A a f)
 ```
 
@@ -906,13 +906,13 @@ The total bundle version of extension extensionality
   : is-equiv
     ( ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]) , (f = g)))
     ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
-      , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl]))
+      , ( ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl]))
     ( extext-weakextext-map I ψ ϕ A a f)
   :=
     is-equiv-are-contr
     ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t]) , (f = g))
     ( Σ ( g : (t : ψ) → A t [ϕ t ↦ a t])
-    , ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl]))
+    , ( ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl]))
     ( is-contr-based-paths ((t : ψ) → A t [ϕ t ↦ a t]) (f))
     ( is-contr-based-paths-ext weakextext I ψ ϕ A a f)
     ( extext-weakextext-map I ψ ϕ A a f)
@@ -934,12 +934,12 @@ extensionality. The following is statement the as proved in RS17.
   : ( ( g : (t : ψ) → A t [ϕ t ↦ a t])
     → is-equiv
         ( f = g)
-        ( ( t : ψ) → (f t = g t) [ϕ t ↦ refl])
+        ( ( t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])
         ( ext-htpy-eq I ψ ϕ A a f g))
   := is-equiv-fiberwise-is-equiv-total
       ( ( t : ψ) → A t [ϕ t ↦ a t])
       ( \ g → (f = g))
-      ( \ g → (t : ψ) → (f t = g t) [ϕ t ↦ refl])
+      ( \ g → (t : ψ) → (f t =_{A t} g t) [ϕ t ↦ refl])
       ( ext-htpy-eq I ψ ϕ A a f)
       ( extext-weakextext-bundle-version weakextext I ψ ϕ A a f)
 ```
@@ -1120,7 +1120,8 @@ generality is needed.
   ( is-contr-fiberwise-A : (t : ψ) → is-contr (A t))
   : ( t : ψ)
   → ( f t
-    = first
+    =_{ A t}
+      first
       ( htpy-ext-prop-is-fiberwise-contr
         htpy-ext-prop
         I ψ ϕ A a
@@ -1153,8 +1154,8 @@ slightly more general statement.
   ( a : (t : ϕ) → A t)
   ( f : (t : ψ) → A t [ϕ t ↦ a t])
   ( a' : (t : ψ) → A t [ϕ t ↦ a t])
-  ( c : (t : ψ) → (f t = a' t))
-  : ( t : ϕ) → (refl =_{f t = a' t} c t)
+  ( c : (t : ψ) → (f t =_{A t} a' t))
+  : ( t : ϕ) → (refl =_{f t =_{A t} a' t} c t)
   := \ t →
     all-paths-equal-is-contr
     ( A t) (is-fiberwise-contr t)
@@ -1176,7 +1177,7 @@ f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
   ( a : (t : ϕ) → A t)
   ( f : (t : ψ) → A t [ϕ t ↦ a t])
   : ( t : ψ)
-    → ( f t = (first
+    → ( f t =_{A t} (first
               ( htpy-ext-prop-is-fiberwise-contr
                 htpy-ext-prop I ψ ϕ A a is-contr-fiberwise-A)) t)[ϕ t ↦ refl]
   :=
@@ -1184,7 +1185,8 @@ f(t) = a'(t) \biggr|^\phi_{\lambda t.refl} \right\rangle$
     htpy-ext-prop I ψ ϕ
     ( \ t →
       ( ( f t)
-      = first
+      =_{ A t}
+        first
         ( htpy-ext-prop-is-fiberwise-contr
           htpy-ext-prop
           I ψ ϕ A a


### PR DESCRIPTION
rzk is fixing a type checker bug (branch `fix-unify-id-type`): identity types over different types were equated whenever their endpoints unified, because the unifier never compared the underlying types (a `TODO` in `TypeCheck.hs`). The fixed checker rejects, for instance, a free homotopy (a path in `Δ¹ → A`) supplied where an endpoint-fixing one (a path in `hom A x y`) is expected.

The library relied on the missing comparison in benign instances, where an unannotated `x = y` picked up an accidental underlying type from inference. This PR states each affected identity type at the type intended, in 25 one-line annotations across three files:

- `hott/05-sigma`: `eq-eq-fiber-Σ` stated its motive's path over the non-dependent `Σ` synthesised for the pair `(x , u)`, rather than the dependent `Σ (a : A), B a` intended.
- `simplicial-hott/03-extension-types`: the pointwise paths of the extension extensionality development (`f t = g t`, `ext-projection-temp t = y`, and the `RS-4-11` cluster) picked up restricted types from applications of sections; they are intended pointwise in `A t`.
- `simplicial-hott/02-simplicial-type-theory`: the paths `h` and `H` of `functorial-retract-shape-inclusion` were stated over types weaker than the ones they are transported over in `04-right-orthogonal`; they are now stated at the precise types of their endpoints (for `H`, the two-branch type of the transport target).

No proof terms change. The library checks both with the current released rzk and with the fix.