### PR TITLE
Left/right adjoints preserve co/limits

### DIFF
--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -2175,6 +2175,76 @@ transported along an arrow f : hom A x y to give a term in C x.
       ( dhom-to A x y f C v)
       ( is-contravariant-C x y f v)
       ( lift))
+
+#def contravariant-uniqueness-curried
+  ( A : U)
+  ( x y : A)
+  ( f : hom A x y)
+  ( C : A → U)
+  ( is-contravariant-C : is-contravariant A C)
+  ( v : C y)
+  : ( u : C x)
+  → ( dhom A x y f C u v)
+  → ( contravariant-transport A x y f C is-contravariant-C v) = u
+  :=
+    \ u g → contravariant-uniqueness A x y f C is-contravariant-C v (u , g)
+```
+
+We show that for each `v : C y`, the map `contravariant-uniqueness` is an
+equivalence. This follows from the fact that the total types (summed over
+`u : C x`) of both sides are contractible.
+
+```rzk title="RS17, Lemma 8.15, dual"
+#def is-equiv-total-map-contravariant-uniqueness-curried
+  ( A : U)
+  ( x y : A)
+  ( f : hom A x y)
+  ( C : A → U)
+  ( is-contravariant-C : is-contravariant A C)
+  ( v : C y)
+  : is-equiv
+      ( Σ ( u : C x) , dhom A x y f C u v)
+      ( Σ ( u : C x)
+        , contravariant-transport A x y f C is-contravariant-C v = u)
+      ( total-map (C x)
+        ( \ u → dhom A x y f C u v)
+        ( \ u → contravariant-transport A x y f C is-contravariant-C v = u)
+        ( contravariant-uniqueness-curried A x y f C is-contravariant-C v))
+  :=
+    is-equiv-are-contr
+      ( Σ ( u : C x) , dhom A x y f C u v)
+      ( Σ ( u : C x)
+        , contravariant-transport A x y f C is-contravariant-C v = u)
+      ( is-contravariant-C x y f v)
+      ( is-contr-based-paths (C x)
+        ( contravariant-transport A x y f C is-contravariant-C v))
+      ( total-map (C x)
+        ( \ u → dhom A x y f C u v)
+        ( \ u → contravariant-transport A x y f C is-contravariant-C v = u)
+        ( contravariant-uniqueness-curried A x y f C is-contravariant-C v))
+
+#def is-equiv-contravariant-uniqueness-curried
+  ( A : U)
+  ( x y : A)
+  ( f : hom A x y)
+  ( C : A → U)
+  ( is-contravariant-C : is-contravariant A C)
+  ( v : C y)
+  ( u : C x)
+  : is-equiv
+      ( dhom A x y f C u v)
+      ( contravariant-transport A x y f C is-contravariant-C v = u)
+      ( contravariant-uniqueness-curried A x y f C is-contravariant-C v u)
+  :=
+
+    is-equiv-fiberwise-is-equiv-total
+      ( C x)
+      ( \ u' → dhom A x y f C u' v)
+      ( \ u' → contravariant-transport A x y f C is-contravariant-C v = u')
+      ( contravariant-uniqueness-curried A x y f C is-contravariant-C v)
+      ( is-equiv-total-map-contravariant-uniqueness-curried
+        A x y f C is-contravariant-C v)
+      u
 ```
 
 ## Contravariant functoriality

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -2236,7 +2236,6 @@ equivalence. This follows from the fact that the total types (summed over
       ( contravariant-transport A x y f C is-contravariant-C v = u)
       ( contravariant-uniqueness-curried A x y f C is-contravariant-C v u)
   :=
-
     is-equiv-fiberwise-is-equiv-total
       ( C x)
       ( \ u' → dhom A x y f C u' v)

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -1663,8 +1663,8 @@ equivalence using `#!rzk is-equiv-is-contr-map`.
                   ( C)
                   ( is-contravariant-C))
                 ( second (first has-final-tot-A))
