### PR TITLE
Autoformat with Prettier in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,5 +62,8 @@
     "editor.detectIndentation": false,
     "editor.insertSpaces": true
   },
-  "rzk.format.enable": true
+  "rzk.format.enable": true,
+  "[literate rzk markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }


### PR DESCRIPTION
Enables autoformatting with prettier in the editor, so that VS Code users don't have to think about that. I thought I did this in a previous PR, but turns out I did the configuration wrong.

Posting this as it seemed @emilyriehl had some issues with this. It is true that you use VS Code, correct?