### PR TITLE
Prove precomposition with an equivalence is an equivalence

### DIFF
--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -1136,3 +1136,54 @@ dependent function types.
   : is-equiv A' A α → is-equiv B' B β
   := is-equiv-equiv-is-equiv' A' A α B' B β S is-equiv-s' is-equiv-s
 ```
+
+## Precomposition with an equivalence is an equivalence
+
+For `#!rzk f : A → B` and any type `#!rzk X`, precomposition
+`#!rzk precomp A B X f : (B → X) → (A → X)` sends `#!rzk g` to `#!rzk g ∘ f`.
+When `#!rzk f` is an equivalence, so is `#!rzk precomp A B X f`: the section
+of `#!rzk f` becomes a retraction of `#!rzk precomp A B X f`, and the
+retraction of `#!rzk f` becomes a section of `#!rzk precomp A B X f`.
+
+```rzk
+#def precomp
+  ( A B X : U)
+  ( f : A → B)
+  : ( B → X) → (A → X)
+  := \ g → comp A B X g f
+
+#def is-equiv-precomp-has-retraction uses (funext)
+  ( A B X : U)
+  ( f : A → B)
+  ( ( ( r , η) , ( s , ε)) : is-equiv A B f)
+  : has-retraction (B → X) (A → X) (precomp A B X f)
+  :=
+    ( precomp B A X s
+    , \ g →
+        eq-htpy B (\ _ → X)
+          ( comp (B → X) (A → X) (B → X) (precomp B A X s) (precomp A B X f) g)
+          ( g)
+          ( \ b → ap B X (f (s b)) b g (ε b)))
+
+#def is-equiv-precomp-has-section uses (funext)
+  ( A B X : U)
+  ( f : A → B)
+  ( ( ( r , η) , ( s , ε)) : is-equiv A B f)
+  : has-section (B → X) (A → X) (precomp A B X f)
+  :=
+    ( precomp B A X r
+    , \ h →
+        eq-htpy A (\ _ → X)
+          ( comp (A → X) (B → X) (A → X) (precomp A B X f) (precomp B A X r) h)
+          ( h)
+          ( \ a → ap A X (r (f a)) a h (η a)))
+
+#def is-equiv-precompose-equiv uses (funext)
+  ( A B X : U)
+  ( f : A → B)
+  ( is-equiv-f : is-equiv A B f)
+  : is-equiv (B → X) (A → X) (precomp A B X f)
+  :=
+    ( is-equiv-precomp-has-retraction A B X f is-equiv-f
+    , is-equiv-precomp-has-section A B X f is-equiv-f)
+```


### PR DESCRIPTION
Adds precomp and is-equiv-precompose-equiv: for f : A -> B an equivalence, precomposition (B -> X) -> (A -> X) is an equivalence for every X. The section of f gives the retraction of precomp_f, and the retraction of f gives the section of precomp_f.