-                x)
-              v)
+                ( x))
+              ( v))
             ( equiv-comp
               ( hom
                 ( Σ ( z : A) , C z)

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -1381,6 +1381,12 @@ family is covariant or not.
   ( C : A → U)
   : U
   := Σ (a : A) , (x : A) → (Equiv (hom A a x) (C x))
+
+#def is-contravariant-representable-family
+  ( A : U)
+  ( C : A → U)
+  : U
+  := Σ (a : A) , (x : A) → (Equiv (hom A x a) (C x))
 ```
 
 The definition makes it slightly awkward to access the actual equivalence, so we
@@ -1393,6 +1399,14 @@ give a helper function.
   ( is-rep-C : is-representable-family A C)
   : ( x : A) → (hom A (first is-rep-C) x) → (C x)
   := \ x → first((second (is-rep-C)) x)
+
+#def equiv-for-is-contravariant-representable-family
+  ( A : U)
+  ( C : A → U)
+  ( is-rep-C : is-contravariant-representable-family A C)
+  : ( x : A) → (hom A x (first is-rep-C) → C x)
+  := \ x → first((second (is-rep-C)) x)
+
 ```
 
 RS Proposition 9.10 gives an if and only if condition for a covariant family
@@ -1407,6 +1421,13 @@ condition a name.
   : U
   := Σ ((a , u) : Σ (x : A) , (C x))
       , is-initial (Σ (x : A) , (C x)) (a , u)
+
+#def has-final-tot
+  ( A : U)
+  ( C : A → U)
+  : U
+  := Σ ((a , u) : Σ (x : A) , C x)
+      , is-final (Σ (x : A) , C x) (a , u)
 ```
 
 As a representable family is fiberwise equivalent to a `#!rzk Σ (x : A) , C x`,
@@ -1437,6 +1458,30 @@ initial object by `#!rzk is-initial-id-hom-is-segal`.
           ( second is-rep-C))
         ( ( first is-rep-C , id-hom A (first is-rep-C)))
         ( is-initial-id-hom-is-segal A is-segal-A (first is-rep-C)))
+
+#def has-final-tot-is-contravariant-representable-family uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( C : A → U)
+  ( is-rep-C : is-contravariant-representable-family A C)
+  : has-final-tot A C
+  :=
+    ( ( first is-rep-C
+      , contra-evid
+          ( A)
+          ( first is-rep-C)
+          ( C)
+          ( equiv-for-is-contravariant-representable-family A C is-rep-C))
+    , is-final-equiv-is-final
+        ( slice A (first is-rep-C))
+        ( Σ ( x : A) , C x)
+        ( total-equiv-family-of-equiv
+          ( A)
+          ( \ x → hom A x (first is-rep-C))
+          ( C)
+          ( second is-rep-C))
+        ( ( first is-rep-C , id-hom A (first is-rep-C)))
+        ( is-final-id-hom-is-segal A is-segal-A (first is-rep-C)))
 
 ```
 
@@ -1572,6 +1617,135 @@ equivalence using `#!rzk is-equiv-is-contr-map`.
                       ( second (first has-initial-tot-A))
                       ( v)))))
             ( second has-initial-tot-A (b , v)))))
