### PR TITLE
Initial and final objects are closed under isomorphism

### DIFF
--- a/src/CONTRIBUTORS.md
+++ b/src/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ Formalizations were contributed by the following people (listed alphabetically):
 - [Jonathan Campbell](https://github.com/jonalfcam),
 - [Robin Carlier](https://github.com/robin-carlier),
 - [Theofanis Chatzidiamantis-Christoforidis](https://github.com/thchatzidiamantis),
+- [Garrett Credi](https://github.com/ddxtanx),
 - [Aras Ergus](https://www.aergus.net/),
 - [Matthias Hutzler](https://github.com/MatthiasHu),
 - [Nikolai Kudasov](https://fizruk.github.io/),
@@ -16,6 +17,7 @@ Formalizations were contributed by the following people (listed alphabetically):
 - [Stiéphen Pradal](https://stiephenpradal.github.io/),
 - [Nima Rasekh](https://guests.mpim-bonn.mpg.de/rasekh/),
 - [Emily Riehl](https://emilyriehl.github.io/),
+- [Judah Towery](https://github.com/jjtowery),
 - [Florrie Verity](https://github.com/floverity),
 - [Tashi Walde](https://www.math.cit.tum.de/en/algebra/personen/walde/), and
 - [Jonathan Weinberger](https://sites.google.com/view/jonathanweinberger).

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -165,10 +165,10 @@ By `#!rzk funext`, these are equals as functions of `#!rzk f` pointwise in
   :=
     eq-htpy funext
       ( hom A a x)
-      ( \ f → C x)
-      ( \ f → ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x f)
-      ( \ f → (ϕ x f))
-      ( \ f → yon-evid-twice-pointwise ϕ x f)
+      ( \ _ → C x)
+      ( ( ( yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x)
+      ( ϕ x)
+      ( yon-evid-twice-pointwise ϕ x)
 ```
 
 By `#!rzk funext` again, these are equal as functions of `#!rzk x` and
@@ -182,9 +182,9 @@ By `#!rzk funext` again, these are equal as functions of `#!rzk x` and
     eq-htpy funext
       ( A)
       ( \ x → (hom A a x → C x))
-      ( \ x → ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ)) x)
-      ( \ x → (ϕ x))
-      ( \ x → yon-evid-once-pointwise ϕ x)
+      ( ( yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ))
+      ( ϕ)
+      ( yon-evid-once-pointwise ϕ)
 
 #end yon-evid
 ```
@@ -703,12 +703,11 @@ By `#!rzk funext`, these are equals as functions of `#!rzk f` pointwise in
   :=
     eq-htpy funext
       ( hom A x a)
-      ( \ f → C x)
-      ( \ f →
-        ( ( contra-yon A is-segal-A a C is-contravariant-C)
-          ( ( contra-evid A a C) ϕ)) x f)
-      ( \ f → (ϕ x f))
-      ( \ f → contra-yon-evid-twice-pointwise ϕ x f)
+      ( \ _ → C x)
+      ( ( ( contra-yon A is-segal-A a C is-contravariant-C)
+          ( ( contra-evid A a C) ϕ)) x)
+      ( ϕ x)
+      ( contra-yon-evid-twice-pointwise ϕ x)
 ```
 
 By `#!rzk funext` again, these are equal as functions of `#!rzk x` and

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -255,7 +255,7 @@ In a Segal type, final objects are isomorphic.
 In a Segal type, an object isomorphic to an initial object is also initial.
 
 ```rzk
-#def initial-iso uses (extext)
+#def is-initial-iso-is-initial uses (extext)
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a b : A)
@@ -279,7 +279,7 @@ In a Segal type, an object isomorphic to an initial object is also initial.
       ( x))
     ( is-initial-a x)
 
-#def final-iso uses (extext)
+#def is-final-iso-is-final uses (extext)
   ( A : U)
   ( is-segal-A : is-segal A)
   ( a b : A)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -264,20 +264,20 @@ In a Segal type, an object isomorphic to an initial object is also initial.
   : is-initial A b
   :=
   \ x →
-  is-contr-equiv-is-contr'
-  ( hom A b x)
-  ( hom A a x)
-  ( precomp-is-segal A is-segal-A a b
-    ( first is-iso-a-b)
-    x
+    is-contr-equiv-is-contr'
+    ( hom A b x)
+    ( hom A a x)
+    ( precomp-is-segal A is-segal-A a b
+      ( first is-iso-a-b)
+      ( x)
     , is-equiv-precomp-is-iso extext A is-segal-A a b
-        ( first is-iso-a-b)
-        ( first (first (second is-iso-a-b)))
-        ( second (first (second is-iso-a-b)))
-        ( first (second (second is-iso-a-b)))
-        ( second (second (second is-iso-a-b)))
-        x)
-  ( is-initial-a x)
+      ( first is-iso-a-b)
+      ( first (first (second is-iso-a-b)))
+      ( second (first (second is-iso-a-b)))
+      ( first (second (second is-iso-a-b)))
+      ( second (second (second is-iso-a-b)))
+      ( x))
+    ( is-initial-a x)
 
 #def final-iso uses (extext)
   ( A : U)
@@ -288,20 +288,20 @@ In a Segal type, an object isomorphic to an initial object is also initial.
   : is-final A b
   :=
   \ x →
-  is-contr-equiv-is-contr
-  ( hom A x a)
-  ( hom A x b)
-  ( postcomp-is-segal A is-segal-A a b
-    ( first is-iso-a-b)
-    x
+    is-contr-equiv-is-contr
+    ( hom A x a)
+    ( hom A x b)
+    ( postcomp-is-segal A is-segal-A a b
+      ( first is-iso-a-b)
+      ( x)
     , is-equiv-postcomp-is-iso extext A is-segal-A a b
-        ( first is-iso-a-b)
-        ( first (first (second is-iso-a-b)))
-        ( second (first (second is-iso-a-b)))
-        ( first (second (second is-iso-a-b)))
-        ( second (second (second is-iso-a-b)))
-        x)
-  ( is-final-a x)
+      ( first is-iso-a-b)
+      ( first (first (second is-iso-a-b)))
+      ( second (first (second is-iso-a-b)))
+      ( first (second (second is-iso-a-b)))
+      ( second (second (second is-iso-a-b)))
+      ( x))
+    ( is-final-a x)
 ```
 
 ## Uniqueness up to isomophism of (co)limits.

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -252,6 +252,58 @@ In a Segal type, final objects are isomorphic.
             ( id-hom A b))))
 ```
 
+In a Segal type, an object isomorphic to an initial object is also initial.
+
+```rzk
+#def initial-iso uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( a b : A)
+  ( is-initial-a : is-initial A a)
+  ( is-iso-a-b : Iso A is-segal-A a b)
+  : is-initial A b
+  :=
+  \ x →
+  is-contr-equiv-is-contr'
+  ( hom A b x)
+  ( hom A a x)
+  ( precomp-is-segal A is-segal-A a b
+    ( first is-iso-a-b)
+    x
+    , is-equiv-precomp-is-iso extext A is-segal-A a b
+        ( first is-iso-a-b)
+        ( first (first (second is-iso-a-b)))
+        ( second (first (second is-iso-a-b)))
+        ( first (second (second is-iso-a-b)))
+        ( second (second (second is-iso-a-b)))
+        x)
+  ( is-initial-a x)
+
+#def final-iso uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( a b : A)
+  ( is-final-a : is-final A a)
+  ( is-iso-a-b : Iso A is-segal-A a b)
+  : is-final A b
+  :=
+  \ x →
+  is-contr-equiv-is-contr
+  ( hom A x a)
+  ( hom A x b)
+  ( postcomp-is-segal A is-segal-A a b
+    ( first is-iso-a-b)
+    x
+    , is-equiv-postcomp-is-iso extext A is-segal-A a b
+        ( first is-iso-a-b)
+        ( first (first (second is-iso-a-b)))
+        ( second (first (second is-iso-a-b)))
+        ( first (second (second is-iso-a-b)))
+        ( second (second (second is-iso-a-b)))
+        x)
+  ( is-final-a x)
+```
+
 ## Uniqueness up to isomophism of (co)limits.
 
 The type of (co)cones of a function with codomain a Segal type is a Segal type.


### PR DESCRIPTION
Addresses #188. Essentially just that isomorphisms induce equivalences between hom types which allows one to transport contractibility. I hope that this matches with the style guide but please let me know if I should alter anything!