+
+#def is-contravariant-representable-family-has-final-tot
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( C : A → U)
+  ( is-contravariant-C : is-contravariant A C)
+  ( has-final-tot-A : has-final-tot A C)
+  : ( is-contravariant-representable-family A C)
+  :=
+    ( first (first has-final-tot-A)
+    , \ x →
+      ( ( contra-yon
+          ( A)
+          ( is-segal-A)
+          ( first (first has-final-tot-A))
+          ( C)
+          ( is-contravariant-C))
+        ( second (first has-final-tot-A))
+        ( x)
+      , is-equiv-is-contr-map
+        ( hom A x (first (first has-final-tot-A)))
+        ( C x)
+        ( ( contra-yon
+            ( A)
+            ( is-segal-A)
+            ( first (first has-final-tot-A))
+            ( C)
+            ( is-contravariant-C))
+          ( second (first has-final-tot-A))
+          x)
+        ( \ v →
+          is-contr-equiv-is-contr
+            ( hom
+              ( Σ ( z : A) , C z)
+              ( x , v)
+              ( first has-final-tot-A))
+            ( fib
+              ( hom A x (first (first has-final-tot-A)))
+              ( C x)
+              ( ( contra-yon
+                  ( A)
+                  ( is-segal-A)
+                  ( first (first has-final-tot-A))
+                  ( C)
+                  ( is-contravariant-C))
+                ( second (first has-final-tot-A))
+                x)
+              v)
+            ( equiv-comp
+              ( hom
+                ( Σ ( z : A) , C z)
+                ( x , v)
+                ( first has-final-tot-A))
+              ( Σ ( h : hom A x (first (first has-final-tot-A)))
+                , dhom
+                    ( A)
+                    ( x)
+                    ( first (first has-final-tot-A))
+                    ( h)
+                    ( C)
+                    ( v)
+                    ( second (first has-final-tot-A)))
+              ( fib
+                ( hom A x (first (first has-final-tot-A)))
+                ( C x)
+                ( ( contra-yon
+                    ( A)
+                    ( is-segal-A)
+                    ( first (first has-final-tot-A))
+                    ( C)
+                    ( is-contravariant-C))
+                  ( second (first has-final-tot-A))
+                  x)
+                v)
+              ( axiom-choice
+                ( 2)
+                ( Δ¹)
+                ( ∂Δ¹)
+                ( \ _ → A)
+                ( \ _ z → C z)
+                ( \ t →
+                  recOR
+                    ( t ≡ 0₂ ↦ x
+                    , t ≡ 1₂ ↦ first (first has-final-tot-A)))
+                ( \ t →
+                  recOR
+                    ( t ≡ 0₂ ↦ v
+                    , t ≡ 1₂ ↦ second (first has-final-tot-A))))
+              ( total-equiv-family-of-equiv
+                ( hom A x (first (first has-final-tot-A)))
+                ( \ h →
+                  dhom
+                    ( A)
+                    ( x)
+                    ( first (first has-final-tot-A))
+                    ( h)
+                    ( C)
+                    ( v)
+                    ( second (first has-final-tot-A)))
+                ( \ h →
+                  contravariant-transport
+                    ( A)
+                    ( x)
+                    ( first (first has-final-tot-A))
+                    ( h)
+                    ( C)
+                    ( is-contravariant-C)
+                    ( second (first has-final-tot-A))
+                  = v)
+                ( \ h →
+                  ( contravariant-uniqueness-curried
+                      ( A)
+                      ( x)
+                      ( first (first has-final-tot-A))
+                      ( h)
+                      ( C)
+                      ( is-contravariant-C)
+                      ( second (first has-final-tot-A))
+                      ( v)
+                  , is-equiv-contravariant-uniqueness-curried
+                      ( A)
+                      ( x)
+                      ( first (first has-final-tot-A))
+                      ( h)
+                      ( C)
+                      ( is-contravariant-C)
+                      ( second (first has-final-tot-A))
+                      ( v)))))
+            ( second has-final-tot-A (x , v)))))
 ```
 
 ```rzk title="RS17, Proposition 9.10"

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -1646,7 +1646,7 @@ equivalence using `#!rzk is-equiv-is-contr-map`.
             ( C)
             ( is-contravariant-C))
           ( second (first has-final-tot-A))
-          x)
+          ( x))
         ( \ v →
           is-contr-equiv-is-contr
             ( hom

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -1689,8 +1689,8 @@ equivalence using `#!rzk is-equiv-is-contr-map`.
                     ( C)
                     ( is-contravariant-C))
                   ( second (first has-final-tot-A))
-                  x)
-                v)
+                  ( x))
+                ( v))
               ( axiom-choice
                 ( 2)
                 ( Δ¹)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -429,7 +429,7 @@ Co-/limits are unique up to isomorphism.
 
 The universal property of limits and colimits.
 
-```rzk title="BM22, Proposition 3.7"
+```rzk title="Bar22, Proposition 3.7"
 #def colimit3-is-colimit uses (funext)
   ( J B : U)
   ( is-segal-B : is-segal B)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -609,7 +609,7 @@ The universal property of limits and colimits.
 
 Left/right adjoints preserve co/limits.
 
-```rzk title="BM22, Theorem 3.8, 3.9"
+```rzk title="Bar22, Theorem 3.8, 3.9"
 #def left-adjoint-preserves-colimit uses (funext extext)
   ( A B J : U)
   ( is-segal-A : is-segal A)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -430,7 +430,7 @@ Co-/limits are unique up to isomorphism.
 The universal property of limits and colimits.
 
 ```rzk title="Bar22, Proposition 3.7"
-#def colimit3-is-colimit uses (funext)
+#def colimit3-colimit uses (funext)
   ( J B : U)
   ( is-segal-B : is-segal B)
   ( g : J → B)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -621,9 +621,9 @@ Left/right adjoints preserve co/limits.
   ( adj : is-transposing-adj A B f u)
   : colimit J B (comp J A B f g)
   :=
-    colimit-is-colimit3 J B is-segal-B (comp J A B f g)
+    colimit-colimit3 J B is-segal-B (comp J A B f g)
       ( left-adjoint-preserves-colimit3 A B J g f u adj
-        ( colimit3-is-colimit J A is-segal-A g colim-g))
+        ( colimit3-colimit J A is-segal-A g colim-g))
 
 #def right-adjoint-preserves-limit uses (funext extext)
   ( A B J : U)
@@ -636,7 +636,7 @@ Left/right adjoints preserve co/limits.
   ( adj : is-transposing-adj A B f u)
   : limit J A (comp J B A u g)
   :=
-    limit-is-limit3 J A is-segal-A (comp J B A u g)
+    limit-limit3 J A is-segal-A (comp J B A u g)
       ( right-adjoint-preserves-limit3 A B J g f u adj
-        ( limit3-is-limit J B is-segal-B g lim-g))
+        ( limit3-limit J B is-segal-B g lim-g))
 ```

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -385,7 +385,7 @@ The type of (co)cones of a function with codomain a Segal type is a Segal type.
     ( is-segal-B)
 ```
 
-Co/limits are unique up to isomorphism.
+Co-/limits are unique up to isomorphism.
 
 ```rzk title="BM, Corollary 1 (i)"
 #def iso-colimit-is-segal uses (extext funext)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -607,7 +607,7 @@ The universal property of limits and colimits.
         ( equiv-transpose-cone A B J g f u adj y))
 ```
 
-Left/right adjoints preserve co/limits.
+Left/right adjoints preserve co-/limits.
 
 ```rzk title="Bar22, Theorem 3.8, 3.9"
 #def left-adjoint-preserves-colimit uses (funext extext)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -181,13 +181,13 @@ When `#!rzk is-segal B` then definitions 1 and 3 coincide.
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (b : B) , (x : B) → Equiv (hom B b x) (family-cone A B f x)
+  := Σ (b : B) , (x : B) → Equiv (hom B x b) (family-cone A B f x)
 
 #def colimit3
   ( A B : U)
   ( f : A → B)
   : U
-  := Σ (b : B) , (x : B) → Equiv (hom B x b) (family-cocone A B f x)
+  := Σ (b : B) , (x : B) → Equiv (hom B b x) (family-cocone A B f x)
 ```
 
 ## Uniqueness of initial and final objects.
@@ -385,7 +385,7 @@ The type of (co)cones of a function with codomain a Segal type is a Segal type.
     ( is-segal-B)
 ```
 
-Colimits are unique up to isomorphism.
+Co/limits are unique up to isomorphism.
 
 ```rzk title="BM, Corollary 1 (i)"
 #def iso-colimit-is-segal uses (extext funext)
@@ -406,9 +406,7 @@ Colimits are unique up to isomorphism.
     ( first y)
     ( second x)
     ( second y)
-```
 
-```rzk
 #def iso-limit-is-segal uses (extext funext)
   ( A B : U)
   ( is-segal-B : is-segal B)
@@ -427,4 +425,218 @@ Colimits are unique up to isomorphism.
     ( first y)
     ( second x)
     ( second y)
+```
+
+The universal property of limits and colimits.
+
+```rzk title="BM22, Proposition 3.7"
+#def colimit3-is-colimit uses (funext)
+  ( J B : U)
+  ( is-segal-B : is-segal B)
+  ( g : J → B)
+  ( colim-g : colimit J B g)
+  : colimit3 J B g
+  :=
+    is-representable-family-has-initial-tot
+      B
+      is-segal-B
+      ( family-cocone J B g)
+      ( is-covariant-family-cone-is-segal J B is-segal-B g)
+      colim-g
+
+#def colimit-is-colimit3 uses (extext)
+  ( J B : U)
+  ( is-segal-B : is-segal B)
+  ( g : J → B)
+  ( colim3-g : colimit3 J B g)
+  : colimit J B g
+  :=
+    has-initial-tot-is-representable-family
+      extext
+      B
+      is-segal-B
+      ( family-cocone J B g)
+      colim3-g
+
+#def limit3-is-limit uses (funext)
+  ( J B : U)
+  ( is-segal-B : is-segal B)
+  ( g : J → B)
+  ( lim-g : limit J B g)
+  : limit3 J B g
+  :=
+    is-contravariant-representable-family-has-final-tot
+      B
+      is-segal-B
+      ( family-cone J B g)
+      ( is-contravariant-family-cone-is-segal J B is-segal-B g)
+      lim-g
+
+#def limit-is-limit3 uses (extext)
+  ( J B : U)
+  ( is-segal-B : is-segal B)
+  ( g : J → B)
+  ( lim3-g : limit3 J B g)
+  : limit J B g
+  :=
+    has-final-tot-is-contravariant-representable-family
+      extext
+      B
+      is-segal-B
+      ( family-cone J B g)
+      lim3-g
+```
+
+```rzk
+#def equiv-transpose-cocone uses (funext)
+  ( A B J : U)
+  ( g : J → A)
+  ( f : A → B)
+  ( u : B → A)
+  ( adj : is-transposing-adj A B f u)
+  ( z : B)
+  : Equiv
+      ( family-cocone J B (comp J A B f g) z)
+      ( family-cocone J A g (u z))
+  :=
+    equiv-triple-comp
+      ( family-cocone J B (comp J A B f g) z)
+      ( ( j : J) → hom B (f (g j)) z)
+      ( ( j : J) → hom A (g j) (u z))
+      ( family-cocone J A g (u z))
+      ( equiv-components-nat-trans
+        J
+        ( \ _ → B)
+        ( comp J A B f g)
+        ( constant J B z))
+      ( equiv-function-equiv-family
+        funext
+        J
+        ( \ j → hom B (f (g j)) z)
+        ( \ j → hom A (g j) (u z))
+        ( \ j → adj (g j) z))
+      ( inv-equiv
+        ( family-cocone J A g (u z))
+        ( ( j : J) → hom A (g j) (u z))
+        ( equiv-components-nat-trans
+          J
+          ( \ _ → A)
+          g
+          ( constant J A (u z))))
+
+#def equiv-transpose-cone uses (funext)
+  ( A B J : U)
+  ( g : J → B)
+  ( f : A → B)
+  ( u : B → A)
+  ( adj : is-transposing-adj A B f u)
+  ( y : A)
+  : Equiv
+      ( family-cone J B g (f y))
+      ( family-cone J A (comp J B A u g) y)
+  :=
+    equiv-triple-comp
+      ( family-cone J B g (f y))
+      ( ( j : J) → hom B (f y) (g j))
+      ( ( j : J) → hom A y (u (g j)))
+      ( family-cone J A (comp J B A u g) y)
+      ( equiv-components-nat-trans
+        J
+        ( \ _ → B)
+        ( constant J B (f y))
+        g)
+      ( equiv-function-equiv-family
+        funext
+        J
+        ( \ j → hom B (f y) (g j))
+        ( \ j → hom A y (u (g j)))
+        ( \ j → adj y (g j)))
+      ( inv-equiv
+        ( family-cone J A (comp J B A u g) y)
+        ( ( j : J) → hom A y (u (g j)))
+        ( equiv-components-nat-trans
+          J
+          ( \ _ → A)
+          ( constant J A y)
+          ( comp J B A u g)))
+
+#def left-adjoint-preserves-colimit3 uses (funext)
+  ( A B J : U)
+  ( g : J → A)
+  ( f : A → B)
+  ( u : B → A)
+  ( adj : is-transposing-adj A B f u)
+  ( ( a , is-represented-cocone-g) : colimit3 J A g)
+  : colimit3 J B (comp J A B f g)
+  :=
+    ( f a
+    , \ z →
+      equiv-triple-comp
+        ( hom B (f a) z)
+        ( hom A a (u z))
+        ( family-cocone J A g (u z))
+        ( family-cocone J B (comp J A B f g) z)
+        ( adj a z)
+        ( is-represented-cocone-g (u z))
+        ( inv-equiv
+          ( family-cocone J B (comp J A B f g) z)
+          ( family-cocone J A g (u z))
+          ( equiv-transpose-cocone A B J g f u adj z)))
+
+#def right-adjoint-preserves-limit3 uses (funext)
+  ( A B J : U)
+  ( g : J → B)
+  ( f : A → B)
+  ( u : B → A)
+  ( adj : is-transposing-adj A B f u)
+  ( ( b , is-represented-cone-g) : limit3 J B g)
+  : limit3 J A (comp J B A u g)
+  :=
+    ( u b
+    , \ y →
+      equiv-triple-comp
+        ( hom A y (u b))
+        ( hom B (f y) b)
+        ( family-cone J B g (f y))
+        ( family-cone J A (comp J B A u g) y)
+        ( inv-equiv
+          ( hom B (f y) b)
+          ( hom A y (u b))
+          ( adj y b))
+        ( is-represented-cone-g (f y))
+        ( equiv-transpose-cone A B J g f u adj y))
+```
+
+Left/right adjoints preserve co/limits.
+
+```rzk title="BM22, Theorem 3.8, 3.9"
+#def left-adjoint-preserves-colimit uses (funext extext)
+  ( A B J : U)
+  ( is-segal-A : is-segal A)
+  ( is-segal-B : is-segal B)
+  ( g : J → A)
+  ( f : A → B)
+  ( u : B → A)
+  ( colim-g : colimit J A g)
+  ( adj : is-transposing-adj A B f u)
+  : colimit J B (comp J A B f g)
+  :=
+    colimit-is-colimit3 J B is-segal-B (comp J A B f g)
+      ( left-adjoint-preserves-colimit3 A B J g f u adj
+        ( colimit3-is-colimit J A is-segal-A g colim-g))
+
+#def right-adjoint-preserves-limit uses (funext extext)
+  ( A B J : U)
+  ( is-segal-A : is-segal A)
+  ( is-segal-B : is-segal B)
+  ( g : J → B)
+  ( f : A → B)
+  ( u : B → A)
+  ( lim-g : limit J B g)
+  ( adj : is-transposing-adj A B f u)
+  : limit J A (comp J B A u g)
+  :=
+    limit-is-limit3 J A is-segal-A (comp J B A u g)
+      ( right-adjoint-preserves-limit3 A B J g f u adj
+        ( limit3-is-limit J B is-segal-B g lim-g))
 ```

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -458,7 +458,7 @@ The universal property of limits and colimits.
       ( family-cocone J B g)
       colim3-g
 
-#def limit3-is-limit uses (funext)
+#def limit3-limit uses (funext)
   ( J B : U)
   ( is-segal-B : is-segal B)
   ( g : J → B)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -472,7 +472,7 @@ The universal property of limits and colimits.
       ( is-contravariant-family-cone-is-segal J B is-segal-B g)
       lim-g
 
-#def limit-is-limit3 uses (extext)
+#def limit-limit3 uses (extext)
   ( J B : U)
   ( is-segal-B : is-segal B)
   ( g : J → B)

--- a/src/simplicial-hott/14-limits.rzk.md
+++ b/src/simplicial-hott/14-limits.rzk.md
@@ -444,7 +444,7 @@ The universal property of limits and colimits.
       ( is-covariant-family-cone-is-segal J B is-segal-B g)
       colim-g
 
-#def colimit-is-colimit3 uses (extext)
+#def colimit-colimit3 uses (extext)
   ( J B : U)
   ( is-segal-B : is-segal B)
   ( g : J → B)


### PR DESCRIPTION
Closes https://github.com/rzk-lang/sHoTT/issues/177

The argument follows Cesar's paper pretty much exactly.  I did some dualizing in the covariant and yoneda files so that I could use the dual version of the proof of Cesar's Proposition 3.7. I've been working on this pretty non-stop since the workshop and took a lot of wrong turns along the way, but I learned a whole ton doing this.
EDIT: Forgot to mention. I swapped the order of the homs in colimit3 and limit3. In Cesar's paper they seem to be in the opposite direction from how they were in the library. Considering that I was able to do the iff result for colimit3/colimit and limit3/limit with this reversed direction, I believe they are oriented correctly now.